### PR TITLE
Msw mocks for Auth and Townhall APIs

### DIFF
--- a/src/mock/handlers/auth.ts
+++ b/src/mock/handlers/auth.ts
@@ -1,4 +1,5 @@
 import { rest } from 'msw';
+import * as AuthTypes from 'domains/Auth/types';
 
 export default [
     rest.post('/api/users/login', (req, res, ctx) => {
@@ -21,5 +22,44 @@ export default [
             return res(ctx.status(400));
         }
         return res(ctx.cookie('jwt', 'not a real jwt'), ctx.status(200));
+    }),
+
+    rest.post('/api/users/consume-password-reset-token', (req, res, ctx) => {
+        const { token, form } = req.body as {
+            token: string;
+            form: AuthTypes.ForgotPassForm;
+        };
+        if (form.password === 'fail') {
+            return res(ctx.status(400));
+        }
+        return res(ctx.status(200, 'Password Reset'));
+    }),
+
+    rest.post('/api/users/request-password-reset', (req, res, ctx) => {
+        const { form } = req.body as {
+            form: AuthTypes.ForgotPassRequestForm;
+        };
+        if (form.email === 'fail') {
+            res(ctx.status(400));
+        }
+        return res(ctx.status(200));
+    }),
+
+    rest.post('/api/users/register', (req, res, ctx) => {
+        const { form } = req.body as {
+            form: AuthTypes.RegisterForm;
+        };
+        if (form.username === 'fail') {
+            return res(ctx.status(400));
+        }
+        return res(ctx.status(200));
+    }),
+
+    rest.post('/api/confirm/user-email', (req, res, ctx) => {
+        const { userId } = req.body as { userId: string };
+        if (userId === 'fail') {
+            return res(ctx.status(400));
+        }
+        return res(ctx.status(200));
     }),
 ];

--- a/src/mock/handlers/auth.ts
+++ b/src/mock/handlers/auth.ts
@@ -25,6 +25,7 @@ export default [
     }),
 
     rest.post('/api/users/consume-password-reset-token', (req, res, ctx) => {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const { token, form } = req.body as {
             token: string;
             form: AuthTypes.ForgotPassForm;

--- a/src/mock/handlers/auth.ts
+++ b/src/mock/handlers/auth.ts
@@ -40,7 +40,7 @@ export default [
         const { form } = req.body as {
             form: AuthTypes.ForgotPassRequestForm;
         };
-        if (form.email === 'fail') {
+        if (form.email === 'fail1234@gmail.com') {
             res(ctx.status(400));
         }
         return res(ctx.status(200));

--- a/src/mock/handlers/townhall.ts
+++ b/src/mock/handlers/townhall.ts
@@ -40,6 +40,7 @@ export default [
     }),
 
     rest.post('/api/townhalls/update', (req, res, ctx) => {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const { form, townhallId } = req.body as {
             form: TownHallTypes.TownhallForm;
             townhallId: string;

--- a/src/mock/handlers/townhall.ts
+++ b/src/mock/handlers/townhall.ts
@@ -1,0 +1,91 @@
+import { rest } from 'msw';
+import faker from 'faker';
+import * as TownHallTypes from 'domains/Townhall/types';
+
+const recent = faker.date.recent();
+const future = faker.date.future();
+
+const makeTownhall = () => ({
+    _id: faker.random.alphaNumeric(5),
+    speaker: {
+        name: `${faker.name.firstName()} ${faker.name.lastName()}`,
+        party: faker.company.companyName(),
+        territory: 'CA-41',
+    },
+    moderator: `${faker.name.firstName()} ${faker.name.lastName()}`,
+    topic: faker.random.word(),
+    picture: faker.image.imageUrl(),
+    readingMaterials: '',
+    date: faker.date.between(recent, future),
+    alignment: faker.company.companyName(),
+});
+
+const makeTownHalls = (amount: number) => {
+    const list = [];
+    for (let i = 0; i < amount; i += 1) {
+        list.push(makeTownhall());
+    }
+    return list;
+};
+
+export default [
+    rest.post('/api/townhalls/create', (req, res, ctx) => {
+        const { form } = req.body as {
+            form: TownHallTypes.TownhallForm;
+        };
+        if (form.speaker === 'fail') {
+            return res(ctx.status(400));
+        }
+        return res(ctx.status(200));
+    }),
+
+    rest.post('/api/townhalls/update', (req, res, ctx) => {
+        const { form, townhallId } = req.body as {
+            form: TownHallTypes.TownhallForm;
+            townhallId: string;
+        };
+        if (form.speaker === 'fail') {
+            return res(ctx.status(400));
+        }
+        return res(ctx.status(200));
+    }),
+
+    rest.post('/api/townhalls/list', (req, res, ctx) => {
+        return res(
+            ctx.json({
+                list: makeTownHalls(10),
+            }),
+            ctx.status(200)
+        );
+    }),
+
+    rest.post('/api/townhalls/:id', (req, res, ctx) => {
+        const { id } = req.params as { id: string };
+        if (id === '0') {
+            return res(
+                ctx.json({
+                    townhall: null,
+                }),
+                ctx.status(400)
+            );
+        }
+        return res(
+            ctx.json({
+                townhall: makeTownhall(),
+            }),
+            ctx.status(200)
+        );
+    }),
+
+    rest.post('/api/townhalls/:_id/create-question', (req, res, ctx) => {
+        const { id } = req.params as { id: string };
+        const { form } = req.body as {
+            form: TownHallTypes.TownhallQuestionForm;
+        };
+
+        if (form.question === 'fail' || id === '0') {
+            return res(ctx.status(400));
+        }
+        return res(ctx.status(200));
+    }),
+];


### PR DESCRIPTION
### 1. Please briefly explain what it is you coded
Adds Mock APIs for Auth and Townhall domains
### 2. Please briefly explain your approach (new components added? modified? removed?)
Used MSW to implement mock APIs. To mock some Townhall APIs, Faker was used to return fake townhall lists.
### 3. Any packages added/updated/removed
No packages added.
