### PR TITLE
feat(frontend): landing page prototype, user settings prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,5 +74,6 @@ There's a few complexities to take note of:
     - Run `yarn workspace @app/db prisma generate`.
     - Run `yarn workspace @app/db start-db` to start db.
     - Run `docker-compose down && docker volume prune && docker container prune && docker image prune` to clear current db.
+    - Run `yarn workspace @app/db start-db` to start db again.
     - Run `yarn workspace @app/db prisma db push --preview-feature` to sync the db with the schema.
     - Run `yarn g:dev-project`.

--- a/README.md
+++ b/README.md
@@ -58,3 +58,21 @@ There's a few complexities to take note of:
 
 - `Subject/type may not be empty` error when trying to commit for the first time?
     - Format your commit message as `addition(scope): what addition you made` where addition can be `fix`, `feature`, `refactor`, etc. `(scope)` can be `(global)`, `(frontend)`, `(backend)`, `(fullstack)`, `(docs)`. Your message should be a string of all lowercase letters that isn't sentence-case, start-case, pascal-case, or upper-case.
+
+- `Can't reach database server at localhost:3003` error when trying to log in or register?
+    - Verify that Docker is running.
+    - Run `yarn workspace @app/db start-db` to start db.
+    - Run `yarn g:dev-project`.
+
+- Still can't log in or register and the server exits with code 0 in the terminal?
+    - Check your node version by running `node -v` and ensure that it's v14.17.1.
+        - Otherwise, change the node version by running `nvm install 14.17.1` and `nvm use 14.17.1`.
+    - Run `yarn workspace @app/db prisma generate`.
+    - Run `yarn g:dev-project`.
+
+- Can't log in or register and the error `public.User does not exist in the current database` shows?
+    - Run `yarn workspace @app/db prisma generate`.
+    - Run `yarn workspace @app/db start-db` to start db.
+    - Run `docker-compose down && docker volume prune && docker container prune && docker image prune` to clear current db.
+    - Run `yarn workspace @app/db prisma db push --preview-feature` to sync the db with the schema.
+    - Run `yarn g:dev-project`.

--- a/app/client/schema.graphql
+++ b/app/client/schema.graphql
@@ -601,3 +601,12 @@ type UserMutationResponse implements MutationResponse {
   message: String!
   body: User
 }
+
+type UserSettings {
+  currentEmail: String!
+  updateEmail: String
+  updatePassword: String
+  deleteAccount: Boolean!
+  isAnonymous: Boolean!
+  isNotificationsEnabled: Boolean!
+}

--- a/app/client/src/components/SettingsMenu/SettingsMenu.tsx
+++ b/app/client/src/components/SettingsMenu/SettingsMenu.tsx
@@ -1,6 +1,19 @@
 import * as React from 'react';
 import { makeStyles } from '@material-ui/core/styles';
-import { Typography, Grid, Divider } from '@material-ui/core';
+import { 
+    Typography,
+    Grid,
+    Divider,
+    Accordion,
+    AccordionSummary,
+    AccordionDetails,
+    IconButton,
+    Menu,
+    MenuItem,
+    ListItemText,
+} from '@material-ui/core';
+import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
+import MoreVert from '@material-ui/icons/MoreVert';
 
 const useStyles = makeStyles((theme) => ({
     root: {
@@ -8,13 +21,24 @@ const useStyles = makeStyles((theme) => ({
         width: '100%',
     },
     container: {
-        marginTop: theme.spacing(4),
+        padding: theme.spacing(2, 1, 2, 2),
+        justifyContent: 'space-between'
+    },
+    panel: {
+        boxShadow: '0 5px 10px 0 rgba(0, 0, 0, .3)',
     },
     componentTitle: {
         margin: theme.spacing(0, 0, 2, 0),
     },
     componentDivider: {
         marginTop: theme.spacing(2),
+    },
+    heading: {
+        flexBasis: '33.33%',
+        flexShrink: 0,
+    },
+    secondaryHeading: {
+        color: theme.palette.text.secondary,
     },
 }));
 
@@ -37,30 +61,113 @@ interface Props {
  */
 export function SettingsMenu({ config }: Props) {
     const classes = useStyles();
+    const [anchorEl, setAnchorEl] = React.useState<HTMLElement | null>(null);
+    const isOpen = React.useMemo(() => Boolean(anchorEl), [anchorEl]);
+    const width = React.useRef(0);
+    const [numExpanded, setNumExpanded] = React.useState(0);
+    const [expandedPanels, setExpandedPanels] = React.useState([])
+
+    const handleChange = (panel) => (event, isExpanded) => {
+        setNumExpanded(isExpanded ? numExpanded + 1 : numExpanded - 1);
+
+        if (isExpanded)
+            setExpandedPanels(oldArray => [...oldArray, panel]);
+        else 
+            setExpandedPanels(expandedPanels.filter(item => item !== panel));
+    };
+
+    const handleExpandAll = () => {
+        setNumExpanded(config.length);
+        setExpandedPanels(config.map(x => Object.values(x)[0]));
+    };
+
+    const handleCollapseAll = () => {
+        setNumExpanded(0);
+        setExpandedPanels([]);
+    };
+
+    function handleOpen(e: React.MouseEvent<HTMLButtonElement, MouseEvent>) {
+        const { currentTarget } = e;
+        width.current = currentTarget.clientWidth;
+        setAnchorEl(currentTarget);
+    }
 
     return (
         <div className={classes.root}>
-            {config.map(
-                ({ title: sectionTitle, description, component }, idx) =>
-                    component && (
-                        <Grid container className={classes.container} key={sectionTitle}>
-                            <Grid item xs={12} className={classes.componentTitle}>
-                                <Typography variant='h5'>{sectionTitle}</Typography>
-                                <Typography variant='body2' color='textSecondary'>
-                                    {description}
-                                </Typography>
-                            </Grid>
-                            <Grid item xs={12}>
-                                {component}
-                            </Grid>
-                            {idx !== config.length - 1 && (
-                                <Grid item xs={12}>
-                                    <Divider className={classes.componentDivider} />
-                                </Grid>
-                            )}
-                        </Grid>
-                    )
-            )}
+            <Grid container className={classes.container}>
+                <Grid item>
+                    <Typography variant='h4'>User Settings</Typography>
+                </Grid>
+                <Grid item>
+                    <IconButton onClick={handleOpen}>
+                        <MoreVert />
+                    </IconButton>
+                    <Menu
+                        anchorEl={anchorEl}
+                        open={isOpen}
+                        onClose={() => setAnchorEl(null)}
+                        onClick={() => setAnchorEl(null)}
+                        anchorOrigin={{
+                            vertical: 'bottom',
+                            horizontal: 'left',
+                        }}
+                        transformOrigin={{
+                            vertical: 'top',
+                            horizontal: 'left',
+                        }}
+                        getContentAnchorEl={null}
+                        PaperProps={{
+                            style: { minWidth: width.current },
+                        }}
+                    >
+                        {numExpanded === 0 && 
+                            <MenuItem button>
+                                <ListItemText primary='Expand All' onClick={() => handleExpandAll()} />
+                            </MenuItem>
+                        }
+                        {numExpanded !== 0 && 
+                            <MenuItem button >
+                                <ListItemText primary='Collapse All' onClick={() => handleCollapseAll()} />
+                            </MenuItem>
+                        }
+                    </Menu>
+                </Grid>
+            </Grid>
+            <div>
+                {config.map(
+                    ({ title: sectionTitle, description, component }, idx) =>
+                        component && (
+                            <Accordion 
+                                expanded={expandedPanels.includes(sectionTitle)} 
+                                onChange={handleChange(sectionTitle)}
+                                className={expandedPanels.includes(sectionTitle) && classes.panel}
+                            >
+                                <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+                                    <Typography variant='body1' className={classes.heading}>{sectionTitle}</Typography>
+                                    <Typography variant='body1' className={classes.secondaryHeading}>{description}</Typography>
+                                </AccordionSummary>
+                                <AccordionDetails>
+                                    <Grid container key={sectionTitle}>
+                                        {/* <Grid item xs={12} className={classes.componentTitle}>
+                                            <Typography variant='h5'>{sectionTitle}</Typography>
+                                            <Typography variant='body2' color='textSecondary'>
+                                                {description}
+                                            </Typography>
+                                        </Grid> */}
+                                        <Grid item xs={12}>
+                                            {component}
+                                        </Grid>
+                                        {/* {idx !== config.length - 1 && (
+                                            <Grid item xs={12}>
+                                                <Divider className={classes.componentDivider} />
+                                            </Grid>
+                                        )} */}
+                                    </Grid>
+                                </AccordionDetails>
+                            </Accordion>
+                        )
+                )}
+            </div>
         </div>
     );
 }

--- a/app/client/src/components/SettingsMenu/SettingsMenu.tsx
+++ b/app/client/src/components/SettingsMenu/SettingsMenu.tsx
@@ -143,8 +143,8 @@ export function SettingsMenu({ config }: Props) {
                                 className={expandedPanels.includes(sectionTitle) && classes.panel}
                             >
                                 <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-                                    <Typography variant='body1' className={classes.heading}>{sectionTitle}</Typography>
-                                    <Typography variant='body1' className={classes.secondaryHeading}>{description}</Typography>
+                                    <Typography variant='body2' className={classes.heading}>{sectionTitle}</Typography>
+                                    <Typography variant='body2' className={classes.secondaryHeading}>{description}</Typography>
                                 </AccordionSummary>
                                 <AccordionDetails>
                                     <Grid container key={sectionTitle}>

--- a/app/client/src/features/accounts/UserProfile/UserProfile.tsx
+++ b/app/client/src/features/accounts/UserProfile/UserProfile.tsx
@@ -1,0 +1,57 @@
+import * as React from 'react';
+import Grid from '@material-ui/core/Grid';
+import { Avatar } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
+// import DoneIcon from '@material-ui/icons/Done';
+
+import { TextField } from '@local/components/TextField';
+
+interface Props {
+    // eslint-disable-next-line react/require-default-props
+    img?: string;
+}
+
+const useStyles = makeStyles((theme) => ({
+    root: {
+        padding: theme.spacing(0, 1, 1, 1),
+        height: '100%',
+        width: '100%',
+    },
+}));
+
+export default function UserProfile({ img }: Props) {
+    const classes = useStyles();
+
+    return (
+        <div className={classes.root}>
+            <Grid container alignContent='center' spacing={2}>
+                <Grid component='span' item xs={12}>
+                    <Avatar src={img} alt='Profile Avatar' />
+                    {/* ROUTING: to page to upload new photo */}
+                </Grid>
+                <Grid component='span' item xs={12}>
+                    <TextField
+                        inputProps={{ 'aria-label': 'E-mail' }}
+                        label='E-mail'
+                        aria-label='E-mail'
+                        required
+                        type='text'
+                        value='TODO'
+                        onChange={() => {}}
+                    />
+                </Grid>
+                <Grid component='span' item xs={12}>
+                    <TextField
+                        inputProps={{ 'aria-label': 'Password' }}
+                        label='Password'
+                        aria-label='Password'
+                        required
+                        type='password'
+                        value='TODO'
+                        onChange={() => {}}
+                    />
+                </Grid>
+            </Grid>
+        </div>
+    );
+}

--- a/app/client/src/features/accounts/UserProfile/index.ts
+++ b/app/client/src/features/accounts/UserProfile/index.ts
@@ -1,0 +1,1 @@
+export { default } from './UserProfile';

--- a/app/client/src/features/accounts/UserSettings/UserSettings.stories.tsx
+++ b/app/client/src/features/accounts/UserSettings/UserSettings.stories.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import Container from '@material-ui/core/Container';
+
+import { UserProvider } from '@local/features/accounts/UserContext';
+import Component from './UserSettings';
+
+export default { title: '@local/domains/User/User Settings' };
+
+export function UserSettings() {
+    return (
+        <Container maxWidth='md'>
+            <UserProvider>
+                <Component />
+            </UserProvider>
+        </Container>
+    );
+}

--- a/app/client/src/features/accounts/UserSettings/UserSettings.tsx
+++ b/app/client/src/features/accounts/UserSettings/UserSettings.tsx
@@ -4,9 +4,8 @@ import {
     Grid,
     Divider,
 } from '@material-ui/core';
-import MoreVert from '@material-ui/icons/MoreVert';
 
-import { makeStyles } from '@material-ui/core/styles';
+// import { makeStyles } from '@material-ui/core/styles';
 
 import { ResponsiveDialog } from '@local/components/ResponsiveDialog';
 // import AppBar from 'layout/AppBar';
@@ -14,7 +13,7 @@ import { ResponsiveDialog } from '@local/components/ResponsiveDialog';
 import { SettingsMenu }  from '@local/components/SettingsMenu/SettingsMenu';
 import { useUser } from '@local/features/accounts';
 import { useRouter } from 'next/router';
-import UserProfile from '../UserProfile/UserProfile';
+// import UserProfile from '../UserProfile/UserProfile';
 
 import {
     // ButtonList,
@@ -22,14 +21,16 @@ import {
     // Notifications,
     // Appearance,
     // Logout,
-    DisableAccount,
-    // DeleteAccount,
+    ModifyUserEmail,
+    ModifyUserPassword,
+    // DisableAccount,
+    DeleteAccount,
     // Feedback,
     // AboutUs,
     // PrivacyPolicy,
     // TermsOfService,
-    TownhallUserSettings,
-    NotificationSettings,
+    // TownhallUserSettings,
+    // NotificationSettings,
 } from './components';
 
 interface Props {
@@ -147,9 +148,23 @@ export default function UserSettings({ id }: Props) {
             title: 'Account Settings',
             description: 'View Account Settings',
             component: (
-                <div>
-                    Test
-                </div>
+                <Grid container spacing={2}>
+                    <Grid item xs={12}>
+                        <ModifyUserEmail user={user} />
+                    </Grid>
+                    <Grid item xs={12}>
+                        <Divider />
+                    </Grid>
+                    <Grid item xs={12}>
+                        <ModifyUserPassword />
+                    </Grid>
+                    <Grid item xs={12}>
+                        <Divider />
+                    </Grid>
+                    <Grid item xs={12}>
+                        <DeleteAccount />
+                    </Grid>
+                </Grid>
             ),
         },
         // {

--- a/app/client/src/features/accounts/UserSettings/UserSettings.tsx
+++ b/app/client/src/features/accounts/UserSettings/UserSettings.tsx
@@ -1,0 +1,176 @@
+import * as React from 'react';
+import {
+    // Typography,
+    Grid,
+    Divider,
+} from '@material-ui/core';
+import MoreVert from '@material-ui/icons/MoreVert';
+
+import { makeStyles } from '@material-ui/core/styles';
+
+import { ResponsiveDialog } from '@local/components/ResponsiveDialog';
+// import AppBar from 'layout/AppBar';
+
+import { SettingsMenu }  from '@local/components/SettingsMenu/SettingsMenu';
+import { useUser } from '@local/features/accounts';
+import { useRouter } from 'next/router';
+import UserProfile from '../UserProfile/UserProfile';
+
+import {
+    // ButtonList,
+    // AppearAnonymous,
+    // Notifications,
+    // Appearance,
+    // Logout,
+    DisableAccount,
+    // DeleteAccount,
+    // Feedback,
+    // AboutUs,
+    // PrivacyPolicy,
+    // TermsOfService,
+    TownhallUserSettings,
+    NotificationSettings,
+} from './components';
+
+interface Props {
+    id?: string;
+}
+
+// const optionsList = [
+//     {
+//         title: 'Townhall',
+//         component: <TownhallUserSettings />,
+//     },
+//     {
+//         title: 'Notifications',
+//         component: <Notifications />,
+//     },
+//     {
+//         title: 'Appearance',
+//         component: <Appearance />,
+//     },
+// ];
+
+// const accountSettingsList = [
+//     {
+//         title: 'Logout',
+//         component: <Logout />,
+//     },
+//     {
+//         title: 'Disable Account',
+//         component: <DisableAccount />,
+//     },
+//     {
+//         title: 'Delete Account',
+//         component: <DeleteAccount />,
+//     },
+// ];
+
+// const informationList = [
+//     {
+//         title: 'Feedback',
+//         component: <Feedback />,
+//     },
+//     {
+//         title: 'About Us',
+//         component: <AboutUs />,
+//     },
+//     {
+//         title: 'Privacy Policy',
+//         component: <PrivacyPolicy />,
+//     },
+//     {
+//         title: 'Terms of Service',
+//         component: <TermsOfService />,
+//     },
+// ];
+
+/**
+ * Displays the settings for User, using SettingsMenu,
+ * it displays the User information like first name, last name, username, email and obfuscated password, so they can change it.
+ * To be pulled and pushed from/to database later <br/></br>
+ * It also displays options for appearing anonymously, notifcations for upcoming townhalls, darkmode and color scheme (like material UIs website) <br/></br>
+ * Account settings shows an option to logout, disable or delete account, each one opens a dialog box, see @local/components/dialog
+ * Information is info about us, feedback, ToS and privacy policy
+ * @category Pages/Auth
+ * @constructor UserSettings
+ * @param Props
+ * @param {string} id id of the container for testing if it exists or styling. Also just for general specification of the element
+ */
+export default function UserSettings({ id }: Props) {
+    // const classes = useStyles();
+    const [open, setOpen] = React.useState(false);
+    const [cont, setContent] = React.useState<JSX.Element | null>(null);
+    const [user] = useUser();
+    const router = useRouter();
+
+    const handleNavigation = (path: string) => () => router.push(path);
+
+
+    React.useEffect(() => {
+        if (cont !== null) setOpen(true);
+        if (cont === null) setOpen(false);
+    }, [cont]);
+
+    // this is a dev mistake, there's no <User> context higher up in the tree
+    if (!user) handleNavigation('/');
+
+    const sections = [
+        // {
+        //     title: 'General',
+        //     description: 'General User Settings',
+        //     component: (
+        //         <Grid container spacing={2}>
+        //             <Grid item xs={12}>
+        //                 <UserProfile img='https://i.imgur.com/3beQH5s.jpeg' />
+        //             </Grid>
+        //             <Grid item xs={12}>
+        //                 <Divider />
+        //             </Grid>
+        //             <Grid item xs={12}>
+        //                 <DisableAccount />
+        //             </Grid>
+        //         </Grid>
+        //     ),
+        // },
+        // {
+        //     title: 'Townhall',
+        //     description: 'Change Townhall Settings',
+        //     component: <TownhallUserSettings settings={user?.settings} />,
+        // },
+        // {
+        //     title: 'Notifications',
+        //     description: 'Customize Notifications Receieved',
+        //     component: <NotificationSettings settings={user?.settings} />,
+        // },
+        {
+            title: 'Account Settings',
+            description: 'View Account Settings',
+            component: (
+                <div>
+                    Test
+                </div>
+            ),
+        },
+        // {
+        //     title: 'Information',
+        //     description: 'Additional Information',
+        //     component: (
+        //         <ButtonList list={informationList} setContent={setContent} />
+        //     ),
+        // },
+    ];
+
+    return (
+        <div id={id} style={{ width: '100%', height: '100%' }}>
+            <SettingsMenu config={sections} />
+            <ResponsiveDialog open={open} onClose={() => setContent(null)}>
+                {cont || <div />}
+            </ResponsiveDialog>
+        </div>
+    );
+}
+
+UserSettings.defaultProps = {
+    id: 'UserSettings',
+};

--- a/app/client/src/features/accounts/UserSettings/components.tsx
+++ b/app/client/src/features/accounts/UserSettings/components.tsx
@@ -5,20 +5,35 @@ import {
     ListItemText,
     Switch,
     Collapse,
-    // Typography,
+    Typography,
     Button,
+    Grid,
 } from '@material-ui/core';
-import { UserSettings } from '@local/graphql-types';
-
-// import { makeStyles } from '@material-ui/core/styles';
-
+import { User, UserSettings } from '@local/graphql-types';
+import { Form } from '@local/components/Form';
+import { FormContent } from '@local/components/FormContent';
+import { TextField } from '@local/components/TextField';
 import { ConfirmationDialog } from '@local/components/ConfirmationDialog';
 import SettingsList from '@local/components/SettingsList';
-
-import { TextField } from '@local/components/TextField';
-
 import SettingsItem from '@local/components/SettingsItem';
+import { useForm } from '@local/features/core';
+import { makeStyles } from '@material-ui/core/styles';
 import text from './help-text';
+
+const initialModifyUserEmail = {
+    newEmail: '',
+};
+
+const initialModifyUserPassword = {
+    oldPassword: '',
+    newPassword: '',
+    confirmNewPassword: '',
+};
+
+const intiialDeleteAccount = {
+    password: '',
+    confirmPassword: '',
+};
 
 /* DEPTH = 3 CURRYING HERE, 
     top to bottom: 
@@ -34,14 +49,17 @@ const buildCheckboxUpdate = <U extends Record<string, boolean | string[]>>(
     setState((prev) => ({ ...prev, [id]: checked }));
 };
 
-// const useStyles = makeStyles((theme) => ({
-//     indent: {
-//         paddingLeft: theme.spacing(4),
-//     },
-//     fullWidth: {
-//         width: '100%',
-//     },
-// }));
+const useStyles = makeStyles((theme) => ({
+    // indent: {
+    //     paddingLeft: theme.spacing(4),
+    // },
+    // fullWidth: {
+    //     width: '100%',
+    // },
+    form: {
+        margin: theme.spacing(0, 1, 0, ),
+    },
+}));
 
 // all really small one time user @local/components go here
 interface DisplayItem {
@@ -97,13 +115,113 @@ export function NotificationSettings({ settings }: { settings: UserSettings }) {
     );
 }
 
-// export function ModifyUserEmail({ user }: { user: User }) {
-//     return (
-//         <Typography>
-//             todo
-//         </Typography>
-//     )
-// }
+export function ModifyUserEmail({ user }: { user: User }) {
+    const [form, errors, handleSubmit, handleChange] = useForm(initialModifyUserEmail);
+    const classes = useStyles();
+
+    return (
+        <Grid container spacing={2}>
+            <Grid component='span' item xs={12}>
+                <Typography variant='h6'>Change Email</Typography>
+            </Grid>
+            <Grid component='span' item xs={12}>
+                <Typography variant='body1'>
+                    <b>Current email:</b> {user.email}
+                </Typography>
+            </Grid>
+            <Grid component='span' item xs={12}>
+                <Typography variant='body2'>
+                    A verification email will be sent to the new email to confirm the update.
+                </Typography>
+            </Grid>
+            <Form className={classes.form} onSubmit={() => {}}>
+                <FormContent>
+                    <TextField
+                        inputProps={{ 'aria-label': 'Enter your new email' }}
+                        label='Enter your new email'
+                        helperText={errors.newEmail}
+                        error={Boolean(errors.newEmail)}
+                        required
+                        type='email'
+                        variant='outlined'
+                        value={form.newEmail}
+                        onChange={handleChange('newEmail')}
+                        spellCheck={false}
+                    />
+                </FormContent>
+                <Grid component='span' item xs={12}>
+                    <Button type='submit' variant='outlined' color='primary'>
+                        Update email
+                    </Button>
+                </Grid>
+            </Form>
+        </Grid>
+    )
+}
+
+export function ModifyUserPassword() {
+    const [form, errors, handleSubmit, handleChange] = useForm(initialModifyUserPassword);
+    const classes = useStyles();
+
+    return (
+        <Grid container spacing={2}>
+            <Grid component='span' item xs={12}>
+                <Typography variant='h6'>Change Password</Typography>
+            </Grid>
+            <Grid component='span' item xs={12}>
+                <Typography variant='body2'>
+                    Passwords must be at least 8 characters.
+                </Typography>
+            </Grid>
+            
+            <Form className={classes.form} onSubmit={() => {}}>
+                <FormContent>
+                    <TextField
+                        inputProps={{ 'aria-label': 'Enter your old password' }}
+                        label='Enter your old password'
+                        helperText={errors.oldPassword}
+                        error={Boolean(errors.oldPassword)}
+                        required
+                        variant='outlined'
+                        type='password'
+                        value={form.oldPassword}
+                        onChange={handleChange('oldPassword')}
+                        spellCheck={false}
+                    />
+                    <TextField
+                        inputProps={{ 'aria-label': 'Enter your new password' }}
+                        label='Enter your new password'
+                        helperText={errors.newPassword}
+                        error={Boolean(errors.newPassword)}
+                        required
+                        variant='outlined'
+                        type='password'
+                        value={form.newPassword}
+                        onChange={handleChange('newPassword')}
+                        spellCheck={false}
+                    />
+                    <TextField
+                        inputProps={{ 'aria-label': 'Enter your new password again' }}
+                        label='Confirm your new password'
+                        helperText={errors.confirmNewPassword}
+                        error={Boolean(errors.confirmNewPassword)}
+                        required
+                        variant='outlined'
+                        type='password'
+                        value={form.confirmNewPassword}
+                        onChange={handleChange('confirmNewPassword')}
+                        spellCheck={false}
+                    />
+                </FormContent>
+                <Grid component='span' item xs={12}>
+                    <Button variant='outlined' color='primary'>
+                        Update password
+                    </Button>
+                </Grid>
+            </Form>
+        </Grid>
+    )
+}
 
 export const ButtonList = ({ list, setContent }: Props) => (
     <List>
@@ -190,39 +308,64 @@ export const DisableAccount = () => {
     );
 };
 
-export const DeleteAccount = () => (
+export function DeleteAccount() {
+    const [form, errors, handleSubmit, handleChange] = useForm(intiialDeleteAccount);
+    const classes = useStyles();
     // ROUTING: to /Login after deleted
-    <span>
-        <h1>
-            Delete Account?
-            <p>
-                All of your account information will be erased from Prytaneum.
-                This action is irreversible. Please enter your password below
-                twice to confirm.
-            </p>
-        </h1>
-        <TextField
-            inputProps={{ 'aria-label': 'Enter your password' }}
-            label='Please enter your password'
-            required
-            variant='outlined'
-            type='password'
-            value=''
-            onChange={() => {}}
-            spellCheck={false}
-        />
-        <TextField
-            inputProps={{ 'aria-label': 'Enter your password again' }}
-            label='Please enter your password again to DELETE your account'
-            required
-            variant='outlined'
-            type='password'
-            value=''
-            onChange={() => {}}
-            spellCheck={false}
-        />
-    </span>
-);
+    
+    return (
+        <Grid container spacing={2}>
+            <Grid component='span' item xs={12}>
+                <Typography variant='h6'>Delete Account</Typography>
+            </Grid>
+            <Grid component='span' item xs={12}>
+                <Typography variant='body2'>
+                    All of your account information will be erased from Prytaneum.
+                </Typography>
+            </Grid>
+            <Grid component='span' item xs={12}>
+                <Typography variant='body2'>
+                    <b>This action is irreversible.</b> Please enter your password below
+                    twice to confirm.
+                </Typography>
+            </Grid>
+            <Form className={classes.form} onSubmit={() => {}}>
+                <FormContent>
+                    <TextField
+                        inputProps={{ 'aria-label': 'Enter your password' }}
+                        label='Enter your password'
+                        helperText={errors.password}
+                        error={Boolean(errors.password)}
+                        required
+                        variant='outlined'
+                        type='password'
+                        value={form.password}
+                        onChange={handleChange('password')}
+                        spellCheck={false}
+                    />
+                    <TextField
+                        inputProps={{ 'aria-label': 'Enter your password again' }}
+                        label='Confirm your password to DELETE your account'
+                        helperText={errors.confirmPassword}
+                        error={Boolean(errors.confirmPassword)}
+                        required
+                        variant='outlined'
+                        type='password'
+                        value={form.confirmPassword}
+                        onChange={handleChange('confirmPassword')}
+                        spellCheck={false}
+                    />
+                </FormContent>
+                <Grid component='span' item xs={12}>
+                    <Button variant='outlined' style={{ color: 'red', borderColor: 'red' }}>
+                        Delete account
+                    </Button>
+                </Grid>
+            </Form>
+        </Grid>
+        
+    );
+}
 
 export const Feedback = () => (
     <span>

--- a/app/client/src/features/accounts/UserSettings/components.tsx
+++ b/app/client/src/features/accounts/UserSettings/components.tsx
@@ -1,0 +1,249 @@
+import * as React from 'react';
+import {
+    List,
+    ListItem,
+    ListItemText,
+    Switch,
+    Collapse,
+    // Typography,
+    Button,
+} from '@material-ui/core';
+import { UserSettings } from '@local/graphql-types';
+
+// import { makeStyles } from '@material-ui/core/styles';
+
+import { ConfirmationDialog } from '@local/components/ConfirmationDialog';
+import SettingsList from '@local/components/SettingsList';
+
+import { TextField } from '@local/components/TextField';
+
+import SettingsItem from '@local/components/SettingsItem';
+import text from './help-text';
+
+/* DEPTH = 3 CURRYING HERE, 
+    top to bottom: 
+        1. Pass in the setState function
+        2. Pass in the key of the checkbox in the state
+        3. handle the change in checkboxes state
+*/
+const buildCheckboxUpdate = <U extends Record<string, boolean | string[]>>(
+    setState: React.Dispatch<React.SetStateAction<U>>
+) => (id: keyof U) => (e: React.ChangeEvent<HTMLInputElement>) => {
+    // e.preventDefault();
+    const { checked } = e.target;
+    setState((prev) => ({ ...prev, [id]: checked }));
+};
+
+// const useStyles = makeStyles((theme) => ({
+//     indent: {
+//         paddingLeft: theme.spacing(4),
+//     },
+//     fullWidth: {
+//         width: '100%',
+//     },
+// }));
+
+// all really small one time user @local/components go here
+interface DisplayItem {
+    title: string;
+    component: JSX.Element;
+}
+
+interface Props {
+    list: DisplayItem[];
+    setContent: (c: JSX.Element) => void;
+}
+
+export function TownhallUserSettings({ settings }: { settings: UserSettings }) {
+    // const [state, setState] = React.useState(user.settings);
+    // const buildHandler = buildCheckboxUpdate<typeof state>(setState);
+    // TODO: API Request
+    return (
+        <SettingsList>
+            <SettingsItem
+                helpText={text.townhall.anonymous}
+                name='Appear Anonymous'
+            >
+                <Switch
+                    checked={settings?.isAnonymous}
+                    // onChange={buildHandler('anonymous')}
+                />
+            </SettingsItem>
+        </SettingsList>
+    );
+}
+
+export function NotificationSettings({ settings }: { settings: UserSettings }) {
+    // const [state, setState] = React.useState(user.settings);
+    // const buildHandler = buildCheckboxUpdate<typeof state>(setState);
+    // TODO: API Request
+    return (
+        <SettingsList>
+            <SettingsItem helpText={text.notifications.enabled} name='Enabled'>
+                <Switch
+                    checked={settings?.isNotificationsEnabled}
+                    // onChange={buildHandler('enabled')}
+                />
+            </SettingsItem>
+            <Collapse>
+                <SettingsItem
+                    helpText={text.notifications.types}
+                    name='Notification Types'
+                >
+                    <div>TODO</div>
+                </SettingsItem>
+            </Collapse>
+        </SettingsList>
+    );
+}
+
+// export function ModifyUserEmail({ user }: { user: User }) {
+//     return (
+//         <Typography>
+//             todo
+//         </Typography>
+//     )
+// }
+
+export const ButtonList = ({ list, setContent }: Props) => (
+    <List>
+        {list.map(({ title, component }) => (
+            <li key={title}>
+                <ListItem
+                    key={title}
+                    button
+                    onClick={() => setContent(component)}
+                >
+                    <ListItemText primary={title} />
+                </ListItem>
+            </li>
+        ))}
+    </List>
+);
+
+export const AppearAnonymous = () => (
+    <span>
+        <h1>
+            {/* TODO: dialog text depends on if they are already anonymous */}
+            You will now appear anonymous.
+        </h1>
+    </span>
+);
+
+export const Notifications = () => (
+    <span>
+        <button type='button' onClick={() => {}}>
+            Notify me about upcoming Townhalls
+        </button>
+    </span>
+);
+
+export const Appearance = () => (
+    <span>
+        <h1>Dark mode</h1>
+        <h1>Color Scheme</h1>
+    </span>
+);
+
+export const Logout = () => (
+    <span>
+        <button
+            type='button'
+            onClick={() => {}} // ROUTING: to /Login or /TownhallList
+        >
+            Click here to return to the home page
+        </button>
+    </span>
+);
+
+export const DisableAccount = () => {
+    const [open, setOpen] = React.useState(false);
+    return (
+        <div>
+            <SettingsItem
+                helpText='You will no longer receive notifications about Town Halls and
+                    you can no longer join live Town Halls. You will still be able
+                    to log into your account.'
+                name='Disable Account'
+            >
+                <Button
+                    variant='outlined'
+                    onClick={() => setOpen(true)}
+                    style={{ color: 'red', borderColor: 'red' }}
+                >
+                    Disable
+                </Button>
+            </SettingsItem>
+            <ConfirmationDialog
+                open={open}
+                onClose={() => setOpen(false)}
+                // FIXME:
+                // eslint-disable-next-line no-console
+                onConfirm={() => console.log('TODO')}
+                title='Disable Account?'
+            >
+                You will no longer receive notifications about Town Halls and
+                you can no longer join live Town Halls. You will still be able
+                to log into your account.
+            </ConfirmationDialog>
+        </div>
+    );
+};
+
+export const DeleteAccount = () => (
+    // ROUTING: to /Login after deleted
+    <span>
+        <h1>
+            Delete Account?
+            <p>
+                All of your account information will be erased from Prytaneum.
+                This action is irreversible. Please enter your password below
+                twice to confirm.
+            </p>
+        </h1>
+        <TextField
+            inputProps={{ 'aria-label': 'Enter your password' }}
+            label='Please enter your password'
+            required
+            variant='outlined'
+            type='password'
+            value=''
+            onChange={() => {}}
+            spellCheck={false}
+        />
+        <TextField
+            inputProps={{ 'aria-label': 'Enter your password again' }}
+            label='Please enter your password again to DELETE your account'
+            required
+            variant='outlined'
+            type='password'
+            value=''
+            onChange={() => {}}
+            spellCheck={false}
+        />
+    </span>
+);
+
+export const Feedback = () => (
+    <span>
+        <h1> hows our driving? </h1>
+    </span>
+);
+
+export const AboutUs = () => (
+    <span>
+        <h1>this was made somehow by some people</h1>
+    </span>
+);
+
+export const PrivacyPolicy = () => (
+    <span>
+        <h1>Information is important.</h1>
+    </span>
+);
+
+export const TermsOfService = () => (
+    <span>
+        <h1>plz no hurt us we no hurt u</h1>
+    </span>
+);

--- a/app/client/src/features/accounts/UserSettings/components.tsx
+++ b/app/client/src/features/accounts/UserSettings/components.tsx
@@ -8,6 +8,7 @@ import {
     Typography,
     Button,
     Grid,
+    Link as MUILink,
 } from '@material-ui/core';
 import { User, UserSettings } from '@local/graphql-types';
 import { Form } from '@local/components/Form';
@@ -18,6 +19,7 @@ import SettingsList from '@local/components/SettingsList';
 import SettingsItem from '@local/components/SettingsItem';
 import { useForm } from '@local/features/core';
 import { makeStyles } from '@material-ui/core/styles';
+import Link from 'next/link';
 import text from './help-text';
 
 const initialModifyUserEmail = {
@@ -57,7 +59,10 @@ const useStyles = makeStyles((theme) => ({
     //     width: '100%',
     // },
     form: {
-        margin: theme.spacing(0, 1, 0, ),
+        margin: theme.spacing(0, 1, 0, 1),
+    },
+    link: {
+        paddingLeft: theme.spacing(1),
     },
 }));
 
@@ -214,9 +219,14 @@ export function ModifyUserPassword() {
                     />
                 </FormContent>
                 <Grid component='span' item xs={12}>
-                    <Button variant='outlined' color='primary'>
+                    <Button type='submit' variant='outlined' color='primary'>
                         Update password
                     </Button>
+                    <Link href='/forgot-password' passHref>
+                        <MUILink className={classes.link} color='primary'>
+                            Forgot Password?
+                        </MUILink>
+                    </Link>
                 </Grid>
             </Form>
         </Grid>
@@ -357,7 +367,7 @@ export function DeleteAccount() {
                     />
                 </FormContent>
                 <Grid component='span' item xs={12}>
-                    <Button variant='outlined' style={{ color: 'red', borderColor: 'red' }}>
+                    <Button type='submit' variant='outlined' style={{ color: 'red', borderColor: 'red' }}>
                         Delete account
                     </Button>
                 </Grid>

--- a/app/client/src/features/accounts/UserSettings/help-text.ts
+++ b/app/client/src/features/accounts/UserSettings/help-text.ts
@@ -1,0 +1,9 @@
+export default {
+    townhall: {
+        anonymous: 'Appear as an anonymous user in townhalls.',
+    },
+    notifications: {
+        enabled: 'Allow notifications to be sent to you',
+        types: 'Which types of notifications are allowed to be sent',
+    },
+};

--- a/app/client/src/features/accounts/UserSettings/index.ts
+++ b/app/client/src/features/accounts/UserSettings/index.ts
@@ -1,0 +1,1 @@
+export { default } from './UserSettings';

--- a/app/client/src/graphql-types.ts
+++ b/app/client/src/graphql-types.ts
@@ -815,3 +815,13 @@ export type UserMutationResponse = MutationResponse & {
   message: Scalars['String'];
   body?: Maybe<User>;
 };
+
+export type UserSettings = {
+  __typename?: 'UserSettings';
+  currentEmail: Scalars['String'];
+  updateEmail?: Maybe<Scalars['String']>;
+  updatePassword?: Maybe<Scalars['String']>;
+  deleteAccount: Scalars['Boolean'];
+  isAnonymous: Scalars['Boolean'];
+  isNotificationsEnabled: Scalars['Boolean'];
+};

--- a/app/client/src/layout/AppBar/Title.tsx
+++ b/app/client/src/layout/AppBar/Title.tsx
@@ -27,7 +27,7 @@ export default function Title() {
     return (
         <div className={classes.titleContainer}>
             <div className={classes.title}>
-                <Typography align='left' variant='h6' noWrap onClick={user ? handleNavigation('/app/home') : handleNavigation('/login')}>
+                <Typography align='left' variant='h6' noWrap onClick={user ? handleNavigation('/app/home') : handleNavigation('/')}>
                     Prytaneum
                 </Typography>
             </div>

--- a/app/client/src/pages/index.tsx
+++ b/app/client/src/pages/index.tsx
@@ -94,7 +94,7 @@ export default function Home() {
             </Grid>
             <Grid item sm={12} md={6}>
                 <Typography variant='h6'>
-                    Where We've Been Used
+                    Where We&apos;ve Been Used
                 </Typography>
                 <Typography variant='body1'>
                     Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do 

--- a/app/client/src/pages/index.tsx
+++ b/app/client/src/pages/index.tsx
@@ -1,1 +1,117 @@
-export { default } from './login';
+import * as React from 'react';
+import { Grid, Typography, Button, Paper, Hidden } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
+import { useRouter } from 'next/router';
+
+import { LoginForm, useUser } from '@local/features/accounts';
+
+const useStyles = makeStyles((theme) => ({
+    root: {
+        width: '100%',
+        height: '100%',
+    },
+    paper: {
+        maxWidth: 425,
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        padding: theme.spacing(3),
+        margin: theme.spacing(1),
+    },
+    avatar: {
+        margin: theme.spacing(1),
+        backgroundColor: theme.palette.secondary.main,
+    },
+    form: {
+        width: '100%', // Fix IE 11 issue.
+        marginTop: theme.spacing(4),
+    },
+    header: {
+        marginBottom: 50,
+    },
+    title: {
+        fontWeight: 400,
+    },
+    subtitle: {
+        textTransform: 'uppercase',
+    },
+}));
+
+export default function Home() {
+    const classes = useStyles();
+    const router = useRouter();
+
+    const [user] = useUser();
+
+    React.useEffect(() => {
+        if (user) router.push('/app/home');
+    }, [user, router]);
+
+    return (
+        <Grid container alignContent='center' className={classes.root} justify='center' spacing={2}>
+            <Grid item xs={12} sm={12} md={6} className={classes.header}>
+                <Typography variant='h1' className={classes.title}>
+                    P
+                </Typography>
+                <Typography variant='h5' className={classes.subtitle}>
+                    A crucial tool<br/>
+                    for a <b>better democracy</b>
+                </Typography>
+            </Grid>
+            <Hidden smDown>    
+                <Grid item xs={6}>
+                    <Paper className={classes.paper}>
+                        <LoginForm
+                            onSuccess={() => router.push('/app/home')}
+                            secondaryActions={
+                                <Button fullWidth variant='outlined' onClick={() => router.push('/register')}>
+                                    Register
+                                </Button>
+                            }
+                        />
+                    </Paper>
+                </Grid>
+            </Hidden>
+            <Grid item sm={12} md={6}>
+                <Typography variant='h6'>
+                    Mission Statement
+                </Typography>
+                <Typography variant='body1'>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do 
+                    eiusmod tempor incididunt ut labore et dolore magna aliqua. 
+                    Scelerisque eu ultrices vitae auctor eu augue ut lectus.
+                </Typography>
+            </Grid>
+            <Grid item sm={12} md={6}>
+                <Typography variant='h6'>
+                    Capabilities
+                </Typography>
+                <Typography variant='body1'>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do 
+                    eiusmod tempor incididunt ut labore et dolore magna aliqua. 
+                    Scelerisque eu ultrices vitae auctor eu augue ut lectus.
+                </Typography>
+            </Grid>
+            <Grid item sm={12} md={6}>
+                <Typography variant='h6'>
+                    Where We've Been Used
+                </Typography>
+                <Typography variant='body1'>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do 
+                    eiusmod tempor incididunt ut labore et dolore magna aliqua. 
+                    Scelerisque eu ultrices vitae auctor eu augue ut lectus.
+                </Typography>
+            </Grid>
+            <Grid item sm={12} md={6}>
+                <Typography variant='h6'>
+                    Features
+                </Typography>
+                <Typography variant='body1'>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do 
+                    eiusmod tempor incididunt ut labore et dolore magna aliqua. 
+                    Scelerisque eu ultrices vitae auctor eu augue ut lectus.
+                </Typography>
+            </Grid>
+        </Grid>
+    );
+}

--- a/app/client/src/pages/settings.tsx
+++ b/app/client/src/pages/settings.tsx
@@ -1,0 +1,1 @@
+export { default } from '../features/accounts/UserSettings'

--- a/app/db/prisma/schema.prisma
+++ b/app/db/prisma/schema.prisma
@@ -20,8 +20,9 @@ model User {
     fullName String? @db.VarChar(200) // computed field, recomputed on name update
     password String?
     preferredLang String @db.VarChar(30)
-    canMakeOrgs Boolean @default(false) 
+    canMakeOrgs Boolean @default(false)
 
+    settings UserSettings[]
     memberOf OrgMember[]
     feedback EventLiveFeedback[]
     questions EventQuestion[]
@@ -29,6 +30,19 @@ model User {
     moderatorOf EventModerator[]
     speakerOf EventSpeaker[]
     registrantOf EventRegistrant[]
+}
+
+model UserSettings {
+    userId String @db.Uuid
+    user User @relation(fields: [userId], references: [id])
+    currentEmail String
+    updateEmail String
+    updatePassword String
+    deleteAccount Boolean @default(false)
+    isAnonymous Boolean @default(false)
+    isNotificationsEnabled Boolean @default(false)
+
+    @@id([userId])
 }
 
 model Organization {

--- a/app/server/src/features/accounts/schema.graphql
+++ b/app/server/src/features/accounts/schema.graphql
@@ -19,6 +19,15 @@ type User implements Node {
     organizations: OrganizationConnection
 }
 
+type UserSettings {
+    currentEmail: String!
+    updateEmail: String
+    updatePassword: String
+    deleteAccount: Boolean!
+    isAnonymous: Boolean!
+    isNotificationsEnabled: Boolean!
+}
+
 type UserEdge {
     node: User!
     cursor: String!

--- a/app/server/src/graphql-types.ts
+++ b/app/server/src/graphql-types.ts
@@ -87,6 +87,16 @@ export type User = Node & {
     organizations?: Maybe<OrganizationConnection>;
 };
 
+export type UserSettings = {
+    __typename?: 'UserSettings';
+    currentEmail: Scalars['String'];
+    updateEmail?: Maybe<Scalars['String']>;
+    updatePassword?: Maybe<Scalars['String']>;
+    deleteAccount: Scalars['Boolean'];
+    isAnonymous: Scalars['Boolean'];
+    isNotificationsEnabled: Scalars['Boolean'];
+};
+
 export type UserEdge = {
     __typename?: 'UserEdge';
     node: User;
@@ -882,6 +892,7 @@ export type ResolversTypes = {
         | ResolversTypes['EventVideoMutationResponse'];
     Operation: Operation;
     User: ResolverTypeWrapper<User>;
+    UserSettings: ResolverTypeWrapper<UserSettings>;
     UserEdge: ResolverTypeWrapper<UserEdge>;
     UserConnection: ResolverTypeWrapper<UserConnection>;
     RegistrationForm: RegistrationForm;
@@ -971,6 +982,7 @@ export type ResolversParentTypes = {
         | ResolversParentTypes['EventSpeakerMutationResponse']
         | ResolversParentTypes['EventVideoMutationResponse'];
     User: User;
+    UserSettings: UserSettings;
     UserEdge: UserEdge;
     UserConnection: UserConnection;
     RegistrationForm: RegistrationForm;
@@ -1116,6 +1128,19 @@ export type UserResolvers<
     isEmailVerified?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
     avatar?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
     organizations?: Resolver<Maybe<ResolversTypes['OrganizationConnection']>, ParentType, ContextType>;
+    __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type UserSettingsResolvers<
+    ContextType = MercuriusContext,
+    ParentType extends ResolversParentTypes['UserSettings'] = ResolversParentTypes['UserSettings']
+> = {
+    currentEmail?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+    updateEmail?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+    updatePassword?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+    deleteAccount?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+    isAnonymous?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+    isNotificationsEnabled?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
     __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -1752,6 +1777,7 @@ export type Resolvers<ContextType = MercuriusContext> = {
     Error?: ErrorResolvers<ContextType>;
     MutationResponse?: MutationResponseResolvers<ContextType>;
     User?: UserResolvers<ContextType>;
+    UserSettings?: UserSettingsResolvers<ContextType>;
     UserEdge?: UserEdgeResolvers<ContextType>;
     UserConnection?: UserConnectionResolvers<ContextType>;
     UserMutationResponse?: UserMutationResponseResolvers<ContextType>;
@@ -1832,6 +1858,15 @@ export interface Loaders<TContext = import('mercurius').MercuriusContext & { rep
         isEmailVerified?: LoaderResolver<Maybe<Scalars['Boolean']>, User, {}, TContext>;
         avatar?: LoaderResolver<Maybe<Scalars['String']>, User, {}, TContext>;
         organizations?: LoaderResolver<Maybe<OrganizationConnection>, User, {}, TContext>;
+    };
+
+    UserSettings?: {
+        currentEmail?: LoaderResolver<Scalars['String'], UserSettings, {}, TContext>;
+        updateEmail?: LoaderResolver<Maybe<Scalars['String']>, UserSettings, {}, TContext>;
+        updatePassword?: LoaderResolver<Maybe<Scalars['String']>, UserSettings, {}, TContext>;
+        deleteAccount?: LoaderResolver<Scalars['Boolean'], UserSettings, {}, TContext>;
+        isAnonymous?: LoaderResolver<Scalars['Boolean'], UserSettings, {}, TContext>;
+        isNotificationsEnabled?: LoaderResolver<Scalars['Boolean'], UserSettings, {}, TContext>;
     };
 
     UserEdge?: {


### PR DESCRIPTION
<!-- Please follow the provided template -->
### 1. Please briefly explain what it is you coded
Made the landing page based on a figma design, and rerouted the app title to the index page instead of the login page if the user isn't logged in.

Re-integrated the user settings page based on the old code from the old domains.

### 2. Please briefly explain your approach (new components added? modified? removed?)
Used a combination of Grid/Hidden/Typography components to build each section. Developed a responsive design for some components to resize/hide depending on the screen size.

Used a combination of MaterialUI components to build each section within the settings. Developed an accordion style present on prytaneum.io.

### 3. Any packages added/updated/removed
N/A
### (Optional) 4. Any feature recommendations/insights/questions/comments/etc.?