### PR TITLE
Fix lint errors

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -1,4 +1,5 @@
 module.exports = {
     presets: ['@babel/preset-typescript', '@babel/preset-react'],
     plugins: [['babel-plugin-typescript-to-proptypes', { comments: true }]],
+    include: ['src'],
 };

--- a/.babelrc.js
+++ b/.babelrc.js
@@ -1,0 +1,4 @@
+module.exports = {
+    presets: ['@babel/preset-typescript', '@babel/preset-react'],
+    plugins: [['babel-plugin-typescript-to-proptypes', { comments: true }]],
+};

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
         "@typescript-eslint/eslint-plugin": "^3.2.0",
         "@typescript-eslint/parser": "^3.2.0",
         "babel-loader": "^8.1.0",
+        "babel-plugin-typescript-to-proptypes": "^1.4.0",
         "eslint": "^6.5.1",
         "eslint-config-airbnb-typescript": "^8.0.2",
         "eslint-config-prettier": "^6.4.0",

--- a/src/components/Bold/Bold.test.tsx
+++ b/src/components/Bold/Bold.test.tsx
@@ -1,10 +1,10 @@
-import React, { Children } from 'react';
+import React from 'react';
 import { render, unmountComponentAtNode } from 'react-dom';
 import ReactTestUtils from 'react-dom/test-utils';
 
 import Bold from './Bold';
 
-describe('Bold', function() {
+describe('Bold', function () {
     let container: HTMLDivElement | null = null;
 
     beforeEach(() => {
@@ -22,16 +22,14 @@ describe('Bold', function() {
     });
 
     it('should render', () => {
-        const children = "hi";
         ReactTestUtils.act(() => {
             render(
                 <Bold>
-                    <div id='test'/>
+                    <div id='test' />
                 </Bold>,
                 container
-            )
+            );
         });
         expect(document.getElementById('test')).toBeTruthy();
     });
-
-}); 
+});

--- a/src/components/LoggedIn/LoggedIn.test.tsx
+++ b/src/components/LoggedIn/LoggedIn.test.tsx
@@ -1,4 +1,4 @@
-import React, { Children } from 'react';
+import React from 'react';
 import { render, unmountComponentAtNode } from 'react-dom';
 import ReactTestUtils from 'react-dom/test-utils';
 import { MemoryRouter, Route } from 'react-router-dom';
@@ -38,7 +38,7 @@ describe('LoggedIn', function () {
 
     it('should render, fail, redirect to /logout', () => {
         const jwt = false;
-        var pathToCheck = '/';
+        const pathToCheck = '/';
         let _location: any;
         ReactTestUtils.act(() => {
             render(
@@ -64,10 +64,9 @@ describe('LoggedIn', function () {
         expect(_location.pathname).toBe('/logout');
     });
 
-
     it('should render, succeed, should render to <>children</>', () => {
         const jwt = true;
-        var pathToCheck = '/';
+        const pathToCheck = '/';
         let _location: any;
         ReactTestUtils.act(() => {
             render(

--- a/src/components/LoggedIn/LoggedIn.test.tsx
+++ b/src/components/LoggedIn/LoggedIn.test.tsx
@@ -39,7 +39,7 @@ describe('LoggedIn', function () {
     it('should render, fail, redirect to /logout', () => {
         const jwt = false;
         const pathToCheck = '/';
-        let _location: any;
+        let _location = { pathname: '' };
         ReactTestUtils.act(() => {
             render(
                 <ThemeProvider theme={theme}>
@@ -67,7 +67,7 @@ describe('LoggedIn', function () {
     it('should render, succeed, should render to <>children</>', () => {
         const jwt = true;
         const pathToCheck = '/';
-        let _location: any;
+        let _location = { pathname: '' };
         ReactTestUtils.act(() => {
             render(
                 <ThemeProvider theme={theme}>

--- a/src/components/LoggedIn/LoggedIn.tsx
+++ b/src/components/LoggedIn/LoggedIn.tsx
@@ -17,11 +17,8 @@ interface Props {
 export default function LoggedIn({ children, jwt }: Props) {
     // const jwt = '';//{ _id: '' }; // useJwt();
     if (NODE_ENV === 'development') {
-        // eslint-disable-next-line no-console
-        console.log('not redirecting');
         return <>{children}</>;
     }
-    // console.log('redirecting');
     // assumption is that if there is no jwt, then they are not logged in
     return jwt ? <>{children}</> : <Redirect to='/logout' />;
 }

--- a/src/components/LoggedIn/LoggedIn.tsx
+++ b/src/components/LoggedIn/LoggedIn.tsx
@@ -17,6 +17,7 @@ interface Props {
 export default function LoggedIn({ children, jwt }: Props) {
     // const jwt = '';//{ _id: '' }; // useJwt();
     if (NODE_ENV === 'development') {
+        // eslint-disable-next-line no-console
         console.log('not redirecting');
         return <>{children}</>;
     }

--- a/src/components/Message/Message.tsx
+++ b/src/components/Message/Message.tsx
@@ -9,8 +9,8 @@ import MessageItemTimestamp from '../MessageItemTimestamp';
 import ScrollTo from '../ScrollTo';
 import { Message } from './types';
 
-const checkIsOwner = (user: { _id: string }, messageUserId = '') =>
-    user._id === messageUserId;
+// const checkIsOwner = (user: { _id: string }, messageUserId = '') =>
+//     user._id === messageUserId;
 
 // export const MessageContext = React.createContext(false);
 // interface Message {

--- a/src/components/Message/MessageAction.tsx
+++ b/src/components/Message/MessageAction.tsx
@@ -44,9 +44,7 @@ export default function MessageActions({ targetMsg, onClick }: Props) {
                     snack('Something went wrong! Try again.', 'error');
                 }
             })
-            .catch((err) => {
-                // eslint-disable-next-line no-console
-                console.log(err);
+            .catch(() => {
                 snack('Something went wrong! Try again.', 'error');
             });
     };

--- a/src/components/Message/MessageAction.tsx
+++ b/src/components/Message/MessageAction.tsx
@@ -45,6 +45,7 @@ export default function MessageActions({ targetMsg, onClick }: Props) {
                 }
             })
             .catch((err) => {
+                // eslint-disable-next-line no-console
                 console.log(err);
                 snack('Something went wrong! Try again.', 'error');
             });

--- a/src/components/Message/MessageOwnerActions.tsx
+++ b/src/components/Message/MessageOwnerActions.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import React from 'react';
 import PropTypes from 'prop-types';
 import Button from '@material-ui/core/Button';
@@ -67,8 +68,8 @@ export default function MessageOwnerActions({ targetMessage, onClick }: Props) {
             } else {
                 snack('Something went wrong! Try again.', 'error');
             }
-        } catch (e) {
-            console.log(e);
+        } catch (error) {
+            console.log(error);
             snack('Something went wrong! Try again.', 'error');
         }
     };

--- a/src/components/Message/MessageOwnerActions.tsx
+++ b/src/components/Message/MessageOwnerActions.tsx
@@ -45,9 +45,7 @@ export default function MessageOwnerActions({ targetMessage, onClick }: Props) {
     const [snack] = useSnack();
     const { roomId } = useParams<Params>();
 
-    const handleEdit = async (
-        e: React.MouseEvent<HTMLAnchorElement, MouseEvent>
-    ) => {
+    const handleEdit = async (e: React.MouseEvent<{ value: unknown }>) => {
         e.preventDefault();
         try {
             const response = await fetch('/api/chat/update-message/', {
@@ -74,7 +72,7 @@ export default function MessageOwnerActions({ targetMessage, onClick }: Props) {
         }
     };
 
-    // Change the delete message to just hide it. ie markit as deleted
+    // Change the delete message to just hide it. ie mark it as deleted
     const handleDelete = async () => {
         try {
             const response = await fetch(`/api/chat/delete-message/${roomId}`, {
@@ -124,8 +122,7 @@ export default function MessageOwnerActions({ targetMessage, onClick }: Props) {
                     color='secondary'
                     variant='contained' // TODO: fix this, should be inside the form tag
                     fullWidth
-                    // TODO: any?
-                    onClick={handleEdit as any}
+                    onClick={handleEdit}
                 >
                     Submit Change
                 </Button>

--- a/src/components/Message/MessageOwnerActions.tsx
+++ b/src/components/Message/MessageOwnerActions.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import React from 'react';
 import PropTypes from 'prop-types';
 import Button from '@material-ui/core/Button';
@@ -66,8 +65,7 @@ export default function MessageOwnerActions({ targetMessage, onClick }: Props) {
             } else {
                 snack('Something went wrong! Try again.', 'error');
             }
-        } catch (error) {
-            console.log(error);
+        } catch {
             snack('Something went wrong! Try again.', 'error');
         }
     };
@@ -91,8 +89,7 @@ export default function MessageOwnerActions({ targetMessage, onClick }: Props) {
             } else {
                 snack('Something went wrong! Try again.', 'error');
             }
-        } catch (e) {
-            console.log(e);
+        } catch {
             snack('Something went wrong! Try again.', 'error');
         }
     };

--- a/src/components/SectionList/SectionList.tsx
+++ b/src/components/SectionList/SectionList.tsx
@@ -10,7 +10,7 @@ import {
 } from '@material-ui/core';
 import { makeStyles, Theme } from '@material-ui/core/styles';
 
-interface Datum {
+export interface Datum {
     image?: string;
     title: string;
     subtitle: string;

--- a/src/components/SettingDemo/SettingDemo.tsx
+++ b/src/components/SettingDemo/SettingDemo.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+// import React from 'react';
 
 // TODO:
 export default function () {}

--- a/src/components/TooltipIconButton/TooltipIconButton.test.tsx
+++ b/src/components/TooltipIconButton/TooltipIconButton.test.tsx
@@ -42,6 +42,7 @@ describe('TooltipIconButton', () => {
 
         expect(onClickButton).toBeCalledTimes(1);
     });
+    // eslint-disable-next-line jest/no-commented-out-tests
     // it('should call onClose when close button is clicked', () => {
     //     const onClose = jest.fn();
     //     ReactTestUtils.act(() => {
@@ -59,6 +60,8 @@ describe('TooltipIconButton', () => {
 
     //     expect(onClose).toBeCalledTimes(1);
     // });
+
+    // eslint-disable-next-line jest/no-commented-out-tests
     // it('should not render children if closed', () => {
     //     const onClose = jest.fn();
     //     ReactTestUtils.act(() => {

--- a/src/components/TooltipIconButton/TooltipIconButton.tsx
+++ b/src/components/TooltipIconButton/TooltipIconButton.tsx
@@ -25,3 +25,7 @@ export default function TooltipIconButton({
         </Tooltip>
     );
 }
+
+TooltipIconButton.defaultProps = {
+    className: '',
+};

--- a/src/contexts/Device.tsx
+++ b/src/contexts/Device.tsx
@@ -24,3 +24,7 @@ export default function Device({ children, override }: Props) {
         </DeviceContext.Provider>
     );
 }
+
+Device.defaultProps = {
+    override: '',
+};

--- a/src/domains/Auth/ForgotPassRequest/ForgotPassRequest.test.tsx
+++ b/src/domains/Auth/ForgotPassRequest/ForgotPassRequest.test.tsx
@@ -97,6 +97,7 @@ describe('ForgotPassRequest', () => {
             if (emailNode && button) {
                 ReactTestUtils.Simulate.change(emailNode, {
                     target: { value: 'email@email.com' },
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 } as any);
                 button.dispatchEvent(
                     new MouseEvent('click', { bubbles: true })
@@ -147,7 +148,7 @@ describe('ForgotPassRequest', () => {
             }
         });
 
-        expect(spy).toBeCalledWith({ email:'email@email.com'});
+        expect(spy).toBeCalledWith({ email: 'email@email.com' });
         jest.runAllTimers();
 
         await ReactTestUtils.act(async () => {

--- a/src/domains/Auth/ForgotPassRequest/ForgotPassRequest.test.tsx
+++ b/src/domains/Auth/ForgotPassRequest/ForgotPassRequest.test.tsx
@@ -140,8 +140,10 @@ describe('ForgotPassRequest', () => {
         ReactTestUtils.act(() => {
             if (emailNode && button) {
                 ReactTestUtils.Simulate.change(emailNode, {
-                    target: { value: 'email@email.com' },
-                } as any);
+                    target: ({
+                        value: 'email@email.com',
+                    } as unknown) as EventTarget,
+                });
                 button.dispatchEvent(
                     new MouseEvent('click', { bubbles: true })
                 );

--- a/src/domains/Auth/LoginForm/LoginForm.test.tsx
+++ b/src/domains/Auth/LoginForm/LoginForm.test.tsx
@@ -55,11 +55,11 @@ describe('LoginForm', () => {
         // change the fields
         ReactTestUtils.act(() => {
             ReactTestUtils.Simulate.change(usernameNode, {
-                target: { value: 'username' },
-            } as any);
+                target: ({ value: 'username' } as unknown) as EventTarget,
+            });
             ReactTestUtils.Simulate.change(passwordNode, {
-                target: { value: 'password' },
-            } as any);
+                target: ({ value: 'password' } as unknown) as EventTarget,
+            });
         });
 
         // expect them to reflect the changed values
@@ -69,7 +69,7 @@ describe('LoginForm', () => {
 
     it('should call handleSubmit & onSuccess appropriately', async () => {
         const onSuccess = jest.fn();
-        const resolveVal = { status: 200 } as AxiosResponse<any>;
+        const resolveVal = { status: 200 } as AxiosResponse<unknown>;
         const loginSpy = jest.spyOn(API, 'login').mockResolvedValue(resolveVal);
         jest.useFakeTimers();
 

--- a/src/domains/Auth/LoginTempForm/LoginTempForm.test.tsx
+++ b/src/domains/Auth/LoginTempForm/LoginTempForm.test.tsx
@@ -59,7 +59,7 @@ describe('LoginTempForm', () => {
     it('should submit and succeed', async () => {
         const onSuccess = jest.fn();
         const onFailure = jest.fn();
-        const resolvedVal = { status: 200 } as AxiosResponse<any>;
+        const resolvedVal = { status: 200 } as AxiosResponse<unknown>;
         const spy = jest.spyOn(API, 'loginTemp').mockResolvedValue(resolvedVal);
         jest.useFakeTimers();
 
@@ -79,8 +79,8 @@ describe('LoginTempForm', () => {
 
         ReactTestUtils.act(() => {
             ReactTestUtils.Simulate.change(usernameNode, {
-                target: { value: 'username' },
-            } as any);
+                target: ({ value: 'username' } as unknown) as EventTarget,
+            });
             button.dispatchEvent(new MouseEvent('click', { bubbles: true }));
         });
 
@@ -118,8 +118,8 @@ describe('LoginTempForm', () => {
 
         ReactTestUtils.act(() => {
             ReactTestUtils.Simulate.change(usernameNode, {
-                target: { value: 'username' },
-            } as any);
+                target: ({ value: 'username' } as unknown) as EventTarget,
+            });
             button.dispatchEvent(new MouseEvent('click', { bubbles: true }));
         });
 

--- a/src/domains/Auth/PasswordResetForm/PasswordResetForm.test.tsx
+++ b/src/domains/Auth/PasswordResetForm/PasswordResetForm.test.tsx
@@ -28,7 +28,7 @@ describe('ForgotPassConsume', () => {
     });
 
     // eslint-disable-next-line jest/expect-expect
-    it('should render', async () => {
+    it('should render', () => {
         ReactTestUtils.act(() => {
             render(
                 <PasswordResetForm onSuccess={jest.fn()} token='' />,

--- a/src/domains/Auth/PasswordResetForm/PasswordResetForm.test.tsx
+++ b/src/domains/Auth/PasswordResetForm/PasswordResetForm.test.tsx
@@ -58,11 +58,11 @@ describe('ForgotPassConsume', () => {
 
         ReactTestUtils.act(() => {
             ReactTestUtils.Simulate.change(passNode, {
-                target: { value: '123' },
-            } as any);
+                target: ({ value: '123' } as unknown) as EventTarget,
+            });
             ReactTestUtils.Simulate.change(confirmNode, {
-                target: { value: '123' },
-            } as any);
+                target: ({ value: '123' } as unnown) as EventTarget,
+            });
             button.dispatchEvent(new MouseEvent('click', { bubbles: true }));
         });
 

--- a/src/domains/Auth/RegisterForm/RegisterForm.test.tsx
+++ b/src/domains/Auth/RegisterForm/RegisterForm.test.tsx
@@ -91,17 +91,17 @@ describe('RegisterForm', () => {
 
         ReactTestUtils.act(() => {
             ReactTestUtils.Simulate.change(usernameNode, {
-                target: { value: form.username },
-            } as any);
+                target: ({ value: form.username } as unknown) as EventTarget,
+            });
             ReactTestUtils.Simulate.change(emailNode, {
-                target: { value: form.email },
-            } as any);
+                target: ({ value: form.email } as unknown) as EventTarget,
+            });
             ReactTestUtils.Simulate.change(passwordNode, {
-                target: { value: form.password },
-            } as any);
+                target: ({ value: form.password } as unknown) as EventTarget,
+            });
             ReactTestUtils.Simulate.change(confirmNode, {
-                target: { value: form.confirmPass },
-            } as any);
+                target: ({ value: form.confirmPass } as unknown) as EventTarget,
+            });
             button.dispatchEvent(new MouseEvent('click', { bubbles: true }));
         });
 
@@ -139,22 +139,24 @@ describe('RegisterForm', () => {
         const usernameNode = document.querySelector('#username') as HTMLElement;
         const emailNode = document.querySelector('#email') as HTMLElement;
         const passwordNode = document.querySelector('#password') as HTMLElement;
-        const confirmNode = document.querySelector('#confirm-password') as HTMLElement;
+        const confirmNode = document.querySelector(
+            '#confirm-password'
+        ) as HTMLElement;
         const button = document.querySelector('[type="submit"]') as HTMLElement;
 
         ReactTestUtils.act(() => {
             ReactTestUtils.Simulate.change(usernameNode, {
-                target: { value: form.username },
-            } as any);
+                target: ({ value: form.username } as unknown) as EventTarget,
+            });
             ReactTestUtils.Simulate.change(emailNode, {
-                target: { value: form.email },
-            } as any);
+                target: ({ value: form.email } as unknown) as EventTarget,
+            });
             ReactTestUtils.Simulate.change(passwordNode, {
-                target: { value: form.password },
-            } as any);
+                target: ({ value: form.password } as unknown) as EventTarget,
+            });
             ReactTestUtils.Simulate.change(confirmNode, {
-                target: { value: form.confirmPass },
-            } as any);
+                target: ({ value: form.confirmPass } as unknown) as EventTarget,
+            });
             button.dispatchEvent(new MouseEvent('click', { bubbles: true }));
         });
 

--- a/src/domains/Townhall/Contexts/Townhall.tsx
+++ b/src/domains/Townhall/Contexts/Townhall.tsx
@@ -41,3 +41,7 @@ export default function TownhallProvider({ value, children }: Props) {
         </TownhallContext.Provider>
     );
 }
+
+TownhallProvider.defaultProps = {
+    value: {},
+};

--- a/src/domains/Townhall/Contexts/Townhall.tsx
+++ b/src/domains/Townhall/Contexts/Townhall.tsx
@@ -3,10 +3,10 @@ import { useParams } from 'react-router-dom';
 import Loader from 'components/Loader';
 
 import useEndpoint from 'hooks/useEndpoint';
-import { Townhall, getTownhall } from '../api';
+import { getTownhall } from '../api';
 
 interface Props {
-    value?: Townhall;
+    value?: Prytaneum.Townhall;
     children: JSX.Element | JSX.Element[];
 }
 
@@ -15,7 +15,9 @@ interface Params {
 }
 
 // this is dangerous to cast an empty object as a townhall, but my component below gaurantees it will always be defined
-export const TownhallContext = React.createContext<Townhall>({} as Townhall);
+export const TownhallContext = React.createContext<Prytaneum.Townhall>(
+    {} as Prytaneum.Townhall
+);
 
 export default function TownhallProvider({ value, children }: Props) {
     const { townhallId } = useParams<Params>();

--- a/src/domains/Townhall/Contexts/Townhall.tsx
+++ b/src/domains/Townhall/Contexts/Townhall.tsx
@@ -32,7 +32,7 @@ export default function TownhallProvider({ value, children }: Props) {
             get();
         }
     }, []);
-    
+
     return !townhall ? (
         <Loader />
     ) : (

--- a/src/domains/Townhall/QuestionQueue/QuestionQueue.tsx
+++ b/src/domains/Townhall/QuestionQueue/QuestionQueue.tsx
@@ -75,6 +75,7 @@ function questionReducer(state: Question[], action: Actions) {
 export default function QuestionQueue() {
     const classes = useStyles();
     const topRef = React.useRef<HTMLDivElement | null>(null);
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const [state, dispatch, socket] = useSocketio<Question[], Actions>({
         url: '/moderator/questions',
         event: 'townhall-question-state',

--- a/src/domains/Townhall/TownhallChat/TownhallChat.tsx
+++ b/src/domains/Townhall/TownhallChat/TownhallChat.tsx
@@ -61,7 +61,7 @@ const chatReducer = (state: Message[], action: Actions): Message[] => {
 };
 
 export default function TownhallChat() {
-    const [state, dispatch, socket] = useSocketio<Message[], Actions>({
+    const [state] = useSocketio<Message[], Actions>({
         url: '/chat',
         event: 'townhall-chat-state',
         reducer: chatReducer,

--- a/src/domains/Townhall/TownhallForm/TownhallForm.tsx
+++ b/src/domains/Townhall/TownhallForm/TownhallForm.tsx
@@ -20,7 +20,7 @@ import {
 interface FormProps {
     onSubmit: () => void;
     initialState?: TownhallFormType;
-    endpoint: (form: TownhallFormType) => Promise<AxiosResponse<any>>;
+    endpoint: (form: TownhallFormType) => Promise<AxiosResponse<unknown>>;
 }
 
 interface DefaultFormProps {

--- a/src/domains/Townhall/api/api.test.ts
+++ b/src/domains/Townhall/api/api.test.ts
@@ -1,4 +1,6 @@
+/* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/unbound-method */
+
 import axios from 'utils/axios';
 import errors from 'utils/errors';
 import * as API from '.';

--- a/src/domains/Townhall/api/api.ts
+++ b/src/domains/Townhall/api/api.ts
@@ -1,6 +1,5 @@
 import axios from 'utils/axios';
 import errors from 'utils/errors';
-import TownhallForm from '../TownhallForm';
 
 /*
     TYPE DECLARATIONS

--- a/src/domains/Townhall/api/api.ts
+++ b/src/domains/Townhall/api/api.ts
@@ -33,7 +33,7 @@ export async function createTownhall(form: TownhallForm) {
         throw errors.fieldError();
     }
     const body: Create = { form };
-    return axios.post('/api/townhalls/create', body);
+    return axios.post<unknown>('/api/townhalls/create', body);
 }
 
 export async function updateTownhall(form: TownhallForm, townhallId: string) {
@@ -48,7 +48,7 @@ export async function updateTownhall(form: TownhallForm, townhallId: string) {
     }
 
     const body: Update = { form, townhallId };
-    return axios.post('/api/townhalls/update', body);
+    return axios.post<unknown>('/api/townhalls/update', body);
 }
 
 export async function getTownhallList() {

--- a/src/hooks/useErrorHandler.ts
+++ b/src/hooks/useErrorHandler.ts
@@ -3,7 +3,6 @@ import useSnack from './useSnack';
 export default function useErrorHandler() {
     const [snack] = useSnack();
     const handleError = (err: Error) => {
-        // console.log(new Error('asdf'))
         snack(`Error: ${err.message}`, 'error');
     };
     // TODO: log this to server?

--- a/src/layout/Footer.tsx
+++ b/src/layout/Footer.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
 
-import Grid from '@material-ui/core/Grid';
-
 export default function Footer() {
     return (
         <footer>

--- a/src/layout/TransitionPage.tsx
+++ b/src/layout/TransitionPage.tsx
@@ -4,7 +4,7 @@ import { useLocation } from 'react-router-dom';
 import Fade from '@material-ui/core/Fade';
 
 interface Props {
-    children: ReactElement<any, any> | undefined; // this is strange?
+    children: ReactElement<unknown, string> | undefined; // this is strange?
 }
 
 export default function TransitionPage({ children }: Props) {

--- a/src/mock/Fixtures.ts
+++ b/src/mock/Fixtures.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 
-export interface Fixture<T = any> {
+export interface Fixture<T = unknown> {
     meta: {
         timeout?: number;
         status: number;
@@ -11,7 +11,7 @@ export interface Fixture<T = any> {
     data?: T;
 }
 
-export function makeSuccessFixture(data?: Record<string, any>) {
+export function makeSuccessFixture(data?: Record<string, unknown>) {
     return {
         meta: { status: 200, statusText: 'OK', config: {}, headers: {} },
         data,

--- a/src/pages/Auth/VerifyEmail/VerifyEmail.test.tsx
+++ b/src/pages/Auth/VerifyEmail/VerifyEmail.test.tsx
@@ -34,7 +34,7 @@ describe('VerifyEmail', () => {
 
     // eslint-disable-next-line jest/expect-expect
     it('should render, verify, & go to /login', async () => {
-        let _location: any;
+        let _location = { pathname: '' };
         jest.useFakeTimers();
         const resolvedValue = { status: 200 };
         const userId = '123456';
@@ -72,7 +72,7 @@ describe('VerifyEmail', () => {
     });
 
     it('should render, fail to verify, & go to /login', async () => {
-        let _location: any;
+        let _location = { pathname: '' };
         jest.useFakeTimers();
         const resolvedValue = { status: 500 };
         const userId = '123456';

--- a/src/pages/Routes.tsx
+++ b/src/pages/Routes.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import { Route, Redirect, Switch, useRouteMatch } from 'react-router-dom';
+import { Route, Redirect, Switch } from 'react-router-dom';
 import Auth from './Auth';
-import LoggedIn from '../components/LoggedIn';
-import Townhall from './Townhall';
-import Nav from '../layout/Nav';
-import Footer from '../layout/Footer';
+// import LoggedIn from '../components/LoggedIn';
+// import Townhall from './Townhall';
+// import Nav from '../layout/Nav';
+// import Footer from '../layout/Footer';
 // import TownhallList from '../domains/Townhall/TownhallList';
 // import Chat from '../domains/Townhall/TownhallChat';
 // import SessionSummary from './SessionSummary';
@@ -19,7 +19,7 @@ import Footer from '../layout/Footer';
 // import Verification from './Verification';
 // import RequestPasswordReset from './RequestPasswordReset';
 // import UpdatePassword from './UpdatePassword';
-import Public from './Public';
+// import Public from './Public';
 
 const DefaultPage = () => <Redirect to='/auth/login' />;
 const AppHomePage = () => <Redirect to='/app/townhalls' />;

--- a/src/pages/Townhall/TownhallPre/TownhallPre.stories.tsx
+++ b/src/pages/Townhall/TownhallPre/TownhallPre.stories.tsx
@@ -1,6 +1,4 @@
 import React from 'react';
-import Container from '@material-ui/core/Container';
-
 import FixtureContext, { makeSuccessFixture } from 'mock/Fixtures';
 import Page from '.';
 

--- a/src/prytaneum.d.ts
+++ b/src/prytaneum.d.ts
@@ -11,6 +11,7 @@ declare namespace Prytaneum {
         picture: string;
         readingMaterials: '';
         date: Date;
+        url: string;
     }
     interface User {
         _id: string;

--- a/src/serviceWorker.ts
+++ b/src/serviceWorker.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 // This optional code is used to register a service worker.
 // register() is not called by default.
 

--- a/src/serviceWorker.ts
+++ b/src/serviceWorker.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 // This optional code is used to register a service worker.
 // register() is not called by default.
 
@@ -12,139 +13,136 @@
 
 const isLocalhost = Boolean(
     window.location.hostname === 'localhost' ||
-      // [::1] is the IPv6 localhost address.
-      window.location.hostname === '[::1]' ||
-      // 127.0.0.0/8 are considered localhost for IPv4.
-      window.location.hostname.match(
-        /^127(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/
-      )
-  );
-  
-  type Config = {
+        // [::1] is the IPv6 localhost address.
+        window.location.hostname === '[::1]' ||
+        // 127.0.0.0/8 are considered localhost for IPv4.
+        window.location.hostname.match(
+            /^127(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/
+        )
+);
+
+type Config = {
     onSuccess?: (registration: ServiceWorkerRegistration) => void;
     onUpdate?: (registration: ServiceWorkerRegistration) => void;
-  };
-  
-  export function register(config?: Config) {
+};
+
+export function register(config?: Config) {
     if (process.env.NODE_ENV === 'production' && 'serviceWorker' in navigator) {
-      // The URL constructor is available in all browsers that support SW.
-      const publicUrl = new URL(
-        process.env.PUBLIC_URL,
-        window.location.href
-      );
-      if (publicUrl.origin !== window.location.origin) {
-        // Our service worker won't work if PUBLIC_URL is on a different origin
-        // from what our page is served on. This might happen if a CDN is used to
-        // serve assets; see https://github.com/facebook/create-react-app/issues/2374
-        return;
-      }
-  
-      window.addEventListener('load', () => {
-        const swUrl = `${process.env.PUBLIC_URL}/service-worker.js`;
-  
-        if (isLocalhost) {
-          // This is running on localhost. Let's check if a service worker still exists or not.
-          checkValidServiceWorker(swUrl, config);
-  
-          // Add some additional logging to localhost, pointing developers to the
-          // service worker/PWA documentation.
-          navigator.serviceWorker.ready.then(() => {
-            console.log(
-              'This web app is being served cache-first by a service ' +
-                'worker. To learn more, visit https://bit.ly/CRA-PWA'
-            );
-          });
-        } else {
-          // Is not localhost. Just register service worker
-          registerValidSW(swUrl, config);
-        }
-      });
-    }
-  }
-  
-  function registerValidSW(swUrl: string, config?: Config) {
-    navigator.serviceWorker
-      .register(swUrl)
-      .then(registration => {
-        registration.onupdatefound = () => {
-          const installingWorker = registration.installing;
-          if (installingWorker == null) {
+        // The URL constructor is available in all browsers that support SW.
+        const publicUrl = new URL(process.env.PUBLIC_URL, window.location.href);
+        if (publicUrl.origin !== window.location.origin) {
+            // Our service worker won't work if PUBLIC_URL is on a different origin
+            // from what our page is served on. This might happen if a CDN is used to
+            // serve assets; see https://github.com/facebook/create-react-app/issues/2374
             return;
-          }
-          installingWorker.onstatechange = () => {
-            if (installingWorker.state === 'installed') {
-              if (navigator.serviceWorker.controller) {
-                // At this point, the updated precached content has been fetched,
-                // but the previous service worker will still serve the older
-                // content until all client tabs are closed.
-                console.log(
-                  'New content is available and will be used when all ' +
-                    'tabs for this page are closed. See https://bit.ly/CRA-PWA.'
-                );
-  
-                // Execute callback
-                if (config && config.onUpdate) {
-                  config.onUpdate(registration);
-                }
-              } else {
-                // At this point, everything has been precached.
-                // It's the perfect time to display a
-                // "Content is cached for offline use." message.
-                console.log('Content is cached for offline use.');
-  
-                // Execute callback
-                if (config && config.onSuccess) {
-                  config.onSuccess(registration);
-                }
-              }
-            }
-          };
-        };
-      })
-      .catch(error => {
-        console.error('Error during service worker registration:', error);
-      });
-  }
-  
-  function checkValidServiceWorker(swUrl: string, config?: Config) {
-    // Check if the service worker can be found. If it can't reload the page.
-    fetch(swUrl, {
-      headers: { 'Service-Worker': 'script' }
-    })
-      .then(response => {
-        // Ensure service worker exists, and that we really are getting a JS file.
-        const contentType = response.headers.get('content-type');
-        if (
-          response.status === 404 ||
-          (contentType != null && contentType.indexOf('javascript') === -1)
-        ) {
-          // No service worker found. Probably a different app. Reload the page.
-          navigator.serviceWorker.ready.then(registration => {
-            registration.unregister().then(() => {
-              window.location.reload();
-            });
-          });
-        } else {
-          // Service worker found. Proceed as normal.
-          registerValidSW(swUrl, config);
         }
-      })
-      .catch(() => {
-        console.log(
-          'No internet connection found. App is running in offline mode.'
-        );
-      });
-  }
-  
-  export function unregister() {
-    if ('serviceWorker' in navigator) {
-      navigator.serviceWorker.ready
-        .then(registration => {
-          registration.unregister();
-        })
-        .catch(error => {
-          console.error(error.message);
+
+        window.addEventListener('load', () => {
+            const swUrl = `${process.env.PUBLIC_URL}/service-worker.js`;
+
+            if (isLocalhost) {
+                // This is running on localhost. Let's check if a service worker still exists or not.
+                checkValidServiceWorker(swUrl, config);
+
+                // Add some additional logging to localhost, pointing developers to the
+                // service worker/PWA documentation.
+                navigator.serviceWorker.ready.then(() => {
+                    console.log(
+                        'This web app is being served cache-first by a service ' +
+                            'worker. To learn more, visit https://bit.ly/CRA-PWA'
+                    );
+                });
+            } else {
+                // Is not localhost. Just register service worker
+                registerValidSW(swUrl, config);
+            }
         });
     }
-  }
-  
+}
+
+function registerValidSW(swUrl: string, config?: Config) {
+    navigator.serviceWorker
+        .register(swUrl)
+        .then((registration) => {
+            registration.onupdatefound = () => {
+                const installingWorker = registration.installing;
+                if (installingWorker == null) {
+                    return;
+                }
+                installingWorker.onstatechange = () => {
+                    if (installingWorker.state === 'installed') {
+                        if (navigator.serviceWorker.controller) {
+                            // At this point, the updated precached content has been fetched,
+                            // but the previous service worker will still serve the older
+                            // content until all client tabs are closed.
+                            console.log(
+                                'New content is available and will be used when all ' +
+                                    'tabs for this page are closed. See https://bit.ly/CRA-PWA.'
+                            );
+
+                            // Execute callback
+                            if (config && config.onUpdate) {
+                                config.onUpdate(registration);
+                            }
+                        } else {
+                            // At this point, everything has been precached.
+                            // It's the perfect time to display a
+                            // "Content is cached for offline use." message.
+                            console.log('Content is cached for offline use.');
+
+                            // Execute callback
+                            if (config && config.onSuccess) {
+                                config.onSuccess(registration);
+                            }
+                        }
+                    }
+                };
+            };
+        })
+        .catch((error) => {
+            console.error('Error during service worker registration:', error);
+        });
+}
+
+function checkValidServiceWorker(swUrl: string, config?: Config) {
+    // Check if the service worker can be found. If it can't reload the page.
+    fetch(swUrl, {
+        headers: { 'Service-Worker': 'script' },
+    })
+        .then((response) => {
+            // Ensure service worker exists, and that we really are getting a JS file.
+            const contentType = response.headers.get('content-type');
+            if (
+                response.status === 404 ||
+                (contentType != null &&
+                    contentType.indexOf('javascript') === -1)
+            ) {
+                // No service worker found. Probably a different app. Reload the page.
+                navigator.serviceWorker.ready.then((registration) => {
+                    registration.unregister().then(() => {
+                        window.location.reload();
+                    });
+                });
+            } else {
+                // Service worker found. Proceed as normal.
+                registerValidSW(swUrl, config);
+            }
+        })
+        .catch(() => {
+            console.log(
+                'No internet connection found. App is running in offline mode.'
+            );
+        });
+}
+
+export function unregister() {
+    if ('serviceWorker' in navigator) {
+        navigator.serviceWorker.ready
+            .then((registration) => {
+                registration.unregister();
+            })
+            .catch((error) => {
+                console.error(error.message);
+            });
+    }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,5 +17,5 @@
         "baseUrl": "src"
     },
     "include": ["src"],
-    "exclude": ["node_modules", "**/*.test.ts"]
+    "exclude": ["node_modules"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4375,6 +4375,16 @@ babel-plugin-transform-undefined-to-void@^6.9.4:
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-undefined-to-void/-/babel-plugin-transform-undefined-to-void-6.9.4.tgz#be241ca81404030678b748717322b89d0c8fe280"
   integrity sha1-viQcqBQEAwZ4t0hxcyK4nQyP4oA=
 
+babel-plugin-typescript-to-proptypes@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-typescript-to-proptypes/-/babel-plugin-typescript-to-proptypes-1.4.0.tgz#ece83e02f53e24cb5f2ed71c131dbadf5f3d13bd"
+  integrity sha512-s01wh3VlVxgGCCkZbMsZ5ui7pVovR2Wsb8/NiEUKcxW2N9tbDqZlv9I0h34OF6hxID7FZ43ytHxm+0MsJ9F7WA==
+  dependencies:
+    "@babel/helper-module-imports" "^7.10.4"
+    "@babel/helper-plugin-utils" "^7.10.4"
+    "@babel/plugin-syntax-typescript" "^7.10.4"
+    "@babel/types" "^7.10.5"
+
 babel-preset-jest@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-24.9.0.tgz#192b521e2217fb1d1f67cf73f70c336650ad3cdc"


### PR DESCRIPTION
### 1. Fixed all linting warnings and errors in the source code (except serviceWorker.ts). Installed typescript-to-proptypes Babel plugin.

## 2. Several components and test suites were modified. Mainly replaced "any" types with the respective types, deleted unused variables, and deleted irrelevant console.logs. To set up the Babel plugin, a .babelrc.js was created.

### 3. Package added: babel-plugin-typescript-to-proptypes
