### PR TITLE
Event UI: Question List/Queue

### DIFF
--- a/app/client/src/__generated__/EventLiveQuery.graphql.ts
+++ b/app/client/src/__generated__/EventLiveQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<6f8c8ee33b904171011bc022568fd1d5>>
+ * @generated SignedSource<<9854651186b42b384133b8743f4b1903>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -133,8 +133,8 @@ v14 = {
   "name": "createdBy",
   "plural": false,
   "selections": [
-    (v2/*: any*/),
     (v11/*: any*/),
+    (v2/*: any*/),
     (v12/*: any*/),
     (v13/*: any*/)
   ],
@@ -143,11 +143,26 @@ v14 = {
 v15 = {
   "alias": null,
   "args": null,
+  "concreteType": "User",
+  "kind": "LinkedField",
+  "name": "createdBy",
+  "plural": false,
+  "selections": [
+    (v2/*: any*/),
+    (v11/*: any*/),
+    (v12/*: any*/),
+    (v13/*: any*/)
+  ],
+  "storageKey": null
+},
+v16 = {
+  "alias": null,
+  "args": null,
   "kind": "ScalarField",
   "name": "createdAt",
   "storageKey": null
 },
-v16 = {
+v17 = {
   "alias": null,
   "args": null,
   "concreteType": "EventQuestion",
@@ -156,34 +171,34 @@ v16 = {
   "plural": false,
   "selections": [
     (v2/*: any*/),
-    (v14/*: any*/),
     (v15/*: any*/),
+    (v16/*: any*/),
     (v10/*: any*/)
   ],
-  "storageKey": null
-},
-v17 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "isLikedByViewer",
   "storageKey": null
 },
 v18 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "position",
+  "name": "isLikedByViewer",
   "storageKey": null
 },
 v19 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "likedByCount",
+  "name": "position",
   "storageKey": null
 },
 v20 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "likedByCount",
+  "storageKey": null
+},
+v21 = {
   "alias": null,
   "args": null,
   "concreteType": "PageInfo",
@@ -208,7 +223,7 @@ v20 = {
   ],
   "storageKey": null
 },
-v21 = {
+v22 = {
   "kind": "ClientExtension",
   "selections": [
     {
@@ -220,24 +235,24 @@ v21 = {
     }
   ]
 },
-v22 = {
+v23 = {
   "kind": "Literal",
   "name": "after",
   "value": ""
 },
-v23 = [
-  (v22/*: any*/),
+v24 = [
+  (v23/*: any*/),
   (v8/*: any*/)
 ],
-v24 = [
-  (v22/*: any*/),
+v25 = [
+  (v23/*: any*/),
   {
     "kind": "Literal",
     "name": "first",
     "value": 100
   }
 ],
-v25 = {
+v26 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -406,26 +421,12 @@ return {
                         "selections": [
                           (v2/*: any*/),
                           (v10/*: any*/),
-                          {
-                            "alias": null,
-                            "args": null,
-                            "concreteType": "User",
-                            "kind": "LinkedField",
-                            "name": "createdBy",
-                            "plural": false,
-                            "selections": [
-                              (v11/*: any*/),
-                              (v2/*: any*/),
-                              (v12/*: any*/),
-                              (v13/*: any*/)
-                            ],
-                            "storageKey": null
-                          },
-                          (v16/*: any*/),
-                          (v15/*: any*/),
+                          (v14/*: any*/),
                           (v17/*: any*/),
+                          (v16/*: any*/),
                           (v18/*: any*/),
                           (v19/*: any*/),
+                          (v20/*: any*/),
                           (v4/*: any*/)
                         ],
                         "storageKey": null
@@ -433,8 +434,8 @@ return {
                     ],
                     "storageKey": null
                   },
-                  (v20/*: any*/),
-                  (v21/*: any*/)
+                  (v21/*: any*/),
+                  (v22/*: any*/)
                 ],
                 "storageKey": "questions(after:\"1\",first:1000)"
               },
@@ -457,7 +458,7 @@ return {
                 "selections": [
                   {
                     "alias": null,
-                    "args": (v23/*: any*/),
+                    "args": (v24/*: any*/),
                     "concreteType": "EventQuestionConnection",
                     "kind": "LinkedField",
                     "name": "questionRecord",
@@ -481,12 +482,12 @@ return {
                             "plural": false,
                             "selections": [
                               (v2/*: any*/),
-                              (v14/*: any*/),
-                              (v15/*: any*/),
-                              (v19/*: any*/),
                               (v10/*: any*/),
-                              (v18/*: any*/),
+                              (v14/*: any*/),
                               (v16/*: any*/),
+                              (v20/*: any*/),
+                              (v19/*: any*/),
+                              (v17/*: any*/),
                               (v4/*: any*/)
                             ],
                             "storageKey": null
@@ -494,14 +495,14 @@ return {
                         ],
                         "storageKey": null
                       },
-                      (v20/*: any*/),
-                      (v21/*: any*/)
+                      (v21/*: any*/),
+                      (v22/*: any*/)
                     ],
                     "storageKey": "questionRecord(after:\"\",first:1000)"
                   },
                   {
                     "alias": null,
-                    "args": (v23/*: any*/),
+                    "args": (v24/*: any*/),
                     "filters": null,
                     "handle": "connection",
                     "key": "QuestionQueueFragment_questionRecord",
@@ -510,7 +511,7 @@ return {
                   },
                   {
                     "alias": null,
-                    "args": (v23/*: any*/),
+                    "args": (v24/*: any*/),
                     "filters": null,
                     "handle": "connection",
                     "key": "QuestionCarousel_questionRecord",
@@ -519,7 +520,7 @@ return {
                   },
                   {
                     "alias": null,
-                    "args": (v23/*: any*/),
+                    "args": (v24/*: any*/),
                     "concreteType": "EventQuestionConnection",
                     "kind": "LinkedField",
                     "name": "enqueuedQuestions",
@@ -543,13 +544,13 @@ return {
                             "plural": false,
                             "selections": [
                               (v2/*: any*/),
-                              (v14/*: any*/),
-                              (v15/*: any*/),
                               (v10/*: any*/),
-                              (v17/*: any*/),
+                              (v14/*: any*/),
+                              (v16/*: any*/),
                               (v18/*: any*/),
                               (v19/*: any*/),
-                              (v16/*: any*/),
+                              (v20/*: any*/),
+                              (v17/*: any*/),
                               (v4/*: any*/)
                             ],
                             "storageKey": null
@@ -557,14 +558,14 @@ return {
                         ],
                         "storageKey": null
                       },
-                      (v20/*: any*/),
-                      (v21/*: any*/)
+                      (v21/*: any*/),
+                      (v22/*: any*/)
                     ],
                     "storageKey": "enqueuedQuestions(after:\"\",first:1000)"
                   },
                   {
                     "alias": null,
-                    "args": (v23/*: any*/),
+                    "args": (v24/*: any*/),
                     "filters": null,
                     "handle": "connection",
                     "key": "QuestionQueueFragment_enqueuedQuestions",
@@ -576,7 +577,7 @@ return {
               },
               {
                 "alias": null,
-                "args": (v24/*: any*/),
+                "args": (v25/*: any*/),
                 "concreteType": "EventLiveFeedbackConnection",
                 "kind": "LinkedField",
                 "name": "liveFeedback",
@@ -600,8 +601,8 @@ return {
                         "plural": false,
                         "selections": [
                           (v2/*: any*/),
-                          (v25/*: any*/),
-                          (v14/*: any*/),
+                          (v26/*: any*/),
+                          (v15/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -610,14 +611,14 @@ return {
                             "name": "refFeedback",
                             "plural": false,
                             "selections": [
-                              (v14/*: any*/),
+                              (v15/*: any*/),
                               (v2/*: any*/),
-                              (v25/*: any*/),
-                              (v15/*: any*/)
+                              (v26/*: any*/),
+                              (v16/*: any*/)
                             ],
                             "storageKey": null
                           },
-                          (v15/*: any*/),
+                          (v16/*: any*/),
                           (v4/*: any*/)
                         ],
                         "storageKey": null
@@ -625,14 +626,14 @@ return {
                     ],
                     "storageKey": null
                   },
-                  (v20/*: any*/),
-                  (v21/*: any*/)
+                  (v21/*: any*/),
+                  (v22/*: any*/)
                 ],
                 "storageKey": "liveFeedback(after:\"\",first:100)"
               },
               {
                 "alias": null,
-                "args": (v24/*: any*/),
+                "args": (v25/*: any*/),
                 "filters": null,
                 "handle": "connection",
                 "key": "useLiveFeedbackListFragment_liveFeedback",
@@ -698,12 +699,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "db3b58e4f97fee4b12f222a7d2776e80",
+    "cacheID": "0af917ff5d7ba9a3fd97b72f3d461136",
     "id": null,
     "metadata": {},
     "name": "EventLiveQuery",
     "operationKind": "query",
-    "text": "query EventLiveQuery(\n  $eventId: ID!\n) {\n  node(id: $eventId) {\n    __typename\n    id\n    ... on Event {\n      isViewerModerator\n      ...EventSidebarFragment\n      ...EventVideoFragment\n    }\n  }\n}\n\nfragment EventDetailsCardFragment on Event {\n  id\n  title\n  topic\n  description\n}\n\nfragment EventSidebarFragment on Event {\n  id\n  isQuestionFeedVisible\n  isViewerModerator\n  ...EventDetailsCardFragment\n  ...SpeakerListFragment\n  ...useQuestionListFragment\n  ...useQuestionQueueFragment\n  ...QuestionCarouselFragment\n  ...useLiveFeedbackListFragment\n}\n\nfragment EventVideoFragment on Event {\n  videos {\n    edges {\n      cursor\n      node {\n        url\n        lang\n        id\n      }\n    }\n  }\n}\n\nfragment LikeFragment on EventQuestion {\n  id\n  isLikedByViewer\n}\n\nfragment LiveFeedbackAuthorFragment on EventLiveFeedback {\n  createdBy {\n    id\n    firstName\n    lastName\n    avatar\n  }\n  createdAt\n}\n\nfragment LiveFeedbackReplyFragment on EventLiveFeedback {\n  id\n  message\n  ...LiveFeedbackAuthorFragment\n}\n\nfragment QuestionActionsFragment on EventQuestion {\n  id\n  ...QuoteFragment\n  ...LikeFragment\n  ...QueueButtonFragment\n}\n\nfragment QuestionAuthorFragment on EventQuestion {\n  createdBy {\n    id\n    firstName\n    lastName\n    avatar\n  }\n  createdAt\n}\n\nfragment QuestionCarouselFragment on Event {\n  id\n  currentQuestion\n  questionQueue {\n    questionRecord(first: 1000, after: \"\") {\n      edges {\n        cursor\n        node {\n          position\n          ...QuestionAuthorFragment\n          ...QuestionContentFragment\n          refQuestion {\n            ...QuestionQuoteFragment\n            id\n          }\n          id\n          __typename\n        }\n      }\n      pageInfo {\n        endCursor\n        hasNextPage\n      }\n    }\n  }\n}\n\nfragment QuestionContentFragment on EventQuestion {\n  question\n}\n\nfragment QuestionQuoteFragment on EventQuestion {\n  id\n  ...QuestionAuthorFragment\n  ...QuestionContentFragment\n}\n\nfragment QuestionStatsFragment on EventQuestion {\n  id\n  likedByCount\n}\n\nfragment QueueButtonFragment on EventQuestion {\n  id\n  position\n}\n\nfragment QuoteFragment on EventQuestion {\n  id\n  ...QuestionAuthorFragment\n  ...QuestionContentFragment\n}\n\nfragment SpeakerListFragment on Event {\n  speakers {\n    edges {\n      node {\n        id\n        pictureUrl\n        name\n        description\n        title\n      }\n      cursor\n    }\n  }\n}\n\nfragment useLiveFeedbackListFragment on Event {\n  id\n  liveFeedback(first: 100, after: \"\") {\n    edges {\n      cursor\n      node {\n        id\n        message\n        createdBy {\n          id\n          firstName\n        }\n        refFeedback {\n          createdBy {\n            id\n          }\n          ...LiveFeedbackReplyFragment\n          id\n        }\n        ...LiveFeedbackReplyFragment\n        ...LiveFeedbackAuthorFragment\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment useQuestionListFragment on Event {\n  id\n  currentQuestion\n  questions(first: 1000, after: \"1\") {\n    edges {\n      cursor\n      node {\n        id\n        question\n        createdBy {\n          firstName\n          id\n        }\n        refQuestion {\n          ...QuestionQuoteFragment\n          id\n        }\n        ...QuestionActionsFragment\n        ...QuestionAuthorFragment\n        ...QuestionContentFragment\n        ...QuestionStatsFragment\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment useQuestionQueueFragment on Event {\n  id\n  currentQuestion\n  questionQueue {\n    questionRecord(first: 1000, after: \"\") {\n      edges {\n        cursor\n        node {\n          id\n          ...QuestionAuthorFragment\n          ...QuestionStatsFragment\n          ...QuestionContentFragment\n          position\n          refQuestion {\n            ...QuestionQuoteFragment\n            id\n          }\n          __typename\n        }\n      }\n      pageInfo {\n        endCursor\n        hasNextPage\n      }\n    }\n    enqueuedQuestions(first: 1000, after: \"\") {\n      edges {\n        cursor\n        node {\n          id\n          ...QuestionActionsFragment\n          ...QuestionAuthorFragment\n          ...QuestionStatsFragment\n          ...QuestionContentFragment\n          position\n          refQuestion {\n            ...QuestionQuoteFragment\n            id\n          }\n          __typename\n        }\n      }\n      pageInfo {\n        endCursor\n        hasNextPage\n      }\n    }\n  }\n}\n"
+    "text": "query EventLiveQuery(\n  $eventId: ID!\n) {\n  node(id: $eventId) {\n    __typename\n    id\n    ... on Event {\n      isViewerModerator\n      ...EventSidebarFragment\n      ...EventVideoFragment\n    }\n  }\n}\n\nfragment EventDetailsCardFragment on Event {\n  id\n  title\n  topic\n  description\n}\n\nfragment EventSidebarFragment on Event {\n  id\n  isQuestionFeedVisible\n  isViewerModerator\n  ...EventDetailsCardFragment\n  ...SpeakerListFragment\n  ...useQuestionListFragment\n  ...useQuestionQueueFragment\n  ...QuestionCarouselFragment\n  ...useLiveFeedbackListFragment\n}\n\nfragment EventVideoFragment on Event {\n  videos {\n    edges {\n      cursor\n      node {\n        url\n        lang\n        id\n      }\n    }\n  }\n}\n\nfragment LikeFragment on EventQuestion {\n  id\n  isLikedByViewer\n}\n\nfragment LiveFeedbackAuthorFragment on EventLiveFeedback {\n  createdBy {\n    id\n    firstName\n    lastName\n    avatar\n  }\n  createdAt\n}\n\nfragment LiveFeedbackReplyFragment on EventLiveFeedback {\n  id\n  message\n  ...LiveFeedbackAuthorFragment\n}\n\nfragment QuestionActionsFragment on EventQuestion {\n  id\n  ...QuoteFragment\n  ...LikeFragment\n  ...QueueButtonFragment\n}\n\nfragment QuestionAuthorFragment on EventQuestion {\n  createdBy {\n    id\n    firstName\n    lastName\n    avatar\n  }\n  createdAt\n}\n\nfragment QuestionCarouselFragment on Event {\n  id\n  currentQuestion\n  questionQueue {\n    questionRecord(first: 1000, after: \"\") {\n      edges {\n        cursor\n        node {\n          position\n          ...QuestionAuthorFragment\n          ...QuestionContentFragment\n          refQuestion {\n            ...QuestionQuoteFragment\n            id\n          }\n          id\n          __typename\n        }\n      }\n      pageInfo {\n        endCursor\n        hasNextPage\n      }\n    }\n  }\n}\n\nfragment QuestionContentFragment on EventQuestion {\n  question\n}\n\nfragment QuestionQuoteFragment on EventQuestion {\n  id\n  ...QuestionAuthorFragment\n  ...QuestionContentFragment\n}\n\nfragment QuestionStatsFragment on EventQuestion {\n  id\n  likedByCount\n}\n\nfragment QueueButtonFragment on EventQuestion {\n  id\n  position\n}\n\nfragment QuoteFragment on EventQuestion {\n  id\n  ...QuestionAuthorFragment\n  ...QuestionContentFragment\n}\n\nfragment SpeakerListFragment on Event {\n  speakers {\n    edges {\n      node {\n        id\n        pictureUrl\n        name\n        description\n        title\n      }\n      cursor\n    }\n  }\n}\n\nfragment useLiveFeedbackListFragment on Event {\n  id\n  liveFeedback(first: 100, after: \"\") {\n    edges {\n      cursor\n      node {\n        id\n        message\n        createdBy {\n          id\n          firstName\n        }\n        refFeedback {\n          createdBy {\n            id\n          }\n          ...LiveFeedbackReplyFragment\n          id\n        }\n        ...LiveFeedbackReplyFragment\n        ...LiveFeedbackAuthorFragment\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment useQuestionListFragment on Event {\n  id\n  currentQuestion\n  questions(first: 1000, after: \"1\") {\n    edges {\n      cursor\n      node {\n        id\n        question\n        createdBy {\n          firstName\n          id\n        }\n        refQuestion {\n          ...QuestionQuoteFragment\n          id\n        }\n        ...QuestionActionsFragment\n        ...QuestionAuthorFragment\n        ...QuestionContentFragment\n        ...QuestionStatsFragment\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment useQuestionQueueFragment on Event {\n  id\n  currentQuestion\n  questionQueue {\n    questionRecord(first: 1000, after: \"\") {\n      edges {\n        cursor\n        node {\n          id\n          question\n          createdBy {\n            firstName\n            id\n          }\n          ...QuestionAuthorFragment\n          ...QuestionStatsFragment\n          ...QuestionContentFragment\n          position\n          refQuestion {\n            ...QuestionQuoteFragment\n            id\n          }\n          __typename\n        }\n      }\n      pageInfo {\n        endCursor\n        hasNextPage\n      }\n    }\n    enqueuedQuestions(first: 1000, after: \"\") {\n      edges {\n        cursor\n        node {\n          id\n          question\n          createdBy {\n            firstName\n            id\n          }\n          ...QuestionActionsFragment\n          ...QuestionAuthorFragment\n          ...QuestionStatsFragment\n          ...QuestionContentFragment\n          position\n          refQuestion {\n            ...QuestionQuoteFragment\n            id\n          }\n          __typename\n        }\n      }\n      pageInfo {\n        endCursor\n        hasNextPage\n      }\n    }\n  }\n}\n"
   }
 };
 })();

--- a/app/client/src/__generated__/EventLiveQuery.graphql.ts
+++ b/app/client/src/__generated__/EventLiveQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<281c5872e68fd7269c2733638a4043e2>>
+ * @generated SignedSource<<6f8c8ee33b904171011bc022568fd1d5>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -166,17 +166,24 @@ v17 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "position",
+  "name": "isLikedByViewer",
   "storageKey": null
 },
 v18 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "likedByCount",
+  "name": "position",
   "storageKey": null
 },
 v19 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "likedByCount",
+  "storageKey": null
+},
+v20 = {
   "alias": null,
   "args": null,
   "concreteType": "PageInfo",
@@ -201,7 +208,7 @@ v19 = {
   ],
   "storageKey": null
 },
-v20 = {
+v21 = {
   "kind": "ClientExtension",
   "selections": [
     {
@@ -213,52 +220,17 @@ v20 = {
     }
   ]
 },
-v21 = {
+v22 = {
   "kind": "Literal",
   "name": "after",
   "value": ""
 },
-v22 = [
-  (v21/*: any*/),
+v23 = [
+  (v22/*: any*/),
   (v8/*: any*/)
 ],
-v23 = [
-  {
-    "alias": null,
-    "args": null,
-    "concreteType": "EventQuestionEdge",
-    "kind": "LinkedField",
-    "name": "edges",
-    "plural": true,
-    "selections": [
-      (v7/*: any*/),
-      {
-        "alias": null,
-        "args": null,
-        "concreteType": "EventQuestion",
-        "kind": "LinkedField",
-        "name": "node",
-        "plural": false,
-        "selections": [
-          (v2/*: any*/),
-          (v14/*: any*/),
-          (v15/*: any*/),
-          (v18/*: any*/),
-          (v10/*: any*/),
-          (v17/*: any*/),
-          (v16/*: any*/),
-          (v4/*: any*/)
-        ],
-        "storageKey": null
-      }
-    ],
-    "storageKey": null
-  },
-  (v19/*: any*/),
-  (v20/*: any*/)
-],
 v24 = [
-  (v21/*: any*/),
+  (v22/*: any*/),
   {
     "kind": "Literal",
     "name": "first",
@@ -451,15 +423,9 @@ return {
                           },
                           (v16/*: any*/),
                           (v15/*: any*/),
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "isLikedByViewer",
-                            "storageKey": null
-                          },
                           (v17/*: any*/),
                           (v18/*: any*/),
+                          (v19/*: any*/),
                           (v4/*: any*/)
                         ],
                         "storageKey": null
@@ -467,8 +433,8 @@ return {
                     ],
                     "storageKey": null
                   },
-                  (v19/*: any*/),
-                  (v20/*: any*/)
+                  (v20/*: any*/),
+                  (v21/*: any*/)
                 ],
                 "storageKey": "questions(after:\"1\",first:1000)"
               },
@@ -491,17 +457,51 @@ return {
                 "selections": [
                   {
                     "alias": null,
-                    "args": (v22/*: any*/),
+                    "args": (v23/*: any*/),
                     "concreteType": "EventQuestionConnection",
                     "kind": "LinkedField",
                     "name": "questionRecord",
                     "plural": false,
-                    "selections": (v23/*: any*/),
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "EventQuestionEdge",
+                        "kind": "LinkedField",
+                        "name": "edges",
+                        "plural": true,
+                        "selections": [
+                          (v7/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "EventQuestion",
+                            "kind": "LinkedField",
+                            "name": "node",
+                            "plural": false,
+                            "selections": [
+                              (v2/*: any*/),
+                              (v14/*: any*/),
+                              (v15/*: any*/),
+                              (v19/*: any*/),
+                              (v10/*: any*/),
+                              (v18/*: any*/),
+                              (v16/*: any*/),
+                              (v4/*: any*/)
+                            ],
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      (v20/*: any*/),
+                      (v21/*: any*/)
+                    ],
                     "storageKey": "questionRecord(after:\"\",first:1000)"
                   },
                   {
                     "alias": null,
-                    "args": (v22/*: any*/),
+                    "args": (v23/*: any*/),
                     "filters": null,
                     "handle": "connection",
                     "key": "QuestionQueueFragment_questionRecord",
@@ -510,7 +510,7 @@ return {
                   },
                   {
                     "alias": null,
-                    "args": (v22/*: any*/),
+                    "args": (v23/*: any*/),
                     "filters": null,
                     "handle": "connection",
                     "key": "QuestionCarousel_questionRecord",
@@ -519,17 +519,52 @@ return {
                   },
                   {
                     "alias": null,
-                    "args": (v22/*: any*/),
+                    "args": (v23/*: any*/),
                     "concreteType": "EventQuestionConnection",
                     "kind": "LinkedField",
                     "name": "enqueuedQuestions",
                     "plural": false,
-                    "selections": (v23/*: any*/),
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "EventQuestionEdge",
+                        "kind": "LinkedField",
+                        "name": "edges",
+                        "plural": true,
+                        "selections": [
+                          (v7/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "EventQuestion",
+                            "kind": "LinkedField",
+                            "name": "node",
+                            "plural": false,
+                            "selections": [
+                              (v2/*: any*/),
+                              (v14/*: any*/),
+                              (v15/*: any*/),
+                              (v10/*: any*/),
+                              (v17/*: any*/),
+                              (v18/*: any*/),
+                              (v19/*: any*/),
+                              (v16/*: any*/),
+                              (v4/*: any*/)
+                            ],
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      (v20/*: any*/),
+                      (v21/*: any*/)
+                    ],
                     "storageKey": "enqueuedQuestions(after:\"\",first:1000)"
                   },
                   {
                     "alias": null,
-                    "args": (v22/*: any*/),
+                    "args": (v23/*: any*/),
                     "filters": null,
                     "handle": "connection",
                     "key": "QuestionQueueFragment_enqueuedQuestions",
@@ -590,8 +625,8 @@ return {
                     ],
                     "storageKey": null
                   },
-                  (v19/*: any*/),
-                  (v20/*: any*/)
+                  (v20/*: any*/),
+                  (v21/*: any*/)
                 ],
                 "storageKey": "liveFeedback(after:\"\",first:100)"
               },
@@ -663,12 +698,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "6912745906cf981a50641716a86118c7",
+    "cacheID": "db3b58e4f97fee4b12f222a7d2776e80",
     "id": null,
     "metadata": {},
     "name": "EventLiveQuery",
     "operationKind": "query",
-    "text": "query EventLiveQuery(\n  $eventId: ID!\n) {\n  node(id: $eventId) {\n    __typename\n    id\n    ... on Event {\n      isViewerModerator\n      ...EventSidebarFragment\n      ...EventVideoFragment\n    }\n  }\n}\n\nfragment EventDetailsCardFragment on Event {\n  id\n  title\n  topic\n  description\n}\n\nfragment EventSidebarFragment on Event {\n  id\n  isQuestionFeedVisible\n  isViewerModerator\n  ...EventDetailsCardFragment\n  ...SpeakerListFragment\n  ...useQuestionListFragment\n  ...useQuestionQueueFragment\n  ...QuestionCarouselFragment\n  ...useLiveFeedbackListFragment\n}\n\nfragment EventVideoFragment on Event {\n  videos {\n    edges {\n      cursor\n      node {\n        url\n        lang\n        id\n      }\n    }\n  }\n}\n\nfragment LikeFragment on EventQuestion {\n  id\n  isLikedByViewer\n}\n\nfragment LiveFeedbackAuthorFragment on EventLiveFeedback {\n  createdBy {\n    id\n    firstName\n    lastName\n    avatar\n  }\n  createdAt\n}\n\nfragment LiveFeedbackReplyFragment on EventLiveFeedback {\n  id\n  message\n  ...LiveFeedbackAuthorFragment\n}\n\nfragment QuestionActionsFragment on EventQuestion {\n  id\n  ...QuoteFragment\n  ...LikeFragment\n  ...QueueButtonFragment\n}\n\nfragment QuestionAuthorFragment on EventQuestion {\n  createdBy {\n    id\n    firstName\n    lastName\n    avatar\n  }\n  createdAt\n}\n\nfragment QuestionCarouselFragment on Event {\n  id\n  currentQuestion\n  questionQueue {\n    questionRecord(first: 1000, after: \"\") {\n      edges {\n        cursor\n        node {\n          position\n          ...QuestionAuthorFragment\n          ...QuestionContentFragment\n          refQuestion {\n            ...QuestionQuoteFragment\n            id\n          }\n          id\n          __typename\n        }\n      }\n      pageInfo {\n        endCursor\n        hasNextPage\n      }\n    }\n  }\n}\n\nfragment QuestionContentFragment on EventQuestion {\n  question\n}\n\nfragment QuestionQuoteFragment on EventQuestion {\n  id\n  ...QuestionAuthorFragment\n  ...QuestionContentFragment\n}\n\nfragment QuestionStatsFragment on EventQuestion {\n  id\n  likedByCount\n}\n\nfragment QueueButtonFragment on EventQuestion {\n  id\n  position\n}\n\nfragment QuoteFragment on EventQuestion {\n  id\n  ...QuestionAuthorFragment\n  ...QuestionContentFragment\n}\n\nfragment SpeakerListFragment on Event {\n  speakers {\n    edges {\n      node {\n        id\n        pictureUrl\n        name\n        description\n        title\n      }\n      cursor\n    }\n  }\n}\n\nfragment useLiveFeedbackListFragment on Event {\n  id\n  liveFeedback(first: 100, after: \"\") {\n    edges {\n      cursor\n      node {\n        id\n        message\n        createdBy {\n          id\n          firstName\n        }\n        refFeedback {\n          createdBy {\n            id\n          }\n          ...LiveFeedbackReplyFragment\n          id\n        }\n        ...LiveFeedbackReplyFragment\n        ...LiveFeedbackAuthorFragment\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment useQuestionListFragment on Event {\n  id\n  currentQuestion\n  questions(first: 1000, after: \"1\") {\n    edges {\n      cursor\n      node {\n        id\n        question\n        createdBy {\n          firstName\n          id\n        }\n        refQuestion {\n          ...QuestionQuoteFragment\n          id\n        }\n        ...QuestionActionsFragment\n        ...QuestionAuthorFragment\n        ...QuestionContentFragment\n        ...QuestionStatsFragment\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment useQuestionQueueFragment on Event {\n  id\n  currentQuestion\n  questionQueue {\n    questionRecord(first: 1000, after: \"\") {\n      edges {\n        cursor\n        node {\n          id\n          ...QuestionAuthorFragment\n          ...QuestionStatsFragment\n          ...QuestionContentFragment\n          position\n          refQuestion {\n            ...QuestionQuoteFragment\n            id\n          }\n          __typename\n        }\n      }\n      pageInfo {\n        endCursor\n        hasNextPage\n      }\n    }\n    enqueuedQuestions(first: 1000, after: \"\") {\n      edges {\n        cursor\n        node {\n          id\n          ...QuestionAuthorFragment\n          ...QuestionStatsFragment\n          ...QuestionContentFragment\n          position\n          refQuestion {\n            ...QuestionQuoteFragment\n            id\n          }\n          __typename\n        }\n      }\n      pageInfo {\n        endCursor\n        hasNextPage\n      }\n    }\n  }\n}\n"
+    "text": "query EventLiveQuery(\n  $eventId: ID!\n) {\n  node(id: $eventId) {\n    __typename\n    id\n    ... on Event {\n      isViewerModerator\n      ...EventSidebarFragment\n      ...EventVideoFragment\n    }\n  }\n}\n\nfragment EventDetailsCardFragment on Event {\n  id\n  title\n  topic\n  description\n}\n\nfragment EventSidebarFragment on Event {\n  id\n  isQuestionFeedVisible\n  isViewerModerator\n  ...EventDetailsCardFragment\n  ...SpeakerListFragment\n  ...useQuestionListFragment\n  ...useQuestionQueueFragment\n  ...QuestionCarouselFragment\n  ...useLiveFeedbackListFragment\n}\n\nfragment EventVideoFragment on Event {\n  videos {\n    edges {\n      cursor\n      node {\n        url\n        lang\n        id\n      }\n    }\n  }\n}\n\nfragment LikeFragment on EventQuestion {\n  id\n  isLikedByViewer\n}\n\nfragment LiveFeedbackAuthorFragment on EventLiveFeedback {\n  createdBy {\n    id\n    firstName\n    lastName\n    avatar\n  }\n  createdAt\n}\n\nfragment LiveFeedbackReplyFragment on EventLiveFeedback {\n  id\n  message\n  ...LiveFeedbackAuthorFragment\n}\n\nfragment QuestionActionsFragment on EventQuestion {\n  id\n  ...QuoteFragment\n  ...LikeFragment\n  ...QueueButtonFragment\n}\n\nfragment QuestionAuthorFragment on EventQuestion {\n  createdBy {\n    id\n    firstName\n    lastName\n    avatar\n  }\n  createdAt\n}\n\nfragment QuestionCarouselFragment on Event {\n  id\n  currentQuestion\n  questionQueue {\n    questionRecord(first: 1000, after: \"\") {\n      edges {\n        cursor\n        node {\n          position\n          ...QuestionAuthorFragment\n          ...QuestionContentFragment\n          refQuestion {\n            ...QuestionQuoteFragment\n            id\n          }\n          id\n          __typename\n        }\n      }\n      pageInfo {\n        endCursor\n        hasNextPage\n      }\n    }\n  }\n}\n\nfragment QuestionContentFragment on EventQuestion {\n  question\n}\n\nfragment QuestionQuoteFragment on EventQuestion {\n  id\n  ...QuestionAuthorFragment\n  ...QuestionContentFragment\n}\n\nfragment QuestionStatsFragment on EventQuestion {\n  id\n  likedByCount\n}\n\nfragment QueueButtonFragment on EventQuestion {\n  id\n  position\n}\n\nfragment QuoteFragment on EventQuestion {\n  id\n  ...QuestionAuthorFragment\n  ...QuestionContentFragment\n}\n\nfragment SpeakerListFragment on Event {\n  speakers {\n    edges {\n      node {\n        id\n        pictureUrl\n        name\n        description\n        title\n      }\n      cursor\n    }\n  }\n}\n\nfragment useLiveFeedbackListFragment on Event {\n  id\n  liveFeedback(first: 100, after: \"\") {\n    edges {\n      cursor\n      node {\n        id\n        message\n        createdBy {\n          id\n          firstName\n        }\n        refFeedback {\n          createdBy {\n            id\n          }\n          ...LiveFeedbackReplyFragment\n          id\n        }\n        ...LiveFeedbackReplyFragment\n        ...LiveFeedbackAuthorFragment\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment useQuestionListFragment on Event {\n  id\n  currentQuestion\n  questions(first: 1000, after: \"1\") {\n    edges {\n      cursor\n      node {\n        id\n        question\n        createdBy {\n          firstName\n          id\n        }\n        refQuestion {\n          ...QuestionQuoteFragment\n          id\n        }\n        ...QuestionActionsFragment\n        ...QuestionAuthorFragment\n        ...QuestionContentFragment\n        ...QuestionStatsFragment\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment useQuestionQueueFragment on Event {\n  id\n  currentQuestion\n  questionQueue {\n    questionRecord(first: 1000, after: \"\") {\n      edges {\n        cursor\n        node {\n          id\n          ...QuestionAuthorFragment\n          ...QuestionStatsFragment\n          ...QuestionContentFragment\n          position\n          refQuestion {\n            ...QuestionQuoteFragment\n            id\n          }\n          __typename\n        }\n      }\n      pageInfo {\n        endCursor\n        hasNextPage\n      }\n    }\n    enqueuedQuestions(first: 1000, after: \"\") {\n      edges {\n        cursor\n        node {\n          id\n          ...QuestionActionsFragment\n          ...QuestionAuthorFragment\n          ...QuestionStatsFragment\n          ...QuestionContentFragment\n          position\n          refQuestion {\n            ...QuestionQuoteFragment\n            id\n          }\n          __typename\n        }\n      }\n      pageInfo {\n        endCursor\n        hasNextPage\n      }\n    }\n  }\n}\n"
   }
 };
 })();

--- a/app/client/src/__generated__/EventLiveQuery.graphql.ts
+++ b/app/client/src/__generated__/EventLiveQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<d7078b5fd2f465e551b35f4e6b8f4524>>
+ * @generated SignedSource<<281c5872e68fd7269c2733638a4043e2>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -115,10 +115,17 @@ v12 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "avatar",
+  "name": "lastName",
   "storageKey": null
 },
 v13 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "avatar",
+  "storageKey": null
+},
+v14 = {
   "alias": null,
   "args": null,
   "concreteType": "User",
@@ -128,18 +135,19 @@ v13 = {
   "selections": [
     (v2/*: any*/),
     (v11/*: any*/),
-    (v12/*: any*/)
+    (v12/*: any*/),
+    (v13/*: any*/)
   ],
   "storageKey": null
 },
-v14 = {
+v15 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "createdAt",
   "storageKey": null
 },
-v15 = {
+v16 = {
   "alias": null,
   "args": null,
   "concreteType": "EventQuestion",
@@ -148,27 +156,27 @@ v15 = {
   "plural": false,
   "selections": [
     (v2/*: any*/),
-    (v13/*: any*/),
     (v14/*: any*/),
+    (v15/*: any*/),
     (v10/*: any*/)
   ],
-  "storageKey": null
-},
-v16 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "position",
   "storageKey": null
 },
 v17 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "likedByCount",
+  "name": "position",
   "storageKey": null
 },
 v18 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "likedByCount",
+  "storageKey": null
+},
+v19 = {
   "alias": null,
   "args": null,
   "concreteType": "PageInfo",
@@ -193,7 +201,7 @@ v18 = {
   ],
   "storageKey": null
 },
-v19 = {
+v20 = {
   "kind": "ClientExtension",
   "selections": [
     {
@@ -205,16 +213,16 @@ v19 = {
     }
   ]
 },
-v20 = {
+v21 = {
   "kind": "Literal",
   "name": "after",
   "value": ""
 },
-v21 = [
-  (v20/*: any*/),
+v22 = [
+  (v21/*: any*/),
   (v8/*: any*/)
 ],
-v22 = [
+v23 = [
   {
     "alias": null,
     "args": null,
@@ -233,12 +241,12 @@ v22 = [
         "plural": false,
         "selections": [
           (v2/*: any*/),
-          (v13/*: any*/),
           (v14/*: any*/),
-          (v17/*: any*/),
-          (v10/*: any*/),
-          (v16/*: any*/),
           (v15/*: any*/),
+          (v18/*: any*/),
+          (v10/*: any*/),
+          (v17/*: any*/),
+          (v16/*: any*/),
           (v4/*: any*/)
         ],
         "storageKey": null
@@ -246,43 +254,22 @@ v22 = [
     ],
     "storageKey": null
   },
-  (v18/*: any*/),
-  (v19/*: any*/)
+  (v19/*: any*/),
+  (v20/*: any*/)
 ],
-v23 = [
-  (v20/*: any*/),
+v24 = [
+  (v21/*: any*/),
   {
     "kind": "Literal",
     "name": "first",
     "value": 100
   }
 ],
-v24 = {
+v25 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "message",
-  "storageKey": null
-},
-v25 = {
-  "alias": null,
-  "args": null,
-  "concreteType": "User",
-  "kind": "LinkedField",
-  "name": "createdBy",
-  "plural": false,
-  "selections": [
-    (v2/*: any*/),
-    (v11/*: any*/),
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "lastName",
-      "storageKey": null
-    },
-    (v12/*: any*/)
-  ],
   "storageKey": null
 };
 return {
@@ -457,12 +444,13 @@ return {
                             "selections": [
                               (v11/*: any*/),
                               (v2/*: any*/),
-                              (v12/*: any*/)
+                              (v12/*: any*/),
+                              (v13/*: any*/)
                             ],
                             "storageKey": null
                           },
+                          (v16/*: any*/),
                           (v15/*: any*/),
-                          (v14/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -470,8 +458,8 @@ return {
                             "name": "isLikedByViewer",
                             "storageKey": null
                           },
-                          (v16/*: any*/),
                           (v17/*: any*/),
+                          (v18/*: any*/),
                           (v4/*: any*/)
                         ],
                         "storageKey": null
@@ -479,8 +467,8 @@ return {
                     ],
                     "storageKey": null
                   },
-                  (v18/*: any*/),
-                  (v19/*: any*/)
+                  (v19/*: any*/),
+                  (v20/*: any*/)
                 ],
                 "storageKey": "questions(after:\"1\",first:1000)"
               },
@@ -503,17 +491,17 @@ return {
                 "selections": [
                   {
                     "alias": null,
-                    "args": (v21/*: any*/),
+                    "args": (v22/*: any*/),
                     "concreteType": "EventQuestionConnection",
                     "kind": "LinkedField",
                     "name": "questionRecord",
                     "plural": false,
-                    "selections": (v22/*: any*/),
+                    "selections": (v23/*: any*/),
                     "storageKey": "questionRecord(after:\"\",first:1000)"
                   },
                   {
                     "alias": null,
-                    "args": (v21/*: any*/),
+                    "args": (v22/*: any*/),
                     "filters": null,
                     "handle": "connection",
                     "key": "QuestionQueueFragment_questionRecord",
@@ -522,7 +510,7 @@ return {
                   },
                   {
                     "alias": null,
-                    "args": (v21/*: any*/),
+                    "args": (v22/*: any*/),
                     "filters": null,
                     "handle": "connection",
                     "key": "QuestionCarousel_questionRecord",
@@ -531,17 +519,17 @@ return {
                   },
                   {
                     "alias": null,
-                    "args": (v21/*: any*/),
+                    "args": (v22/*: any*/),
                     "concreteType": "EventQuestionConnection",
                     "kind": "LinkedField",
                     "name": "enqueuedQuestions",
                     "plural": false,
-                    "selections": (v22/*: any*/),
+                    "selections": (v23/*: any*/),
                     "storageKey": "enqueuedQuestions(after:\"\",first:1000)"
                   },
                   {
                     "alias": null,
-                    "args": (v21/*: any*/),
+                    "args": (v22/*: any*/),
                     "filters": null,
                     "handle": "connection",
                     "key": "QuestionQueueFragment_enqueuedQuestions",
@@ -553,7 +541,7 @@ return {
               },
               {
                 "alias": null,
-                "args": (v23/*: any*/),
+                "args": (v24/*: any*/),
                 "concreteType": "EventLiveFeedbackConnection",
                 "kind": "LinkedField",
                 "name": "liveFeedback",
@@ -577,8 +565,8 @@ return {
                         "plural": false,
                         "selections": [
                           (v2/*: any*/),
-                          (v24/*: any*/),
                           (v25/*: any*/),
+                          (v14/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -587,14 +575,14 @@ return {
                             "name": "refFeedback",
                             "plural": false,
                             "selections": [
-                              (v25/*: any*/),
+                              (v14/*: any*/),
                               (v2/*: any*/),
-                              (v24/*: any*/),
-                              (v14/*: any*/)
+                              (v25/*: any*/),
+                              (v15/*: any*/)
                             ],
                             "storageKey": null
                           },
-                          (v14/*: any*/),
+                          (v15/*: any*/),
                           (v4/*: any*/)
                         ],
                         "storageKey": null
@@ -602,14 +590,14 @@ return {
                     ],
                     "storageKey": null
                   },
-                  (v18/*: any*/),
-                  (v19/*: any*/)
+                  (v19/*: any*/),
+                  (v20/*: any*/)
                 ],
                 "storageKey": "liveFeedback(after:\"\",first:100)"
               },
               {
                 "alias": null,
-                "args": (v23/*: any*/),
+                "args": (v24/*: any*/),
                 "filters": null,
                 "handle": "connection",
                 "key": "useLiveFeedbackListFragment_liveFeedback",
@@ -675,12 +663,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "7ce9763d5566f25f3b745d8365933a16",
+    "cacheID": "6912745906cf981a50641716a86118c7",
     "id": null,
     "metadata": {},
     "name": "EventLiveQuery",
     "operationKind": "query",
-    "text": "query EventLiveQuery(\n  $eventId: ID!\n) {\n  node(id: $eventId) {\n    __typename\n    id\n    ... on Event {\n      isViewerModerator\n      ...EventSidebarFragment\n      ...EventVideoFragment\n    }\n  }\n}\n\nfragment EventDetailsCardFragment on Event {\n  id\n  title\n  topic\n  description\n}\n\nfragment EventSidebarFragment on Event {\n  id\n  isQuestionFeedVisible\n  isViewerModerator\n  ...EventDetailsCardFragment\n  ...SpeakerListFragment\n  ...useQuestionListFragment\n  ...useQuestionQueueFragment\n  ...QuestionCarouselFragment\n  ...useLiveFeedbackListFragment\n}\n\nfragment EventVideoFragment on Event {\n  videos {\n    edges {\n      cursor\n      node {\n        url\n        lang\n        id\n      }\n    }\n  }\n}\n\nfragment LikeFragment on EventQuestion {\n  id\n  isLikedByViewer\n}\n\nfragment LiveFeedbackAuthorFragment on EventLiveFeedback {\n  createdBy {\n    id\n    firstName\n    lastName\n    avatar\n  }\n  createdAt\n}\n\nfragment LiveFeedbackReplyFragment on EventLiveFeedback {\n  id\n  message\n  ...LiveFeedbackAuthorFragment\n}\n\nfragment QuestionActionsFragment on EventQuestion {\n  id\n  ...QuoteFragment\n  ...LikeFragment\n  ...QueueButtonFragment\n}\n\nfragment QuestionAuthorFragment on EventQuestion {\n  createdBy {\n    id\n    firstName\n    avatar\n  }\n  createdAt\n}\n\nfragment QuestionCarouselFragment on Event {\n  id\n  currentQuestion\n  questionQueue {\n    questionRecord(first: 1000, after: \"\") {\n      edges {\n        cursor\n        node {\n          position\n          ...QuestionAuthorFragment\n          ...QuestionContentFragment\n          refQuestion {\n            ...QuestionQuoteFragment\n            id\n          }\n          id\n          __typename\n        }\n      }\n      pageInfo {\n        endCursor\n        hasNextPage\n      }\n    }\n  }\n}\n\nfragment QuestionContentFragment on EventQuestion {\n  question\n}\n\nfragment QuestionQuoteFragment on EventQuestion {\n  id\n  ...QuestionAuthorFragment\n  ...QuestionContentFragment\n}\n\nfragment QuestionStatsFragment on EventQuestion {\n  id\n  likedByCount\n}\n\nfragment QueueButtonFragment on EventQuestion {\n  id\n  position\n}\n\nfragment QuoteFragment on EventQuestion {\n  id\n  ...QuestionAuthorFragment\n  ...QuestionContentFragment\n}\n\nfragment SpeakerListFragment on Event {\n  speakers {\n    edges {\n      node {\n        id\n        pictureUrl\n        name\n        description\n        title\n      }\n      cursor\n    }\n  }\n}\n\nfragment useLiveFeedbackListFragment on Event {\n  id\n  liveFeedback(first: 100, after: \"\") {\n    edges {\n      cursor\n      node {\n        id\n        message\n        createdBy {\n          id\n          firstName\n        }\n        refFeedback {\n          createdBy {\n            id\n          }\n          ...LiveFeedbackReplyFragment\n          id\n        }\n        ...LiveFeedbackReplyFragment\n        ...LiveFeedbackAuthorFragment\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment useQuestionListFragment on Event {\n  id\n  currentQuestion\n  questions(first: 1000, after: \"1\") {\n    edges {\n      cursor\n      node {\n        id\n        question\n        createdBy {\n          firstName\n          id\n        }\n        refQuestion {\n          ...QuestionQuoteFragment\n          id\n        }\n        ...QuestionActionsFragment\n        ...QuestionAuthorFragment\n        ...QuestionContentFragment\n        ...QuestionStatsFragment\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment useQuestionQueueFragment on Event {\n  id\n  currentQuestion\n  questionQueue {\n    questionRecord(first: 1000, after: \"\") {\n      edges {\n        cursor\n        node {\n          id\n          ...QuestionAuthorFragment\n          ...QuestionStatsFragment\n          ...QuestionContentFragment\n          position\n          refQuestion {\n            ...QuestionQuoteFragment\n            id\n          }\n          __typename\n        }\n      }\n      pageInfo {\n        endCursor\n        hasNextPage\n      }\n    }\n    enqueuedQuestions(first: 1000, after: \"\") {\n      edges {\n        cursor\n        node {\n          id\n          ...QuestionAuthorFragment\n          ...QuestionStatsFragment\n          ...QuestionContentFragment\n          position\n          refQuestion {\n            ...QuestionQuoteFragment\n            id\n          }\n          __typename\n        }\n      }\n      pageInfo {\n        endCursor\n        hasNextPage\n      }\n    }\n  }\n}\n"
+    "text": "query EventLiveQuery(\n  $eventId: ID!\n) {\n  node(id: $eventId) {\n    __typename\n    id\n    ... on Event {\n      isViewerModerator\n      ...EventSidebarFragment\n      ...EventVideoFragment\n    }\n  }\n}\n\nfragment EventDetailsCardFragment on Event {\n  id\n  title\n  topic\n  description\n}\n\nfragment EventSidebarFragment on Event {\n  id\n  isQuestionFeedVisible\n  isViewerModerator\n  ...EventDetailsCardFragment\n  ...SpeakerListFragment\n  ...useQuestionListFragment\n  ...useQuestionQueueFragment\n  ...QuestionCarouselFragment\n  ...useLiveFeedbackListFragment\n}\n\nfragment EventVideoFragment on Event {\n  videos {\n    edges {\n      cursor\n      node {\n        url\n        lang\n        id\n      }\n    }\n  }\n}\n\nfragment LikeFragment on EventQuestion {\n  id\n  isLikedByViewer\n}\n\nfragment LiveFeedbackAuthorFragment on EventLiveFeedback {\n  createdBy {\n    id\n    firstName\n    lastName\n    avatar\n  }\n  createdAt\n}\n\nfragment LiveFeedbackReplyFragment on EventLiveFeedback {\n  id\n  message\n  ...LiveFeedbackAuthorFragment\n}\n\nfragment QuestionActionsFragment on EventQuestion {\n  id\n  ...QuoteFragment\n  ...LikeFragment\n  ...QueueButtonFragment\n}\n\nfragment QuestionAuthorFragment on EventQuestion {\n  createdBy {\n    id\n    firstName\n    lastName\n    avatar\n  }\n  createdAt\n}\n\nfragment QuestionCarouselFragment on Event {\n  id\n  currentQuestion\n  questionQueue {\n    questionRecord(first: 1000, after: \"\") {\n      edges {\n        cursor\n        node {\n          position\n          ...QuestionAuthorFragment\n          ...QuestionContentFragment\n          refQuestion {\n            ...QuestionQuoteFragment\n            id\n          }\n          id\n          __typename\n        }\n      }\n      pageInfo {\n        endCursor\n        hasNextPage\n      }\n    }\n  }\n}\n\nfragment QuestionContentFragment on EventQuestion {\n  question\n}\n\nfragment QuestionQuoteFragment on EventQuestion {\n  id\n  ...QuestionAuthorFragment\n  ...QuestionContentFragment\n}\n\nfragment QuestionStatsFragment on EventQuestion {\n  id\n  likedByCount\n}\n\nfragment QueueButtonFragment on EventQuestion {\n  id\n  position\n}\n\nfragment QuoteFragment on EventQuestion {\n  id\n  ...QuestionAuthorFragment\n  ...QuestionContentFragment\n}\n\nfragment SpeakerListFragment on Event {\n  speakers {\n    edges {\n      node {\n        id\n        pictureUrl\n        name\n        description\n        title\n      }\n      cursor\n    }\n  }\n}\n\nfragment useLiveFeedbackListFragment on Event {\n  id\n  liveFeedback(first: 100, after: \"\") {\n    edges {\n      cursor\n      node {\n        id\n        message\n        createdBy {\n          id\n          firstName\n        }\n        refFeedback {\n          createdBy {\n            id\n          }\n          ...LiveFeedbackReplyFragment\n          id\n        }\n        ...LiveFeedbackReplyFragment\n        ...LiveFeedbackAuthorFragment\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment useQuestionListFragment on Event {\n  id\n  currentQuestion\n  questions(first: 1000, after: \"1\") {\n    edges {\n      cursor\n      node {\n        id\n        question\n        createdBy {\n          firstName\n          id\n        }\n        refQuestion {\n          ...QuestionQuoteFragment\n          id\n        }\n        ...QuestionActionsFragment\n        ...QuestionAuthorFragment\n        ...QuestionContentFragment\n        ...QuestionStatsFragment\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment useQuestionQueueFragment on Event {\n  id\n  currentQuestion\n  questionQueue {\n    questionRecord(first: 1000, after: \"\") {\n      edges {\n        cursor\n        node {\n          id\n          ...QuestionAuthorFragment\n          ...QuestionStatsFragment\n          ...QuestionContentFragment\n          position\n          refQuestion {\n            ...QuestionQuoteFragment\n            id\n          }\n          __typename\n        }\n      }\n      pageInfo {\n        endCursor\n        hasNextPage\n      }\n    }\n    enqueuedQuestions(first: 1000, after: \"\") {\n      edges {\n        cursor\n        node {\n          id\n          ...QuestionAuthorFragment\n          ...QuestionStatsFragment\n          ...QuestionContentFragment\n          position\n          refQuestion {\n            ...QuestionQuoteFragment\n            id\n          }\n          __typename\n        }\n      }\n      pageInfo {\n        endCursor\n        hasNextPage\n      }\n    }\n  }\n}\n"
   }
 };
 })();

--- a/app/client/src/__generated__/QuestionAuthorFragment.graphql.ts
+++ b/app/client/src/__generated__/QuestionAuthorFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<49431ebd934f1f1f081bb6f0be683222>>
+ * @generated SignedSource<<cf3e6420c69d3b2cb5cd4d62d4e56d9d>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -14,6 +14,7 @@ export type QuestionAuthorFragment$data = {
   readonly createdBy: {
     readonly id: string;
     readonly firstName: string | null;
+    readonly lastName: string | null;
     readonly avatar: string | null;
   } | null;
   readonly createdAt: Date | null;
@@ -57,6 +58,13 @@ const node: ReaderFragment = {
           "alias": null,
           "args": null,
           "kind": "ScalarField",
+          "name": "lastName",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
           "name": "avatar",
           "storageKey": null
         }
@@ -75,6 +83,6 @@ const node: ReaderFragment = {
   "abstractKey": null
 };
 
-(node as any).hash = "ceb68b6d1dc8416b91ca7a6ad567cfd7";
+(node as any).hash = "07cc8aa9d42b1b0fe1513e088f57ce1b";
 
 export default node;

--- a/app/client/src/__generated__/QuestionQueueMutation.graphql.ts
+++ b/app/client/src/__generated__/QuestionQueueMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<eebf4986f6f16eb65ec7e5722e89fcee>>
+ * @generated SignedSource<<c26191486286d7ae8a784e92d8db435e>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -26,6 +26,10 @@ export type QuestionQueueMutation$data = {
       readonly cursor: string;
       readonly node: {
         readonly id: string;
+        readonly question: string | null;
+        readonly createdBy: {
+          readonly firstName: string | null;
+        } | null;
         readonly position: number | null;
       };
     } | null;
@@ -40,6 +44,11 @@ export type QuestionQueueMutation$rawResponse = {
       readonly cursor: string;
       readonly node: {
         readonly id: string;
+        readonly question: string | null;
+        readonly createdBy: {
+          readonly firstName: string | null;
+          readonly id: string;
+        } | null;
         readonly position: number | null;
       };
     } | null;
@@ -62,68 +71,110 @@ var v0 = [
 ],
 v1 = [
   {
-    "alias": null,
-    "args": [
-      {
-        "kind": "Variable",
-        "name": "input",
-        "variableName": "input"
-      }
-    ],
-    "concreteType": "EventQuestionMutationResponse",
-    "kind": "LinkedField",
-    "name": "updateQuestionPosition",
-    "plural": false,
+    "kind": "Variable",
+    "name": "input",
+    "variableName": "input"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "isError",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "message",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "cursor",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "question",
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "firstName",
+  "storageKey": null
+},
+v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "position",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "QuestionQueueMutation",
     "selections": [
       {
         "alias": null,
-        "args": null,
-        "kind": "ScalarField",
-        "name": "isError",
-        "storageKey": null
-      },
-      {
-        "alias": null,
-        "args": null,
-        "kind": "ScalarField",
-        "name": "message",
-        "storageKey": null
-      },
-      {
-        "alias": null,
-        "args": null,
-        "concreteType": "EventQuestionEdge",
+        "args": (v1/*: any*/),
+        "concreteType": "EventQuestionMutationResponse",
         "kind": "LinkedField",
-        "name": "body",
+        "name": "updateQuestionPosition",
         "plural": false,
         "selections": [
+          (v2/*: any*/),
+          (v3/*: any*/),
           {
             "alias": null,
             "args": null,
-            "kind": "ScalarField",
-            "name": "cursor",
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "concreteType": "EventQuestion",
+            "concreteType": "EventQuestionEdge",
             "kind": "LinkedField",
-            "name": "node",
+            "name": "body",
             "plural": false,
             "selections": [
+              (v4/*: any*/),
               {
                 "alias": null,
                 "args": null,
-                "kind": "ScalarField",
-                "name": "id",
-                "storageKey": null
-              },
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "position",
+                "concreteType": "EventQuestion",
+                "kind": "LinkedField",
+                "name": "node",
+                "plural": false,
+                "selections": [
+                  (v5/*: any*/),
+                  (v6/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "User",
+                    "kind": "LinkedField",
+                    "name": "createdBy",
+                    "plural": false,
+                    "selections": [
+                      (v7/*: any*/)
+                    ],
+                    "storageKey": null
+                  },
+                  (v8/*: any*/)
+                ],
                 "storageKey": null
               }
             ],
@@ -133,16 +184,6 @@ v1 = [
         "storageKey": null
       }
     ],
-    "storageKey": null
-  }
-];
-return {
-  "fragment": {
-    "argumentDefinitions": (v0/*: any*/),
-    "kind": "Fragment",
-    "metadata": null,
-    "name": "QuestionQueueMutation",
-    "selections": (v1/*: any*/),
     "type": "Mutation",
     "abstractKey": null
   },
@@ -151,19 +192,72 @@ return {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Operation",
     "name": "QuestionQueueMutation",
-    "selections": (v1/*: any*/)
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "EventQuestionMutationResponse",
+        "kind": "LinkedField",
+        "name": "updateQuestionPosition",
+        "plural": false,
+        "selections": [
+          (v2/*: any*/),
+          (v3/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "EventQuestionEdge",
+            "kind": "LinkedField",
+            "name": "body",
+            "plural": false,
+            "selections": [
+              (v4/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "EventQuestion",
+                "kind": "LinkedField",
+                "name": "node",
+                "plural": false,
+                "selections": [
+                  (v5/*: any*/),
+                  (v6/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "User",
+                    "kind": "LinkedField",
+                    "name": "createdBy",
+                    "plural": false,
+                    "selections": [
+                      (v7/*: any*/),
+                      (v5/*: any*/)
+                    ],
+                    "storageKey": null
+                  },
+                  (v8/*: any*/)
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
   },
   "params": {
-    "cacheID": "2d7a5e85f80973632c7bb58ebdcd6a72",
+    "cacheID": "d81b33f4d92004792283cb8c780fc2f8",
     "id": null,
     "metadata": {},
     "name": "QuestionQueueMutation",
     "operationKind": "mutation",
-    "text": "mutation QuestionQueueMutation(\n  $input: UpdateQuestionPosition!\n) {\n  updateQuestionPosition(input: $input) {\n    isError\n    message\n    body {\n      cursor\n      node {\n        id\n        position\n      }\n    }\n  }\n}\n"
+    "text": "mutation QuestionQueueMutation(\n  $input: UpdateQuestionPosition!\n) {\n  updateQuestionPosition(input: $input) {\n    isError\n    message\n    body {\n      cursor\n      node {\n        id\n        question\n        createdBy {\n          firstName\n          id\n        }\n        position\n      }\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "8ab3dc1fc2c96fa3f35bf76e9ca90b47";
+(node as any).hash = "dbced572ae8572ce239520f31ebcee65";
 
 export default node;

--- a/app/client/src/__generated__/QuoteMutation.graphql.ts
+++ b/app/client/src/__generated__/QuoteMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<196226b8dc501a95406ae7fbc5121374>>
+ * @generated SignedSource<<5e6b969250e5b30d38604e892413d5bf>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -195,6 +195,13 @@ return {
                         "alias": null,
                         "args": null,
                         "kind": "ScalarField",
+                        "name": "lastName",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
                         "name": "avatar",
                         "storageKey": null
                       }
@@ -227,12 +234,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "edac19b9a4b664ae8fcd3dee48f82ce9",
+    "cacheID": "4cfe4be57b7208a5f78ed7cd4819995b",
     "id": null,
     "metadata": {},
     "name": "QuoteMutation",
     "operationKind": "mutation",
-    "text": "mutation QuoteMutation(\n  $input: CreateQuestion!\n) {\n  createQuestion(input: $input) {\n    isError\n    message\n    body {\n      cursor\n      node {\n        id\n        ...QuestionAuthorFragment\n        ...QuestionContentFragment\n      }\n    }\n  }\n}\n\nfragment QuestionAuthorFragment on EventQuestion {\n  createdBy {\n    id\n    firstName\n    avatar\n  }\n  createdAt\n}\n\nfragment QuestionContentFragment on EventQuestion {\n  question\n}\n"
+    "text": "mutation QuoteMutation(\n  $input: CreateQuestion!\n) {\n  createQuestion(input: $input) {\n    isError\n    message\n    body {\n      cursor\n      node {\n        id\n        ...QuestionAuthorFragment\n        ...QuestionContentFragment\n      }\n    }\n  }\n}\n\nfragment QuestionAuthorFragment on EventQuestion {\n  createdBy {\n    id\n    firstName\n    lastName\n    avatar\n  }\n  createdAt\n}\n\nfragment QuestionContentFragment on EventQuestion {\n  question\n}\n"
   }
 };
 })();

--- a/app/client/src/__generated__/useEnqueuedPushSubscription.graphql.ts
+++ b/app/client/src/__generated__/useEnqueuedPushSubscription.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<e3abd5174f2fcf662c0d38040a7f1fc3>>
+ * @generated SignedSource<<69189086eaa00117fcde4598436b3a0d>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -191,6 +191,13 @@ return {
                         "alias": null,
                         "args": null,
                         "kind": "ScalarField",
+                        "name": "lastName",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
                         "name": "avatar",
                         "storageKey": null
                       }
@@ -248,12 +255,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "3fb9a357fefc8b480b60fb0a34387a12",
+    "cacheID": "67c87713b931d5b1f7adb5afcf1b64b0",
     "id": null,
     "metadata": {},
     "name": "useEnqueuedPushSubscription",
     "operationKind": "subscription",
-    "text": "subscription useEnqueuedPushSubscription(\n  $eventId: ID!\n) {\n  enqueuedPushQuestion(eventId: $eventId) {\n    edge {\n      node {\n        id\n        ...QuestionAuthorFragment\n        ...QuestionStatsFragment\n        ...QuestionContentFragment\n        position\n      }\n      cursor\n    }\n  }\n}\n\nfragment QuestionAuthorFragment on EventQuestion {\n  createdBy {\n    id\n    firstName\n    avatar\n  }\n  createdAt\n}\n\nfragment QuestionContentFragment on EventQuestion {\n  question\n}\n\nfragment QuestionStatsFragment on EventQuestion {\n  id\n  likedByCount\n}\n"
+    "text": "subscription useEnqueuedPushSubscription(\n  $eventId: ID!\n) {\n  enqueuedPushQuestion(eventId: $eventId) {\n    edge {\n      node {\n        id\n        ...QuestionAuthorFragment\n        ...QuestionStatsFragment\n        ...QuestionContentFragment\n        position\n      }\n      cursor\n    }\n  }\n}\n\nfragment QuestionAuthorFragment on EventQuestion {\n  createdBy {\n    id\n    firstName\n    lastName\n    avatar\n  }\n  createdAt\n}\n\nfragment QuestionContentFragment on EventQuestion {\n  question\n}\n\nfragment QuestionStatsFragment on EventQuestion {\n  id\n  likedByCount\n}\n"
   }
 };
 })();

--- a/app/client/src/__generated__/useEnqueuedUnshiftSubscription.graphql.ts
+++ b/app/client/src/__generated__/useEnqueuedUnshiftSubscription.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<a948def59fd6f998a12a6a597f6339e5>>
+ * @generated SignedSource<<b8fb542701dbd2bbd5d44c18165a08c7>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -191,6 +191,13 @@ return {
                         "alias": null,
                         "args": null,
                         "kind": "ScalarField",
+                        "name": "lastName",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
                         "name": "avatar",
                         "storageKey": null
                       }
@@ -248,12 +255,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "6069fe16fe43abc9f8ca8644ae7089c6",
+    "cacheID": "8ee31a3f8f0bb628bdbb2d437c2ca46d",
     "id": null,
     "metadata": {},
     "name": "useEnqueuedUnshiftSubscription",
     "operationKind": "subscription",
-    "text": "subscription useEnqueuedUnshiftSubscription(\n  $eventId: ID!\n) {\n  enqueuedUnshiftQuestion(eventId: $eventId) {\n    edge {\n      node {\n        id\n        ...QuestionAuthorFragment\n        ...QuestionStatsFragment\n        ...QuestionContentFragment\n        position\n      }\n      cursor\n    }\n  }\n}\n\nfragment QuestionAuthorFragment on EventQuestion {\n  createdBy {\n    id\n    firstName\n    avatar\n  }\n  createdAt\n}\n\nfragment QuestionContentFragment on EventQuestion {\n  question\n}\n\nfragment QuestionStatsFragment on EventQuestion {\n  id\n  likedByCount\n}\n"
+    "text": "subscription useEnqueuedUnshiftSubscription(\n  $eventId: ID!\n) {\n  enqueuedUnshiftQuestion(eventId: $eventId) {\n    edge {\n      node {\n        id\n        ...QuestionAuthorFragment\n        ...QuestionStatsFragment\n        ...QuestionContentFragment\n        position\n      }\n      cursor\n    }\n  }\n}\n\nfragment QuestionAuthorFragment on EventQuestion {\n  createdBy {\n    id\n    firstName\n    lastName\n    avatar\n  }\n  createdAt\n}\n\nfragment QuestionContentFragment on EventQuestion {\n  question\n}\n\nfragment QuestionStatsFragment on EventQuestion {\n  id\n  likedByCount\n}\n"
   }
 };
 })();

--- a/app/client/src/__generated__/useQuestionCreatedSubscription.graphql.ts
+++ b/app/client/src/__generated__/useQuestionCreatedSubscription.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<973fcc553d1dd7c5afccbe38315ed609>>
+ * @generated SignedSource<<68863c468cd2859b7405c52bdc377542>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -89,6 +89,13 @@ v6 = {
       "args": null,
       "kind": "ScalarField",
       "name": "firstName",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "lastName",
       "storageKey": null
     },
     {
@@ -285,12 +292,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "bda99367f7bb07b699a16661e8b363a7",
+    "cacheID": "ccf0bd9310a02bdd78010805f6ddd718",
     "id": null,
     "metadata": {},
     "name": "useQuestionCreatedSubscription",
     "operationKind": "subscription",
-    "text": "subscription useQuestionCreatedSubscription(\n  $eventId: ID!\n) {\n  questionCreated(eventId: $eventId) {\n    edge {\n      cursor\n      node {\n        id\n        position\n        ...QuestionAuthorFragment\n        ...QuestionContentFragment\n        ...QuestionStatsFragment\n        refQuestion {\n          ...QuestionQuoteFragment\n          id\n        }\n      }\n    }\n  }\n}\n\nfragment QuestionAuthorFragment on EventQuestion {\n  createdBy {\n    id\n    firstName\n    avatar\n  }\n  createdAt\n}\n\nfragment QuestionContentFragment on EventQuestion {\n  question\n}\n\nfragment QuestionQuoteFragment on EventQuestion {\n  id\n  ...QuestionAuthorFragment\n  ...QuestionContentFragment\n}\n\nfragment QuestionStatsFragment on EventQuestion {\n  id\n  likedByCount\n}\n"
+    "text": "subscription useQuestionCreatedSubscription(\n  $eventId: ID!\n) {\n  questionCreated(eventId: $eventId) {\n    edge {\n      cursor\n      node {\n        id\n        position\n        ...QuestionAuthorFragment\n        ...QuestionContentFragment\n        ...QuestionStatsFragment\n        refQuestion {\n          ...QuestionQuoteFragment\n          id\n        }\n      }\n    }\n  }\n}\n\nfragment QuestionAuthorFragment on EventQuestion {\n  createdBy {\n    id\n    firstName\n    lastName\n    avatar\n  }\n  createdAt\n}\n\nfragment QuestionContentFragment on EventQuestion {\n  question\n}\n\nfragment QuestionQuoteFragment on EventQuestion {\n  id\n  ...QuestionAuthorFragment\n  ...QuestionContentFragment\n}\n\nfragment QuestionStatsFragment on EventQuestion {\n  id\n  likedByCount\n}\n"
   }
 };
 })();

--- a/app/client/src/__generated__/useQuestionDeletedSubscription.graphql.ts
+++ b/app/client/src/__generated__/useQuestionDeletedSubscription.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<ebe3f60386e25d6a836c0dc8042029c7>>
+ * @generated SignedSource<<4293a31fa5e618e574b1795f1790c499>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -209,6 +209,13 @@ return {
                         "alias": null,
                         "args": null,
                         "kind": "ScalarField",
+                        "name": "lastName",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
                         "name": "avatar",
                         "storageKey": null
                       }
@@ -249,12 +256,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "26ea29cb633f9e27f0e064468fbd9e99",
+    "cacheID": "53c7398ad617da6374e256493c67b5bf",
     "id": null,
     "metadata": {},
     "name": "useQuestionDeletedSubscription",
     "operationKind": "subscription",
-    "text": "subscription useQuestionDeletedSubscription(\n  $eventId: ID!\n) {\n  questionDeleted(eventId: $eventId) {\n    edge {\n      cursor\n      node {\n        id\n        position\n        ...QuestionAuthorFragment\n        ...QuestionContentFragment\n        ...QuestionStatsFragment\n      }\n    }\n  }\n}\n\nfragment QuestionAuthorFragment on EventQuestion {\n  createdBy {\n    id\n    firstName\n    avatar\n  }\n  createdAt\n}\n\nfragment QuestionContentFragment on EventQuestion {\n  question\n}\n\nfragment QuestionStatsFragment on EventQuestion {\n  id\n  likedByCount\n}\n"
+    "text": "subscription useQuestionDeletedSubscription(\n  $eventId: ID!\n) {\n  questionDeleted(eventId: $eventId) {\n    edge {\n      cursor\n      node {\n        id\n        position\n        ...QuestionAuthorFragment\n        ...QuestionContentFragment\n        ...QuestionStatsFragment\n      }\n    }\n  }\n}\n\nfragment QuestionAuthorFragment on EventQuestion {\n  createdBy {\n    id\n    firstName\n    lastName\n    avatar\n  }\n  createdAt\n}\n\nfragment QuestionContentFragment on EventQuestion {\n  question\n}\n\nfragment QuestionStatsFragment on EventQuestion {\n  id\n  likedByCount\n}\n"
   }
 };
 })();

--- a/app/client/src/__generated__/useQuestionQueueFragment.graphql.ts
+++ b/app/client/src/__generated__/useQuestionQueueFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<2d680f70ccd83c9da17862d6461473ec>>
+ * @generated SignedSource<<556f3c6c2cf0553ef711fc61c387704b>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -38,7 +38,7 @@ export type useQuestionQueueFragment$data = {
           readonly refQuestion: {
             readonly " $fragmentSpreads": FragmentRefs<"QuestionQuoteFragment">;
           } | null;
-          readonly " $fragmentSpreads": FragmentRefs<"QuestionAuthorFragment" | "QuestionStatsFragment" | "QuestionContentFragment">;
+          readonly " $fragmentSpreads": FragmentRefs<"QuestionActionsFragment" | "QuestionAuthorFragment" | "QuestionStatsFragment" | "QuestionContentFragment">;
         };
       }> | null;
     } | null;
@@ -59,120 +59,95 @@ var v0 = {
   "name": "id",
   "storageKey": null
 },
-v1 = [
-  {
-    "alias": null,
-    "args": null,
-    "concreteType": "EventQuestionEdge",
-    "kind": "LinkedField",
-    "name": "edges",
-    "plural": true,
-    "selections": [
-      {
-        "alias": null,
-        "args": null,
-        "kind": "ScalarField",
-        "name": "cursor",
-        "storageKey": null
-      },
-      {
-        "alias": null,
-        "args": null,
-        "concreteType": "EventQuestion",
-        "kind": "LinkedField",
-        "name": "node",
-        "plural": false,
-        "selections": [
-          (v0/*: any*/),
-          {
-            "args": null,
-            "kind": "FragmentSpread",
-            "name": "QuestionAuthorFragment"
-          },
-          {
-            "args": null,
-            "kind": "FragmentSpread",
-            "name": "QuestionStatsFragment"
-          },
-          {
-            "args": null,
-            "kind": "FragmentSpread",
-            "name": "QuestionContentFragment"
-          },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "position",
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "concreteType": "EventQuestion",
-            "kind": "LinkedField",
-            "name": "refQuestion",
-            "plural": false,
-            "selections": [
-              {
-                "args": null,
-                "kind": "FragmentSpread",
-                "name": "QuestionQuoteFragment"
-              }
-            ],
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "__typename",
-            "storageKey": null
-          }
-        ],
-        "storageKey": null
-      }
-    ],
-    "storageKey": null
-  },
-  {
-    "alias": null,
-    "args": null,
-    "concreteType": "PageInfo",
-    "kind": "LinkedField",
-    "name": "pageInfo",
-    "plural": false,
-    "selections": [
-      {
-        "alias": null,
-        "args": null,
-        "kind": "ScalarField",
-        "name": "endCursor",
-        "storageKey": null
-      },
-      {
-        "alias": null,
-        "args": null,
-        "kind": "ScalarField",
-        "name": "hasNextPage",
-        "storageKey": null
-      }
-    ],
-    "storageKey": null
-  },
-  {
-    "kind": "ClientExtension",
-    "selections": [
-      {
-        "alias": null,
-        "args": null,
-        "kind": "ScalarField",
-        "name": "__id",
-        "storageKey": null
-      }
-    ]
-  }
-];
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "cursor",
+  "storageKey": null
+},
+v2 = {
+  "args": null,
+  "kind": "FragmentSpread",
+  "name": "QuestionAuthorFragment"
+},
+v3 = {
+  "args": null,
+  "kind": "FragmentSpread",
+  "name": "QuestionStatsFragment"
+},
+v4 = {
+  "args": null,
+  "kind": "FragmentSpread",
+  "name": "QuestionContentFragment"
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "position",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "EventQuestion",
+  "kind": "LinkedField",
+  "name": "refQuestion",
+  "plural": false,
+  "selections": [
+    {
+      "args": null,
+      "kind": "FragmentSpread",
+      "name": "QuestionQuoteFragment"
+    }
+  ],
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v8 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "PageInfo",
+  "kind": "LinkedField",
+  "name": "pageInfo",
+  "plural": false,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "endCursor",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "hasNextPage",
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+},
+v9 = {
+  "kind": "ClientExtension",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "__id",
+      "storageKey": null
+    }
+  ]
+};
 return {
   "argumentDefinitions": [
     {
@@ -234,7 +209,40 @@ return {
           "kind": "LinkedField",
           "name": "__QuestionQueueFragment_questionRecord_connection",
           "plural": false,
-          "selections": (v1/*: any*/),
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "EventQuestionEdge",
+              "kind": "LinkedField",
+              "name": "edges",
+              "plural": true,
+              "selections": [
+                (v1/*: any*/),
+                {
+                  "alias": null,
+                  "args": null,
+                  "concreteType": "EventQuestion",
+                  "kind": "LinkedField",
+                  "name": "node",
+                  "plural": false,
+                  "selections": [
+                    (v0/*: any*/),
+                    (v2/*: any*/),
+                    (v3/*: any*/),
+                    (v4/*: any*/),
+                    (v5/*: any*/),
+                    (v6/*: any*/),
+                    (v7/*: any*/)
+                  ],
+                  "storageKey": null
+                }
+              ],
+              "storageKey": null
+            },
+            (v8/*: any*/),
+            (v9/*: any*/)
+          ],
           "storageKey": null
         },
         {
@@ -244,7 +252,45 @@ return {
           "kind": "LinkedField",
           "name": "__QuestionQueueFragment_enqueuedQuestions_connection",
           "plural": false,
-          "selections": (v1/*: any*/),
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "EventQuestionEdge",
+              "kind": "LinkedField",
+              "name": "edges",
+              "plural": true,
+              "selections": [
+                (v1/*: any*/),
+                {
+                  "alias": null,
+                  "args": null,
+                  "concreteType": "EventQuestion",
+                  "kind": "LinkedField",
+                  "name": "node",
+                  "plural": false,
+                  "selections": [
+                    (v0/*: any*/),
+                    {
+                      "args": null,
+                      "kind": "FragmentSpread",
+                      "name": "QuestionActionsFragment"
+                    },
+                    (v2/*: any*/),
+                    (v3/*: any*/),
+                    (v4/*: any*/),
+                    (v5/*: any*/),
+                    (v6/*: any*/),
+                    (v7/*: any*/)
+                  ],
+                  "storageKey": null
+                }
+              ],
+              "storageKey": null
+            },
+            (v8/*: any*/),
+            (v9/*: any*/)
+          ],
           "storageKey": null
         }
       ],
@@ -256,6 +302,6 @@ return {
 };
 })();
 
-(node as any).hash = "bf9a1f6c7fd332126002af6c4448e3dd";
+(node as any).hash = "f0fda8dedb259325adec27500ec5acf9";
 
 export default node;

--- a/app/client/src/__generated__/useQuestionQueueFragment.graphql.ts
+++ b/app/client/src/__generated__/useQuestionQueueFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<556f3c6c2cf0553ef711fc61c387704b>>
+ * @generated SignedSource<<7a27093fadd9fa47fd9801198dc04476>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -20,6 +20,10 @@ export type useQuestionQueueFragment$data = {
         readonly cursor: string;
         readonly node: {
           readonly id: string;
+          readonly question: string | null;
+          readonly createdBy: {
+            readonly firstName: string | null;
+          } | null;
           readonly position: number | null;
           readonly refQuestion: {
             readonly " $fragmentSpreads": FragmentRefs<"QuestionQuoteFragment">;
@@ -34,6 +38,10 @@ export type useQuestionQueueFragment$data = {
         readonly cursor: string;
         readonly node: {
           readonly id: string;
+          readonly question: string | null;
+          readonly createdBy: {
+            readonly firstName: string | null;
+          } | null;
           readonly position: number | null;
           readonly refQuestion: {
             readonly " $fragmentSpreads": FragmentRefs<"QuestionQuoteFragment">;
@@ -67,28 +75,53 @@ v1 = {
   "storageKey": null
 },
 v2 = {
+  "alias": null,
   "args": null,
-  "kind": "FragmentSpread",
-  "name": "QuestionAuthorFragment"
+  "kind": "ScalarField",
+  "name": "question",
+  "storageKey": null
 },
 v3 = {
+  "alias": null,
   "args": null,
-  "kind": "FragmentSpread",
-  "name": "QuestionStatsFragment"
+  "concreteType": "User",
+  "kind": "LinkedField",
+  "name": "createdBy",
+  "plural": false,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "firstName",
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
 },
 v4 = {
   "args": null,
   "kind": "FragmentSpread",
-  "name": "QuestionContentFragment"
+  "name": "QuestionAuthorFragment"
 },
 v5 = {
+  "args": null,
+  "kind": "FragmentSpread",
+  "name": "QuestionStatsFragment"
+},
+v6 = {
+  "args": null,
+  "kind": "FragmentSpread",
+  "name": "QuestionContentFragment"
+},
+v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "position",
   "storageKey": null
 },
-v6 = {
+v8 = {
   "alias": null,
   "args": null,
   "concreteType": "EventQuestion",
@@ -104,14 +137,14 @@ v6 = {
   ],
   "storageKey": null
 },
-v7 = {
+v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "__typename",
   "storageKey": null
 },
-v8 = {
+v10 = {
   "alias": null,
   "args": null,
   "concreteType": "PageInfo",
@@ -136,7 +169,7 @@ v8 = {
   ],
   "storageKey": null
 },
-v9 = {
+v11 = {
   "kind": "ClientExtension",
   "selections": [
     {
@@ -233,15 +266,17 @@ return {
                     (v4/*: any*/),
                     (v5/*: any*/),
                     (v6/*: any*/),
-                    (v7/*: any*/)
+                    (v7/*: any*/),
+                    (v8/*: any*/),
+                    (v9/*: any*/)
                   ],
                   "storageKey": null
                 }
               ],
               "storageKey": null
             },
-            (v8/*: any*/),
-            (v9/*: any*/)
+            (v10/*: any*/),
+            (v11/*: any*/)
           ],
           "storageKey": null
         },
@@ -271,25 +306,27 @@ return {
                   "plural": false,
                   "selections": [
                     (v0/*: any*/),
+                    (v2/*: any*/),
+                    (v3/*: any*/),
                     {
                       "args": null,
                       "kind": "FragmentSpread",
                       "name": "QuestionActionsFragment"
                     },
-                    (v2/*: any*/),
-                    (v3/*: any*/),
                     (v4/*: any*/),
                     (v5/*: any*/),
                     (v6/*: any*/),
-                    (v7/*: any*/)
+                    (v7/*: any*/),
+                    (v8/*: any*/),
+                    (v9/*: any*/)
                   ],
                   "storageKey": null
                 }
               ],
               "storageKey": null
             },
-            (v8/*: any*/),
-            (v9/*: any*/)
+            (v10/*: any*/),
+            (v11/*: any*/)
           ],
           "storageKey": null
         }
@@ -302,6 +339,6 @@ return {
 };
 })();
 
-(node as any).hash = "f0fda8dedb259325adec27500ec5acf9";
+(node as any).hash = "83041d7b8a3882356dbe791565b11e26";
 
 export default node;

--- a/app/client/src/__generated__/useQuestionUpdatedSubscription.graphql.ts
+++ b/app/client/src/__generated__/useQuestionUpdatedSubscription.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<22da51052edb7dbc47ea1f0b2c98703b>>
+ * @generated SignedSource<<f319184f3608ca4863e07ea13d9c2a46>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -183,6 +183,13 @@ return {
                         "alias": null,
                         "args": null,
                         "kind": "ScalarField",
+                        "name": "lastName",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
                         "name": "avatar",
                         "storageKey": null
                       }
@@ -222,12 +229,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "ab5397ca34bfa53ab404893b2d18f962",
+    "cacheID": "ca827eebaf4e7b307ff44728a475226f",
     "id": null,
     "metadata": {},
     "name": "useQuestionUpdatedSubscription",
     "operationKind": "subscription",
-    "text": "subscription useQuestionUpdatedSubscription(\n  $eventId: ID!\n) {\n  questionUpdated(eventId: $eventId) {\n    edge {\n      cursor\n      node {\n        id\n        position\n        ...QuestionAuthorFragment\n        ...QuestionContentFragment\n        ...QuestionStatsFragment\n      }\n    }\n  }\n}\n\nfragment QuestionAuthorFragment on EventQuestion {\n  createdBy {\n    id\n    firstName\n    avatar\n  }\n  createdAt\n}\n\nfragment QuestionContentFragment on EventQuestion {\n  question\n}\n\nfragment QuestionStatsFragment on EventQuestion {\n  id\n  likedByCount\n}\n"
+    "text": "subscription useQuestionUpdatedSubscription(\n  $eventId: ID!\n) {\n  questionUpdated(eventId: $eventId) {\n    edge {\n      cursor\n      node {\n        id\n        position\n        ...QuestionAuthorFragment\n        ...QuestionContentFragment\n        ...QuestionStatsFragment\n      }\n    }\n  }\n}\n\nfragment QuestionAuthorFragment on EventQuestion {\n  createdBy {\n    id\n    firstName\n    lastName\n    avatar\n  }\n  createdAt\n}\n\nfragment QuestionContentFragment on EventQuestion {\n  question\n}\n\nfragment QuestionStatsFragment on EventQuestion {\n  id\n  likedByCount\n}\n"
   }
 };
 })();

--- a/app/client/src/__generated__/useRecordPushSubscription.graphql.ts
+++ b/app/client/src/__generated__/useRecordPushSubscription.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<b4c774f82320b029cbf68eeb93e7023d>>
+ * @generated SignedSource<<06c00819bd5bb734618219f250bd57be>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -191,6 +191,13 @@ return {
                         "alias": null,
                         "args": null,
                         "kind": "ScalarField",
+                        "name": "lastName",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
                         "name": "avatar",
                         "storageKey": null
                       }
@@ -248,12 +255,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "82c633534ff425978ed6b0829f879489",
+    "cacheID": "dcff8aec72ded50cb47231ab1b42a22b",
     "id": null,
     "metadata": {},
     "name": "useRecordPushSubscription",
     "operationKind": "subscription",
-    "text": "subscription useRecordPushSubscription(\n  $eventId: ID!\n) {\n  recordPushQuestion(eventId: $eventId) {\n    edge {\n      node {\n        id\n        ...QuestionAuthorFragment\n        ...QuestionStatsFragment\n        ...QuestionContentFragment\n        position\n      }\n      cursor\n    }\n  }\n}\n\nfragment QuestionAuthorFragment on EventQuestion {\n  createdBy {\n    id\n    firstName\n    avatar\n  }\n  createdAt\n}\n\nfragment QuestionContentFragment on EventQuestion {\n  question\n}\n\nfragment QuestionStatsFragment on EventQuestion {\n  id\n  likedByCount\n}\n"
+    "text": "subscription useRecordPushSubscription(\n  $eventId: ID!\n) {\n  recordPushQuestion(eventId: $eventId) {\n    edge {\n      node {\n        id\n        ...QuestionAuthorFragment\n        ...QuestionStatsFragment\n        ...QuestionContentFragment\n        position\n      }\n      cursor\n    }\n  }\n}\n\nfragment QuestionAuthorFragment on EventQuestion {\n  createdBy {\n    id\n    firstName\n    lastName\n    avatar\n  }\n  createdAt\n}\n\nfragment QuestionContentFragment on EventQuestion {\n  question\n}\n\nfragment QuestionStatsFragment on EventQuestion {\n  id\n  likedByCount\n}\n"
   }
 };
 })();

--- a/app/client/src/__generated__/useRecordUnshiftSubscription.graphql.ts
+++ b/app/client/src/__generated__/useRecordUnshiftSubscription.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<8f1dcd61cc86eabce75741cbee490114>>
+ * @generated SignedSource<<db793c965384115d5a31a37316c35c7b>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -191,6 +191,13 @@ return {
                         "alias": null,
                         "args": null,
                         "kind": "ScalarField",
+                        "name": "lastName",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
                         "name": "avatar",
                         "storageKey": null
                       }
@@ -248,12 +255,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "bbb6ba98d16766bb63a1dded06c6c07d",
+    "cacheID": "f60df4d601fd5d54f77715515f4dffe9",
     "id": null,
     "metadata": {},
     "name": "useRecordUnshiftSubscription",
     "operationKind": "subscription",
-    "text": "subscription useRecordUnshiftSubscription(\n  $eventId: ID!\n) {\n  recordUnshiftQuestion(eventId: $eventId) {\n    edge {\n      node {\n        id\n        ...QuestionAuthorFragment\n        ...QuestionStatsFragment\n        ...QuestionContentFragment\n        position\n      }\n      cursor\n    }\n  }\n}\n\nfragment QuestionAuthorFragment on EventQuestion {\n  createdBy {\n    id\n    firstName\n    avatar\n  }\n  createdAt\n}\n\nfragment QuestionContentFragment on EventQuestion {\n  question\n}\n\nfragment QuestionStatsFragment on EventQuestion {\n  id\n  likedByCount\n}\n"
+    "text": "subscription useRecordUnshiftSubscription(\n  $eventId: ID!\n) {\n  recordUnshiftQuestion(eventId: $eventId) {\n    edge {\n      node {\n        id\n        ...QuestionAuthorFragment\n        ...QuestionStatsFragment\n        ...QuestionContentFragment\n        position\n      }\n      cursor\n    }\n  }\n}\n\nfragment QuestionAuthorFragment on EventQuestion {\n  createdBy {\n    id\n    firstName\n    lastName\n    avatar\n  }\n  createdAt\n}\n\nfragment QuestionContentFragment on EventQuestion {\n  question\n}\n\nfragment QuestionStatsFragment on EventQuestion {\n  id\n  likedByCount\n}\n"
   }
 };
 })();

--- a/app/client/src/components/DropArea/DropArea.tsx
+++ b/app/client/src/components/DropArea/DropArea.tsx
@@ -6,7 +6,7 @@ import {
     DroppableStateSnapshot,
     DroppableProps,
 } from 'react-beautiful-dnd';
-import Card from '@material-ui/core/Card';
+import { Grid } from '@material-ui/core';
 
 interface Props {
     getStyle?: (isDraggingOver: boolean) => React.CSSProperties;
@@ -25,22 +25,19 @@ export default function DropArea(
                 snapshot: DroppableStateSnapshot
             ) => {
                 return (
-                    <Card
+                    <Grid
+                        container
+                        direction='column'
                         // recommended method from the library maintainer itself
                         // eslint-disable-next-line @typescript-eslint/unbound-method
                         ref={provided.innerRef}
-                        style={
-                            getStyle
-                                ? getStyle(snapshot.isDraggingOver)
-                                : undefined
-                        }
                         // also recommende method from the library
                         // eslint-disable-next-line react/jsx-props-no-spreading
                         {...provided.droppableProps}
                     >
                         {children}
                         {provided.placeholder}
-                    </Card>
+                    </Grid>
                 );
             }}
         </Droppable>

--- a/app/client/src/components/ListFilter/ListFilter.tsx
+++ b/app/client/src/components/ListFilter/ListFilter.tsx
@@ -8,7 +8,6 @@ import {
     InputAdornment,
     Badge,
     Checkbox,
-    Typography,
     Tooltip,
 } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';

--- a/app/client/src/components/ListFilter/ListFilter.tsx
+++ b/app/client/src/components/ListFilter/ListFilter.tsx
@@ -15,6 +15,7 @@ import { makeStyles } from '@material-ui/core/styles';
 import FilterIcon from '@material-ui/icons/FilterList';
 import SearchIcon from '@material-ui/icons/Search';
 import CloseIcon from '@material-ui/icons/Close';
+import RefreshIcon from '@material-ui/icons/Refresh';
 import { Skeleton, SkeletonProps } from '@material-ui/lab';
 
 import { TextField } from '@local/components/TextField';
@@ -44,6 +45,11 @@ const useStyles = makeStyles((theme) => ({
         width: 'auto',
         marginLeft: theme.spacing(0.5),
     },
+    input: {
+        ['& fieldset']: {
+            borderRadius: 9999 // rounded text field
+        },
+    }
 }));
 
 type Filters = Set<string>;
@@ -115,12 +121,21 @@ export default function ListFilter<T>({ filterMap, onSearch, length, onFilterCha
                         value={search}
                         onChange={handleSearch}
                         onKeyDown={handleKeyPress}
+                        className={classes.input}
                         InputProps={{
                             // TODO: animation change here
+                            startAdornment: (
+                                <InputAdornment position='start'>
+                                    <SearchIcon />
+                                </InputAdornment>
+                            ),
+                            // TODO: add refresh action
                             endAdornment:
                                 search === '' ? (
                                     <InputAdornment position='end'>
-                                        <SearchIcon />
+                                        <IconButton edge='end' onClick={clearSearch}>
+                                            <RefreshIcon />
+                                        </IconButton>
                                     </InputAdornment>
                                 ) : (
                                     <InputAdornment position='end'>

--- a/app/client/src/components/ListFilter/ListFilter.tsx
+++ b/app/client/src/components/ListFilter/ListFilter.tsx
@@ -173,13 +173,6 @@ export default function ListFilter<T>({ filterMap, onSearch, length, onFilterCha
                         </Grid>
                     ))}
                 </Grid>
-                { displayNumResults && // hide number of results if on feedback tab and not logged in
-                    <Grid item xs={12} className={classes.resultsText}>
-                        <Typography variant='body2' color='textSecondary'>
-                            {`${length} Results Displayed`}
-                        </Typography>
-                    </Grid>
-                }
             </Grid>
             {filterMap && (
                 <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={() => setAnchorEl(null)}>

--- a/app/client/src/components/ListFilter/ListFilter.tsx
+++ b/app/client/src/components/ListFilter/ListFilter.tsx
@@ -39,6 +39,7 @@ const useStyles = makeStyles((theme) => ({
     },
     search: {
         flex: 1,
+        marginBottom: theme.spacing(2),
     },
     iconContainer: {
         flexBasis: 'auto',

--- a/app/client/src/features/core/theme.tsx
+++ b/app/client/src/features/core/theme.tsx
@@ -35,6 +35,22 @@ declare module '@material-ui/core/styles/createMuiTheme' {
     }
 }
 
+declare module '@material-ui/core/styles/createPalette' {
+
+    interface Palette {
+        custom: {
+            creamCan: string;
+            lightBlue: string;
+        };
+    }
+    interface PaletteOptions {
+        custom?: {
+            creamCan?: string;
+            lightBlue?: string;
+        };
+    }
+}
+
 const easingFunc = 'cubic-bezier(0.4, 0, 0.2, 1)';
 
 const base = createMuiTheme({
@@ -95,6 +111,10 @@ const base = createMuiTheme({
         background: {
             default: '#f3f1ee',
         },
+        custom: {
+            creamCan: '#f5c64f',
+            lightBlue: '#8eafff',
+        }
     },
 });
 

--- a/app/client/src/features/events/EventSidebar/EventSidebar.tsx
+++ b/app/client/src/features/events/EventSidebar/EventSidebar.tsx
@@ -124,7 +124,10 @@ export const EventSidebar = ({ fragmentRef }: EventSidebarProps) => {
             wrap='nowrap'
         >
             <Grid item>
-                <CurrentQuestionCard fragmentRef={data} />
+                <CurrentQuestionCard
+                    isViewerModerator={Boolean(data.isViewerModerator)}
+                    fragmentRef={data}
+                />
             </Grid>
             <Grid
                 container

--- a/app/client/src/features/events/EventSidebar/EventSidebar.tsx
+++ b/app/client/src/features/events/EventSidebar/EventSidebar.tsx
@@ -90,8 +90,6 @@ export const EventSidebar = ({ fragmentRef }: EventSidebarProps) => {
     const [tabIndex, setTabIndex] = React.useState<number>(0);
     const [displayFeedbackButton, setDisplayFeedbackButton] = React.useState<boolean>(false);
     const data = useFragment(EVENT_SIDEBAR_FRAGMENT, fragmentRef);
-    const [displayCurrentQuestionCard, setDisplayCurrentQuestionCard] = React.useState<boolean>(false);
-    const [isPrevQuestionQueue, setIsPrevQuestionQueue] = React.useState<boolean>(false); // question queue display is previous questions
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const handleTabChange = (e: React.ChangeEvent<any>, newTabIndex: number) => {
@@ -106,12 +104,6 @@ export const EventSidebar = ({ fragmentRef }: EventSidebarProps) => {
     // const tabs = React.useMemo(() => buildTabs(tabVisibility), [tabVisibility]);
 
     React.useEffect(() => {
-        if (data.isViewerModerator && tabIndex == 0) {
-            setDisplayCurrentQuestionCard(!isPrevQuestionQueue);
-        } else {
-            setDisplayCurrentQuestionCard(true);
-        }
-
         if (data.isViewerModerator && tabIndex === 2) {
             setDisplayFeedbackButton(true);
         } else if (!data.isViewerModerator && tabIndex === 1) {
@@ -119,7 +111,7 @@ export const EventSidebar = ({ fragmentRef }: EventSidebarProps) => {
         } else {
             setDisplayFeedbackButton(false);
         }
-    }, [tabIndex, data, isPrevQuestionQueue]);
+    }, [tabIndex, data]);
 
     return (
         <Grid
@@ -130,14 +122,12 @@ export const EventSidebar = ({ fragmentRef }: EventSidebarProps) => {
             alignItems='flex-start'
             wrap='nowrap'
         >
-            { displayCurrentQuestionCard &&
-                <Grid item>
-                    <CurrentQuestionCard
-                        isViewerModerator={Boolean(data.isViewerModerator)}
-                        fragmentRef={data}
-                    />
-                </Grid>
-            }
+            <Grid item>
+                <CurrentQuestionCard
+                    isViewerModerator={Boolean(data.isViewerModerator)}
+                    fragmentRef={data}
+                />
+            </Grid>
             <Grid
                 container
                 direction='column'
@@ -175,7 +165,7 @@ export const EventSidebar = ({ fragmentRef }: EventSidebarProps) => {
 
             <Grid component={TabPanels} container item xs='auto' className={classes.paneContainer}>
                 <TabPanel visible={data.isViewerModerator ? tabIndex === 0 : false}>
-                    <QuestionQueue handleQueueDisplay={setIsPrevQuestionQueue} fragmentRef={data} />
+                    <QuestionQueue fragmentRef={data} />
                 </TabPanel>
                 <TabPanel visible={data.isViewerModerator ? tabIndex === 1 : tabIndex === 0}>
                     <QuestionList fragmentRef={data} />

--- a/app/client/src/features/events/EventSidebar/EventSidebar.tsx
+++ b/app/client/src/features/events/EventSidebar/EventSidebar.tsx
@@ -11,7 +11,6 @@ import TabPanel, { TabPanels } from '@local/components/TabPanel';
 import { QuestionList } from '@local/features/events/Questions/QuestionList';
 import { QuestionQueue } from '@local/features/events/Moderation/ManageQuestions';
 import AskQuestion from '@local/features/events/Questions/AskQuestion';
-import { QuestionCarousel } from '@local/features/events/Questions/QuestionCarousel';
 import { LiveFeedbackList } from '@local/features/events/LiveFeedback/LiveFeedbackList';
 import { SubmitLiveFeedback } from '@local/features/events/LiveFeedback/SubmitLiveFeedback';
 import { EventDetailsCard } from '../EventDetailsCard';

--- a/app/client/src/features/events/EventSidebar/EventSidebar.tsx
+++ b/app/client/src/features/events/EventSidebar/EventSidebar.tsx
@@ -91,6 +91,8 @@ export const EventSidebar = ({ fragmentRef }: EventSidebarProps) => {
     const [tabIndex, setTabIndex] = React.useState<number>(0);
     const [displayFeedbackButton, setDisplayFeedbackButton] = React.useState<boolean>(false);
     const data = useFragment(EVENT_SIDEBAR_FRAGMENT, fragmentRef);
+    const [displayCurrentQuestionCard, setDisplayCurrentQuestionCard] = React.useState<boolean>(false);
+    const [isPrevQuestionQueue, setIsPrevQuestionQueue] = React.useState<boolean>(false); // question queue display is previous questions
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const handleTabChange = (e: React.ChangeEvent<any>, newTabIndex: number) => {
@@ -105,6 +107,12 @@ export const EventSidebar = ({ fragmentRef }: EventSidebarProps) => {
     // const tabs = React.useMemo(() => buildTabs(tabVisibility), [tabVisibility]);
 
     React.useEffect(() => {
+        if (data.isViewerModerator && tabIndex == 0) {
+            setDisplayCurrentQuestionCard(!isPrevQuestionQueue);
+        } else {
+            setDisplayCurrentQuestionCard(true);
+        }
+
         if (data.isViewerModerator && tabIndex === 2) {
             setDisplayFeedbackButton(true);
         } else if (!data.isViewerModerator && tabIndex === 1) {
@@ -112,7 +120,7 @@ export const EventSidebar = ({ fragmentRef }: EventSidebarProps) => {
         } else {
             setDisplayFeedbackButton(false);
         }
-    }, [tabIndex, data]);
+    }, [tabIndex, data, isPrevQuestionQueue]);
 
     return (
         <Grid
@@ -123,12 +131,14 @@ export const EventSidebar = ({ fragmentRef }: EventSidebarProps) => {
             alignItems='flex-start'
             wrap='nowrap'
         >
-            <Grid item>
-                <CurrentQuestionCard
-                    isViewerModerator={Boolean(data.isViewerModerator)}
-                    fragmentRef={data}
-                />
-            </Grid>
+            { displayCurrentQuestionCard &&
+                <Grid item>
+                    <CurrentQuestionCard
+                        isViewerModerator={Boolean(data.isViewerModerator)}
+                        fragmentRef={data}
+                    />
+                </Grid>
+            }
             <Grid
                 container
                 direction='column'
@@ -166,7 +176,7 @@ export const EventSidebar = ({ fragmentRef }: EventSidebarProps) => {
 
             <Grid component={TabPanels} container item xs='auto' className={classes.paneContainer}>
                 <TabPanel visible={data.isViewerModerator ? tabIndex === 0 : false}>
-                    <QuestionQueue fragmentRef={data} />
+                    <QuestionQueue handleQueueDisplay={setIsPrevQuestionQueue} fragmentRef={data} />
                 </TabPanel>
                 <TabPanel visible={data.isViewerModerator ? tabIndex === 1 : tabIndex === 0}>
                     <QuestionList fragmentRef={data} />

--- a/app/client/src/features/events/EventSidebar/EventSidebar.tsx
+++ b/app/client/src/features/events/EventSidebar/EventSidebar.tsx
@@ -14,9 +14,9 @@ import AskQuestion from '@local/features/events/Questions/AskQuestion';
 import { LiveFeedbackList } from '@local/features/events/LiveFeedback/LiveFeedbackList';
 import { SubmitLiveFeedback } from '@local/features/events/LiveFeedback/SubmitLiveFeedback';
 import { EventDetailsCard } from '../EventDetailsCard';
-import { CurrentQuestionCard } from '../Moderation/ManageQuestions/CurrentQuestionCard'
 import { SpeakerList } from '../Speakers';
 import { Tabs } from '@local/components/Tabs'
+import { QuestionCarousel } from '../Questions/QuestionCarousel';
 
 export const EVENT_SIDEBAR_FRAGMENT = graphql`
     fragment EventSidebarFragment on Event {
@@ -123,10 +123,11 @@ export const EventSidebar = ({ fragmentRef }: EventSidebarProps) => {
             wrap='nowrap'
         >
             <Grid item>
-                <CurrentQuestionCard
+                {!data.isViewerModerator && <QuestionCarousel fragmentRef={data} />}
+                {/* <CurrentQuestionCard
                     isViewerModerator={Boolean(data.isViewerModerator)}
                     fragmentRef={data}
-                />
+                /> */}
             </Grid>
             <Grid
                 container
@@ -153,8 +154,6 @@ export const EventSidebar = ({ fragmentRef }: EventSidebarProps) => {
                     )
                 }
             </Grid>
-
-            {!data.isViewerModerator && <QuestionCarousel fragmentRef={data} />}
 
             <Tabs 
                 tabIndex={tabIndex}

--- a/app/client/src/features/events/EventSidebar/EventSidebar.tsx
+++ b/app/client/src/features/events/EventSidebar/EventSidebar.tsx
@@ -15,6 +15,7 @@ import { QuestionCarousel } from '@local/features/events/Questions/QuestionCarou
 import { LiveFeedbackList } from '@local/features/events/LiveFeedback/LiveFeedbackList';
 import { SubmitLiveFeedback } from '@local/features/events/LiveFeedback/SubmitLiveFeedback';
 import { EventDetailsCard } from '../EventDetailsCard';
+import { CurrentQuestionCard } from '../Moderation/ManageQuestions/CurrentQuestionCard'
 import { SpeakerList } from '../Speakers';
 import { Tabs } from '@local/components/Tabs'
 
@@ -122,6 +123,9 @@ export const EventSidebar = ({ fragmentRef }: EventSidebarProps) => {
             alignItems='flex-start'
             wrap='nowrap'
         >
+            <Grid item>
+                <CurrentQuestionCard fragmentRef={data} />
+            </Grid>
             <Grid
                 container
                 direction='column'

--- a/app/client/src/features/events/Moderation/ManageQuestions/CurrentQuestionCard.tsx
+++ b/app/client/src/features/events/Moderation/ManageQuestions/CurrentQuestionCard.tsx
@@ -33,7 +33,8 @@ const useStyles = makeStyles((theme) => ({
         top: theme.spacing(-2),
         left: '50%',
         transform: 'translateX(-50%)',
-        background: '#F5C64F',
+        backgroundColor: theme.palette.custom.creamCan,
+        background: theme.palette.background.default,
         color: 'white',
         textTransform: 'uppercase',
         fontWeight: 600

--- a/app/client/src/features/events/Moderation/ManageQuestions/CurrentQuestionCard.tsx
+++ b/app/client/src/features/events/Moderation/ManageQuestions/CurrentQuestionCard.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/indent */
 import * as React from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import { Grid, Chip, Card } from '@material-ui/core';
@@ -117,7 +116,6 @@ export function CurrentQuestionCard({ isViewerModerator, fragmentRef }: Question
                             <NextQuestionButton disabled={!canGoForward} />
                         </Grid>
                     }
-
                 </Card>
             }
         </>

--- a/app/client/src/features/events/Moderation/ManageQuestions/CurrentQuestionCard.tsx
+++ b/app/client/src/features/events/Moderation/ManageQuestions/CurrentQuestionCard.tsx
@@ -48,22 +48,6 @@ interface QuestionQueueProps {
     fragmentRef: useQuestionQueueFragment$key;
 }
 
-export const QUESTION_QUEUE_MUTATION = graphql`
-    mutation QuestionQueueMutation($input: UpdateQuestionPosition!) @raw_response_type {
-        updateQuestionPosition(input: $input) {
-            isError
-            message
-            body {
-                cursor
-                node {
-                    id
-                    position
-                }
-            }
-        }
-    }
-`;
-
 export function CurrentQuestionCard({ fragmentRef }: QuestionQueueProps) {
     //
     // ─── HOOKS ──────────────────────────────────────────────────────────────────────

--- a/app/client/src/features/events/Moderation/ManageQuestions/CurrentQuestionCard.tsx
+++ b/app/client/src/features/events/Moderation/ManageQuestions/CurrentQuestionCard.tsx
@@ -4,7 +4,7 @@ import { Grid, Chip, Card } from '@material-ui/core';
 import BookmarkIcon from '@material-ui/icons/Bookmark';
 
 import type { useQuestionQueueFragment$key } from '@local/__generated__/useQuestionQueueFragment.graphql';
-import { QuestionAuthor, QuestionContent } from '../../Questions';
+import { QuestionAuthor, QuestionContent, QuestionQuote } from '../../Questions';
 import { NextQuestionButton } from './NextQuestionButton';
 import { PreviousQuestionButton } from './PreviousQuestionButton';
 import { useQuestionQueue } from './useQuestionQueue';
@@ -109,6 +109,7 @@ export function CurrentQuestionCard({ isViewerModerator, fragmentRef }: Question
                         className={classes.answeringNow}
                     />
                     <QuestionAuthor fragmentRef={currentQuestion.node} />
+                    {currentQuestion.node.refQuestion && <QuestionQuote fragmentRef={currentQuestion.node.refQuestion} />}
                     <QuestionContent fragmentRef={currentQuestion.node} />
                     { isViewerModerator &&
                         <Grid container alignItems='center' justify='space-between' className={classes.currentQuestionActions}>

--- a/app/client/src/features/events/Moderation/ManageQuestions/CurrentQuestionCard.tsx
+++ b/app/client/src/features/events/Moderation/ManageQuestions/CurrentQuestionCard.tsx
@@ -1,0 +1,138 @@
+/* eslint-disable @typescript-eslint/indent */
+import * as React from 'react';
+import { makeStyles } from '@material-ui/core/styles';
+import { Grid, Chip, Card } from '@material-ui/core';
+import { graphql } from 'react-relay';
+import BookmarkIcon from '@material-ui/icons/Bookmark';
+
+import type { useQuestionQueueFragment$key } from '@local/__generated__/useQuestionQueueFragment.graphql';
+import { QuestionAuthor, QuestionContent } from '../../Questions';
+import { NextQuestionButton } from './NextQuestionButton';
+import { PreviousQuestionButton } from './PreviousQuestionButton';
+import { useQuestionQueue } from './useQuestionQueue';
+import { useRecordPush } from './useRecordPush';
+import { useRecordRemove } from './useRecordRemove';
+import { useRecordUnshift } from './useRecordUnshift';
+import { useEnqueuedPush } from './useEnqueuedPush';
+import { useEnqueuedRemove } from './useEnqueuedRemove';
+import { useEnqueuedUnshift } from './useEnqueuedUnshift';
+
+const useStyles = makeStyles((theme) => ({
+    item: {
+        width: '100%',
+        paddingTop: theme.spacing(0.5),
+        borderRadius: '10px',
+    },
+    relative: {
+        position: 'relative',
+        overflow: 'visible',
+        marginTop: theme.spacing(3)
+    },
+    answeringNow: {
+        padding: theme.spacing(0.5),
+        position: 'absolute',
+        top: theme.spacing(-2),
+        left: '50%',
+        transform: 'translateX(-50%)',
+        background: '#F5C64F',
+        color: 'white',
+        textTransform: 'uppercase',
+        fontWeight: 600
+    },
+    currentQuestionActions: {
+        padding: theme.spacing(0, 1, 1, 1)
+    }
+}));
+
+interface QuestionQueueProps {
+    fragmentRef: useQuestionQueueFragment$key;
+}
+
+export const QUESTION_QUEUE_MUTATION = graphql`
+    mutation QuestionQueueMutation($input: UpdateQuestionPosition!) @raw_response_type {
+        updateQuestionPosition(input: $input) {
+            isError
+            message
+            body {
+                cursor
+                node {
+                    id
+                    position
+                }
+            }
+        }
+    }
+`;
+
+export function CurrentQuestionCard({ fragmentRef }: QuestionQueueProps) {
+    //
+    // ─── HOOKS ──────────────────────────────────────────────────────────────────────
+    //
+    const { questionQueue } = useQuestionQueue({ fragmentRef });
+    const recordConnection = React.useMemo(
+        () => ({ connection: questionQueue?.questionRecord?.__id ?? '' }),
+        [questionQueue?.questionRecord]
+    );
+    const enqueuedConnection = React.useMemo(
+        () => ({ connection: questionQueue?.enqueuedQuestions?.__id ?? '' }),
+        [questionQueue?.enqueuedQuestions]
+    );
+
+    const classes = useStyles();
+
+    //
+    // ─── SUBSCRIPTION HOOKS ─────────────────────────────────────────────────────────
+    //
+    useRecordPush(recordConnection);
+    useRecordRemove(recordConnection);
+    useRecordUnshift(recordConnection);
+    useEnqueuedPush(enqueuedConnection);
+    useEnqueuedRemove(enqueuedConnection);
+    useEnqueuedUnshift(enqueuedConnection);
+
+    //
+    // ─── COMPUTED VALUES ────────────────────────────────────────────────────────────
+    //
+    const enqueuedQuestions = React.useMemo(
+        () =>
+            questionQueue?.enqueuedQuestions?.edges
+                ?.slice(0) // hacky way to copy the array, except current question -- feeling lazy TODO: more elegant solution
+                ?.sort(({ node: a }, { node: b }) => (a?.position ?? 0) - (b?.position ?? 0)) ?? [],
+        [questionQueue]
+    );
+    const questionRecord = React.useMemo(
+        () =>
+            questionQueue?.questionRecord?.edges
+                ?.slice(0) // hacky way to copy the array, except current question -- feeling lazy TODO: more elegant solution
+                ?.sort(({ node: a }, { node: b }) => (a?.position ?? 0) - (b?.position ?? 0)) ?? [],
+        [questionQueue]
+    );
+    const canGoBackward = React.useMemo(() => questionRecord.length > 0, [questionRecord]);
+    const canGoForward = React.useMemo(() => enqueuedQuestions.length > 0, [enqueuedQuestions]);
+    const currentQuestion = React.useMemo(
+        () => (questionRecord.length > 0 ? questionRecord[questionRecord.length - 1] : null),
+        [questionRecord]
+    );
+
+    return (
+        <>
+            { currentQuestion &&
+                <Card className={`${classes.item} ${classes.relative}`}>
+                    <Chip
+                        color='secondary'
+                        icon={<BookmarkIcon fontSize='small' />}
+                        label='Answering Now'
+                        className={classes.answeringNow}
+                    />
+                    <QuestionAuthor fragmentRef={currentQuestion.node} />
+                    <QuestionContent fragmentRef={currentQuestion.node} />
+                    <Grid container alignItems='center' justify='space-between' className={classes.currentQuestionActions}>
+                        <PreviousQuestionButton disabled={!canGoBackward} />
+                        <NextQuestionButton disabled={!canGoForward} />
+                    </Grid>
+
+                </Card>
+            }
+        </>
+    );
+}

--- a/app/client/src/features/events/Moderation/ManageQuestions/CurrentQuestionCard.tsx
+++ b/app/client/src/features/events/Moderation/ManageQuestions/CurrentQuestionCard.tsx
@@ -2,7 +2,6 @@
 import * as React from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import { Grid, Chip, Card } from '@material-ui/core';
-import { graphql } from 'react-relay';
 import BookmarkIcon from '@material-ui/icons/Bookmark';
 
 import type { useQuestionQueueFragment$key } from '@local/__generated__/useQuestionQueueFragment.graphql';
@@ -45,10 +44,11 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 interface QuestionQueueProps {
+    isViewerModerator: boolean;
     fragmentRef: useQuestionQueueFragment$key;
 }
 
-export function CurrentQuestionCard({ fragmentRef }: QuestionQueueProps) {
+export function CurrentQuestionCard({ isViewerModerator, fragmentRef }: QuestionQueueProps) {
     //
     // ─── HOOKS ──────────────────────────────────────────────────────────────────────
     //
@@ -110,10 +110,12 @@ export function CurrentQuestionCard({ fragmentRef }: QuestionQueueProps) {
                     />
                     <QuestionAuthor fragmentRef={currentQuestion.node} />
                     <QuestionContent fragmentRef={currentQuestion.node} />
-                    <Grid container alignItems='center' justify='space-between' className={classes.currentQuestionActions}>
-                        <PreviousQuestionButton disabled={!canGoBackward} />
-                        <NextQuestionButton disabled={!canGoForward} />
-                    </Grid>
+                    { isViewerModerator &&
+                        <Grid container alignItems='center' justify='space-between' className={classes.currentQuestionActions}>
+                            <PreviousQuestionButton disabled={!canGoBackward} />
+                            <NextQuestionButton disabled={!canGoForward} />
+                        </Grid>
+                    }
 
                 </Card>
             }

--- a/app/client/src/features/events/Moderation/ManageQuestions/QuestionQueue.tsx
+++ b/app/client/src/features/events/Moderation/ManageQuestions/QuestionQueue.tsx
@@ -98,7 +98,6 @@ type QuestionNode = ArrayElement<
 >;
 
 interface QuestionQueueProps {
-    handleQueueDisplay: (arg0: boolean) => void; // modifies boolean value if previous questions are currently displayed
     fragmentRef: useQuestionQueueFragment$key;
 }
 
@@ -199,7 +198,7 @@ function useStyledQueue({ eventId }: { eventId: string }) {
     return [reorder, getListStyle, itemStyle] as const;
 }
 
-export function QuestionQueue({ handleQueueDisplay, fragmentRef }: QuestionQueueProps) {
+export function QuestionQueue({ fragmentRef }: QuestionQueueProps) {
     //
     // ─── HOOKS ──────────────────────────────────────────────────────────────────────
     //
@@ -208,7 +207,6 @@ export function QuestionQueue({ handleQueueDisplay, fragmentRef }: QuestionQueue
     const handleQueueChange = (e: React.ChangeEvent<any>) => {
         e.preventDefault();
         setQueueIndex(e.target.value);
-        handleQueueDisplay(e.target.value === 1); // true if view shows previous questions
     };
     const { questionQueue, connections } = useQuestionQueue({ fragmentRef });
     const recordConnection = React.useMemo(

--- a/app/client/src/features/events/Moderation/ManageQuestions/QuestionQueue.tsx
+++ b/app/client/src/features/events/Moderation/ManageQuestions/QuestionQueue.tsx
@@ -378,7 +378,7 @@ export function QuestionQueue({ fragmentRef }: QuestionQueueProps) {
                 </>
                 :
                 <List>
-                    {prevFilteredList.map((question) => (
+                    {prevFilteredList.reverse().map((question) => (
                         <ListItem key={question.node.id} disableGutters>
                             <Card className={`${classes.item} ${classes.previousQuestion}`}>
                                 <QuestionAuthor fragmentRef={question.node} />

--- a/app/client/src/features/events/Moderation/ManageQuestions/QuestionQueue.tsx
+++ b/app/client/src/features/events/Moderation/ManageQuestions/QuestionQueue.tsx
@@ -256,10 +256,15 @@ export function QuestionQueue({ fragmentRef }: QuestionQueueProps) {
         () => (questionRecord.length > 0 ? questionRecord[questionRecord.length - 1] : null),
         [questionRecord]
     );
+    const prevQuestions = React.useMemo(
+        () => (questionRecord.length > 0 ? questionRecord.slice(0, -1) : []), // removes current question from display in tab for previous questions
+        [questionRecord]
+    );
     const nextQuestion = React.useMemo(
         () => (canGoForward ? enqueuedQuestions[0] : null),
         [canGoForward, enqueuedQuestions]
     );
+    
 
     //
     // ─── UTILITIES ──────────────────────────────────────────────────────────────────
@@ -290,7 +295,7 @@ export function QuestionQueue({ fragmentRef }: QuestionQueueProps) {
         []
     );
 
-    const prevAccessors = React.useMemo<Accessors<ArrayElement<typeof questionRecord>>[]>(
+    const prevAccessors = React.useMemo<Accessors<ArrayElement<typeof prevQuestions>>[]>(
         () => [
             (q) => q?.node.question || '', // question text itself
             (q) => q?.node.createdBy?.firstName || '', // first name of the user
@@ -299,7 +304,7 @@ export function QuestionQueue({ fragmentRef }: QuestionQueueProps) {
     );
 
     const [filteredList, handleSearch, handleFilterChange] = useFilters(enqueuedQuestions, accessors);
-    const [prevFilteredList, prevHandleSearch, prevHandleFilterChange] = useFilters(questionRecord, prevAccessors);
+    const [prevFilteredList, prevHandleSearch, prevHandleFilterChange] = useFilters(prevQuestions, prevAccessors);
 
     return (
         <>

--- a/app/client/src/features/events/Moderation/ManageQuestions/QuestionQueue.tsx
+++ b/app/client/src/features/events/Moderation/ManageQuestions/QuestionQueue.tsx
@@ -1,9 +1,10 @@
 /* eslint-disable @typescript-eslint/indent */
 import * as React from 'react';
 import { makeStyles, useTheme } from '@material-ui/core/styles';
-import { Select, MenuItem, Grid, Typography, Card, List, ListItem } from '@material-ui/core';
+import { Select, MenuItem, Grid, Typography, Card, List, ListItem, IconButton } from '@material-ui/core';
 import { graphql, useMutation } from 'react-relay';
 import { DragDropContext, DropResult } from 'react-beautiful-dnd';
+import FilterListIcon from '@material-ui/icons/FilterList';
 
 import type { QuestionQueueMutation } from '@local/__generated__/QuestionQueueMutation.graphql';
 import type {
@@ -27,35 +28,10 @@ import { QuestionActions } from '../../Questions/QuestionActions';
 import ListFilter, { useFilters, Accessors } from '@local/components/ListFilter';
 
 const useStyles = makeStyles((theme) => ({
-    root: {
-        marginBottom: theme.spacing(2),
-        padding: theme.spacing(2),
-        maxWidth: 700,
-    },
-    title: {
-        marginLeft: theme.spacing(2),
-        // fontSize: 14,
-    },
-    divider: {
-        margin: theme.spacing(2, 0),
-        width: '100%',
-    },
-    empty: {
-        margin: theme.spacing(5, 0),
-    },
     item: {
         width: '100%',
         paddingTop: theme.spacing(0.5),
         borderRadius: '10px'
-    },
-    dialogContent: {
-        '& > *': {
-            marginBottom: theme.spacing(2),
-        },
-    },
-    pastQuestionsContainer: {
-        padding: theme.spacing(2),
-        backgroundColor: theme.palette.secondary.main,
     },
     questionActions: {
         display: 'flex',
@@ -91,7 +67,7 @@ const useStyles = makeStyles((theme) => ({
         color: '#B5B5B5'
     },
     select: {
-        width: '8rem',
+        width: '7.5rem',
         height: 'min-content',
         textAlign: 'center',
         textTransform: 'uppercase',
@@ -109,8 +85,12 @@ const useStyles = makeStyles((theme) => ({
     },
     listFilter: {
         flex: 1,
-        marginLeft: theme.spacing(1)
+        marginLeft: theme.spacing(0.5)
     },
+    filterIcon: {
+        height: 'min-content',
+        marginLeft: theme.spacing(0.5)
+    }
 }));
 
 type QuestionNode = ArrayElement<
@@ -336,6 +316,10 @@ export function QuestionQueue({ fragmentRef }: QuestionQueueProps) {
                         Previous
                     </MenuItem>
                 </Select>
+                {/* TODO: add filter functionality */}
+                <IconButton className={classes.filterIcon}>
+                    <FilterListIcon />
+                </IconButton>
                 <ListFilter
                     className={classes.listFilter}
                     onFilterChange={queueIndex === 0 ? handleFilterChange : prevHandleFilterChange}

--- a/app/client/src/features/events/Moderation/ManageQuestions/QuestionQueue.tsx
+++ b/app/client/src/features/events/Moderation/ManageQuestions/QuestionQueue.tsx
@@ -388,6 +388,7 @@ export function QuestionQueue({ fragmentRef }: QuestionQueueProps) {
                         <ListItem key={question.node.id} disableGutters>
                             <Card className={`${classes.item} ${classes.previousQuestion}`}>
                                 <QuestionAuthor fragmentRef={question.node} />
+                                {question.node.refQuestion && <QuestionQuote fragmentRef={question.node.refQuestion} />}
                                 <QuestionContent fragmentRef={question.node} />
                                 <QuestionStats fragmentRef={question.node} />
                             </Card>

--- a/app/client/src/features/events/Moderation/ManageQuestions/QuestionQueue.tsx
+++ b/app/client/src/features/events/Moderation/ManageQuestions/QuestionQueue.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/indent */
 import * as React from 'react';
 import { makeStyles, useTheme } from '@material-ui/core/styles';
-import { Grid, Paper, Typography, Card, List, ListItem } from '@material-ui/core';
+import { Grid, Typography, Card, List, ListItem } from '@material-ui/core';
 import { graphql, useMutation } from 'react-relay';
 import { DragDropContext, DropResult } from 'react-beautiful-dnd';
 
@@ -15,7 +15,6 @@ import DropArea from '@local/components/DropArea';
 import { ArrayElement } from '@local/utils/ts-utils';
 import { QuestionAuthor, QuestionStats, QuestionContent, QuestionQuote } from '../../Questions';
 import { NextQuestionButton } from './NextQuestionButton';
-import { PreviousQuestionButton } from './PreviousQuestionButton';
 import { useEvent } from '../../useEvent';
 import { useQuestionQueue } from './useQuestionQueue';
 import { useRecordPush } from './useRecordPush';
@@ -43,16 +42,10 @@ const useStyles = makeStyles((theme) => ({
     empty: {
         margin: theme.spacing(5, 0),
     },
-    fullWidth: {
+    item: {
         width: '100%',
-    },
-    currentQuestionWrapper: {
-        backgroundColor: theme.palette.primary.main,
-        padding: theme.spacing(2),
-    },
-    currentQuestionTitle: {
-        marginBottom: theme.spacing(1),
-        color: 'white',
+        paddingTop: theme.spacing(0.5),
+        borderRadius: '10px'
     },
     dialogContent: {
         '& > *': {
@@ -69,15 +62,8 @@ const useStyles = makeStyles((theme) => ({
         padding: 'theme.spacing(1) 0',
         width: '10rem',
     },
-    cardFooter: {
-        alignItems: 'center',
-        justifyContent: 'space-between'
-    },
     filler: {
         visibility: 'hidden'
-    },
-    test: {
-        background: 'blue'
     },
     relative: {
         position: 'relative'
@@ -99,7 +85,7 @@ const useStyles = makeStyles((theme) => ({
         paddingBottom: theme.spacing(2),
         textAlign: 'center',
         color: '#B5B5B5'
-    }
+    },
 }));
 
 type QuestionNode = ArrayElement<
@@ -279,23 +265,6 @@ export function QuestionQueue({ fragmentRef }: QuestionQueueProps) {
 
     return (
         <>
-            <Grid container component={Paper} className={classes.root} justify='center' alignContent='flex-start'>
-                {currentQuestion && (
-                    <Card elevation={0} className={classes.fullWidth}>
-                        <QuestionAuthor fragmentRef={currentQuestion.node} />
-                        <QuestionContent fragmentRef={currentQuestion.node} />
-                    </Card>
-                )}
-                {!currentQuestion && (
-                    <Typography color='textSecondary' variant='body2' className={classes.empty}>
-                        There is no current question to display
-                    </Typography>
-                )}
-                <Grid container item justify='space-between'>
-                    <PreviousQuestionButton disabled={!canGoBackward} />
-                    <NextQuestionButton disabled={!canGoForward} variant='outlined' />
-                </Grid>
-            </Grid>
             <Grid className={classes.helperText}>
                 <Typography variant='caption'>
                     Drag and drop questions to re-order queue
@@ -319,10 +288,10 @@ export function QuestionQueue({ fragmentRef }: QuestionQueueProps) {
                                         className={classes.nextQuestion}
                                     />
                                 }
-                                <Card className={classes.fullWidth}>
+                                <Card className={classes.item}>
                                     <QuestionAuthor fragmentRef={question.node} />
                                     <QuestionContent fragmentRef={question.node} />
-                                    <Grid container className={classes.cardFooter}>
+                                    <Grid container alignItems='center' justify='space-between'>
                                         <QuestionStats fragmentRef={question.node} />
                                         <QuestionActions
                                             className={classes.questionActions}
@@ -345,7 +314,7 @@ export function QuestionQueue({ fragmentRef }: QuestionQueueProps) {
             <List>
                 {questionRecord.slice(0, -1).map((question) => (
                     <ListItem key={question.node.id} disableGutters>
-                        <Card className={classes.fullWidth}>
+                        <Card className={classes.item}>
                             <QuestionAuthor fragmentRef={question.node} />
                             <QuestionContent fragmentRef={question.node} />
                             <QuestionStats fragmentRef={question.node} />

--- a/app/client/src/features/events/Moderation/ManageQuestions/QuestionQueue.tsx
+++ b/app/client/src/features/events/Moderation/ManageQuestions/QuestionQueue.tsx
@@ -81,6 +81,9 @@ const useStyles = makeStyles((theme) => ({
             background: '#E6B035',
         }
     },
+    previousQuestion: {
+        paddingBottom: theme.spacing(2),
+    },
     helperText: {
         width: '100%',
         paddingBottom: theme.spacing(2),
@@ -393,7 +396,7 @@ export function QuestionQueue({ fragmentRef }: QuestionQueueProps) {
                 <List>
                     {questionRecord.slice(0, -1).filter(question => prevFilteredList.includes(question)).map((question) => (
                         <ListItem key={question.node.id} disableGutters>
-                            <Card className={classes.item}>
+                            <Card className={`${classes.item} ${classes.previousQuestion}`}>
                                 <QuestionAuthor fragmentRef={question.node} />
                                 <QuestionContent fragmentRef={question.node} />
                                 <QuestionStats fragmentRef={question.node} />

--- a/app/client/src/features/events/Moderation/ManageQuestions/QuestionQueue.tsx
+++ b/app/client/src/features/events/Moderation/ManageQuestions/QuestionQueue.tsx
@@ -336,7 +336,7 @@ export function QuestionQueue({ fragmentRef }: QuestionQueueProps) {
                     </Grid>
                     <DragDropContext onDragEnd={onDragEnd}>
                         <DropArea getStyle={getListStyle} droppableId='droppable'>
-                            {enqueuedQuestions.filter(question => filteredList.includes(question)).map((question, idx) => (
+                            {filteredList.map((question, idx) => (
                                 <DragArea
                                     getStyle={itemStyle}
                                     key={question.node.id}
@@ -378,7 +378,7 @@ export function QuestionQueue({ fragmentRef }: QuestionQueueProps) {
                 </>
                 :
                 <List>
-                    {questionRecord.slice(0, -1).filter(question => prevFilteredList.includes(question)).map((question) => (
+                    {prevFilteredList.map((question) => (
                         <ListItem key={question.node.id} disableGutters>
                             <Card className={`${classes.item} ${classes.previousQuestion}`}>
                                 <QuestionAuthor fragmentRef={question.node} />

--- a/app/client/src/features/events/Moderation/ManageQuestions/QuestionQueue.tsx
+++ b/app/client/src/features/events/Moderation/ManageQuestions/QuestionQueue.tsx
@@ -324,7 +324,7 @@ export function QuestionQueue({ handleQueueDisplay, fragmentRef }: QuestionQueue
                 </IconButton>
                 <ListFilter
                     className={classes.listFilter}
-                    onFilterChange={queueIndex === 0 ? handleFilterChange : prevHandleFilterChange}
+                    onFilterChange={queueIndex === 0 ? () => handleFilterChange : () => prevHandleFilterChange}
                     onSearch={queueIndex === 0 ? handleSearch : prevHandleSearch}
                     length={queueIndex === 0 ? filteredList.length : prevFilteredList.length}
                 />
@@ -356,6 +356,7 @@ export function QuestionQueue({ handleQueueDisplay, fragmentRef }: QuestionQueue
                                         }
                                         <Card className={classes.item}>
                                             <QuestionAuthor fragmentRef={question.node} />
+                                            {question.node.refQuestion && <QuestionQuote fragmentRef={question.node.refQuestion} />}
                                             <QuestionContent fragmentRef={question.node} />
                                             <Grid container alignItems='center' justify='space-between'>
                                                 <QuestionStats fragmentRef={question.node} />

--- a/app/client/src/features/events/Moderation/ManageQuestions/QuestionQueue.tsx
+++ b/app/client/src/features/events/Moderation/ManageQuestions/QuestionQueue.tsx
@@ -98,6 +98,7 @@ type QuestionNode = ArrayElement<
 >;
 
 interface QuestionQueueProps {
+    handleQueueDisplay: (arg0: boolean) => void; // modifies boolean value if previous questions are currently displayed
     fragmentRef: useQuestionQueueFragment$key;
 }
 
@@ -198,7 +199,7 @@ function useStyledQueue({ eventId }: { eventId: string }) {
     return [reorder, getListStyle, itemStyle] as const;
 }
 
-export function QuestionQueue({ fragmentRef }: QuestionQueueProps) {
+export function QuestionQueue({ handleQueueDisplay, fragmentRef }: QuestionQueueProps) {
     //
     // ─── HOOKS ──────────────────────────────────────────────────────────────────────
     //
@@ -207,6 +208,7 @@ export function QuestionQueue({ fragmentRef }: QuestionQueueProps) {
     const handleQueueChange = (e: React.ChangeEvent<any>) => {
         e.preventDefault();
         setQueueIndex(e.target.value);
+        handleQueueDisplay(e.target.value === 1); // true if view shows previous questions
     };
     const { questionQueue, connections } = useQuestionQueue({ fragmentRef });
     const recordConnection = React.useMemo(

--- a/app/client/src/features/events/Moderation/ManageQuestions/useQuestionQueue.ts
+++ b/app/client/src/features/events/Moderation/ManageQuestions/useQuestionQueue.ts
@@ -31,6 +31,7 @@ export const USE_QUESTION_QUEUE_FRAGMENT = graphql`
                     cursor
                     node {
                         id
+                        ...QuestionActionsFragment
                         ...QuestionAuthorFragment
                         ...QuestionStatsFragment
                         ...QuestionContentFragment
@@ -47,5 +48,5 @@ export const USE_QUESTION_QUEUE_FRAGMENT = graphql`
 
 export function useQuestionQueue({ fragmentRef }: { fragmentRef: useQuestionQueueFragment$key }) {
     const { questionQueue } = useFragment(USE_QUESTION_QUEUE_FRAGMENT, fragmentRef);
-    return questionQueue;
+    return { questionQueue, connections: questionQueue?.enqueuedQuestions?.__id ? [questionQueue.enqueuedQuestions.__id] : [] };
 }

--- a/app/client/src/features/events/Moderation/ManageQuestions/useQuestionQueue.ts
+++ b/app/client/src/features/events/Moderation/ManageQuestions/useQuestionQueue.ts
@@ -14,6 +14,10 @@ export const USE_QUESTION_QUEUE_FRAGMENT = graphql`
                     cursor
                     node {
                         id
+                        question
+                        createdBy {
+                            firstName
+                        }
                         ...QuestionAuthorFragment
                         ...QuestionStatsFragment
                         ...QuestionContentFragment
@@ -31,6 +35,10 @@ export const USE_QUESTION_QUEUE_FRAGMENT = graphql`
                     cursor
                     node {
                         id
+                        question
+                        createdBy {
+                            firstName
+                        }
                         ...QuestionActionsFragment
                         ...QuestionAuthorFragment
                         ...QuestionStatsFragment

--- a/app/client/src/features/events/Questions/QuestionActions/DequeueQuestionButton.tsx
+++ b/app/client/src/features/events/Questions/QuestionActions/DequeueQuestionButton.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Button } from '@material-ui/core';
-import RemoveFromQueueIcon from '@material-ui/icons/RemoveFromQueue';
+import CancelIcon from '@material-ui/icons/Cancel';
 import { graphql, useMutation } from 'react-relay';
 
 import type { DequeueQuestionButtonMutation } from '@local/__generated__/DequeueQuestionButtonMutation.graphql';
@@ -50,7 +50,7 @@ export function DequeueQuestionButton({ questionId }: QueueButtonProps) {
         });
     };
     return (
-        <Button fullWidth color='secondary' endIcon={<RemoveFromQueueIcon fontSize='small' />} onClick={handleClick}>
+        <Button fullWidth color='secondary' endIcon={<CancelIcon fontSize='small' />} onClick={handleClick}>
             Dequeue
         </Button>
     );

--- a/app/client/src/features/events/Questions/QuestionActions/EnqueueQuestionButton.tsx
+++ b/app/client/src/features/events/Questions/QuestionActions/EnqueueQuestionButton.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Button } from '@material-ui/core';
-import QueueIcon from '@material-ui/icons/QueueOutlined';
+import AddCircleIcon from '@material-ui/icons/AddCircle';
 import { graphql, useMutation } from 'react-relay';
 
 import type { EnqueueQuestionButtonMutation } from '@local/__generated__/EnqueueQuestionButtonMutation.graphql';
@@ -58,7 +58,7 @@ export function EnqueueQuestionButton({ questionId }: QueueButtonProps) {
         });
     };
     return (
-        <Button fullWidth endIcon={<QueueIcon fontSize='small' />} onClick={handleClick}>
+        <Button fullWidth endIcon={<AddCircleIcon fontSize='small' />} onClick={handleClick}>
             Enqueue
         </Button>
     );

--- a/app/client/src/features/events/Questions/QuestionActions/Like.tsx
+++ b/app/client/src/features/events/Questions/QuestionActions/Like.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Button } from '@material-ui/core';
-import ThumbUpIcon from '@material-ui/icons/ThumbUpOutlined';
+import ThumbUp from '@material-ui/icons/ThumbUp';
 import { graphql, useMutation, useFragment } from 'react-relay';
 
 import type { LikeMutation } from '@local/__generated__/LikeMutation.graphql';
@@ -52,7 +52,7 @@ export function Like({ className = undefined, fragmentRef }: Props) {
         <Button
             color={isLikedByViewer ? 'secondary' : 'inherit'}
             onClick={handleClick}
-            endIcon={<ThumbUpIcon fontSize='small' />}
+            endIcon={<ThumbUp fontSize='small' />}
             fullWidth
             className={className}
         >

--- a/app/client/src/features/events/Questions/QuestionActions/Quote.tsx
+++ b/app/client/src/features/events/Questions/QuestionActions/Quote.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Button, DialogContent, Card } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
-import QuoteIcon from '@material-ui/icons/FormatQuoteOutlined';
+import FormatQuoteIcon from '@material-ui/icons/FormatQuote';
 import { graphql, useMutation, useFragment } from 'react-relay';
 
 import type { QuoteFragment$key } from '@local/__generated__/QuoteFragment.graphql';
@@ -92,7 +92,7 @@ export function Quote({ className, connections, fragmentRef }: QuoteProps) {
             <Button
                 color='inherit'
                 onClick={open}
-                endIcon={<QuoteIcon fontSize='small' />}
+                endIcon={<FormatQuoteIcon fontSize='small' />}
                 fullWidth
                 className={className}
             >

--- a/app/client/src/features/events/Questions/QuestionAuthor.tsx
+++ b/app/client/src/features/events/Questions/QuestionAuthor.tsx
@@ -40,14 +40,23 @@ export function QuestionAuthor({ fragmentRef, ...props }: QuestionAuthorProps) {
         ),
         [time, month]
     );
+    // make author name given available data
+    const createAuthorName = () => {
+        let authorName = '';
+        if (authorData.createdBy) {
+            authorName += authorData.createdBy.firstName;
+            if (authorData.createdBy.lastName) { authorName += ' ' + authorData.createdBy.lastName; }
+        }
+        else { authorName = 'Unknown User'; }
+        return authorName
+    };
+    const authorName = createAuthorName();
+    
     return (
         <CardHeader
-            avatar={
-                <Avatar>
-                    {authorData.createdBy?.firstName ? authorData.createdBy?.firstName[0] : 'U'}
-                </Avatar>
-            }
-            title={<Typography>{(authorData.createdBy?.firstName + ' ' + authorData.createdBy?.lastName) ?? 'Unknown User'}</Typography>}
+            // get first letter of name to display
+            avatar={<Avatar>{authorName[0]}</Avatar>}
+            title={<Typography>{authorName}</Typography>}
             subheader={subheader}
             {...props}
         />

--- a/app/client/src/features/events/Questions/QuestionAuthor.tsx
+++ b/app/client/src/features/events/Questions/QuestionAuthor.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { Typography, CardHeader, CardHeaderProps } from '@material-ui/core';
+import { Avatar, Typography, CardHeader, CardHeaderProps } from '@material-ui/core';
 import { graphql, useFragment } from 'react-relay';
 
 import type { QuestionAuthorFragment$key } from '@local/__generated__/QuestionAuthorFragment.graphql';
@@ -14,6 +14,7 @@ export const QUESTION_AUTHOR_FRAGMENT = graphql`
         createdBy {
             id
             firstName
+            lastName
             avatar
         }
         createdAt
@@ -41,7 +42,12 @@ export function QuestionAuthor({ fragmentRef, ...props }: QuestionAuthorProps) {
     );
     return (
         <CardHeader
-            title={<Typography>{authorData.createdBy?.firstName ?? 'Unknown User'}</Typography>}
+            avatar={
+                <Avatar>
+                    {authorData.createdBy?.firstName ? authorData.createdBy?.firstName[0] : 'U'}
+                </Avatar>
+            }
+            title={<Typography>{(authorData.createdBy?.firstName + ' ' + authorData.createdBy?.lastName) ?? 'Unknown User'}</Typography>}
             subheader={subheader}
             {...props}
         />

--- a/app/client/src/features/events/Questions/QuestionCarousel/QuestionCarousel.tsx
+++ b/app/client/src/features/events/Questions/QuestionCarousel/QuestionCarousel.tsx
@@ -130,7 +130,7 @@ export function QuestionCarousel({ fragmentRef }: QuestionCarouselProps) {
                     <ChevronLeft />
                 </IconButton>
                 <Button onClick={() => dispatch({ type: 'goToCurrent' })} className={classes.btn}>
-                    {state.idx === state.currQuestionIdx ? 'Answering Now' : 'Go To Current'}
+                    {state.idx === state.currQuestionIdx ? 'Upcoming Question' : 'Go To Current'}
                 </Button>
                 <IconButton
                     disabled={state.currQuestionIdx === state.idx || state.idx === -1}

--- a/app/client/src/features/events/Questions/QuestionContent.tsx
+++ b/app/client/src/features/events/Questions/QuestionContent.tsx
@@ -1,5 +1,6 @@
 import { graphql, useFragment } from 'react-relay';
 import { CardContent, CardContentProps, Typography, TypographyProps } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
 
 import type { QuestionContentFragment$key } from '@local/__generated__/QuestionContentFragment.graphql';
 
@@ -14,11 +15,18 @@ export const QUESTION_CONTENT_FRAGMENT = graphql`
     }
 `;
 
+const useStyles = makeStyles((theme) => ({
+    content: {
+        margin: '-0.5rem 0'
+    },
+}));
+
 export function QuestionContent({ fragmentRef, typographyProps = {}, ...props }: QuestionContentProps) {
     const questionContentData = useFragment(QUESTION_CONTENT_FRAGMENT, fragmentRef);
+    const classes = useStyles();
     return (
-        <CardContent {...props}>
-            <Typography style={{ wordBreak: 'break-word' }} {...typographyProps}>{questionContentData.question}</Typography>
+        <CardContent {...props} className={classes.content}>
+            <Typography variant='inherit' style={{ wordBreak: 'break-word' }} {...typographyProps}>{questionContentData.question}</Typography>
         </CardContent>
     );
 }

--- a/app/client/src/features/events/Questions/QuestionContent.tsx
+++ b/app/client/src/features/events/Questions/QuestionContent.tsx
@@ -17,7 +17,7 @@ export const QUESTION_CONTENT_FRAGMENT = graphql`
 
 const useStyles = makeStyles((theme) => ({
     content: {
-        margin: '-0.5rem 0'
+        margin: theme.spacing(-2, 0, -1, 0)
     },
 }));
 

--- a/app/client/src/features/events/Questions/QuestionList/QuestionList.tsx
+++ b/app/client/src/features/events/Questions/QuestionList/QuestionList.tsx
@@ -42,7 +42,6 @@ const useStyles = makeStyles((theme) => ({
     questionActions: {
         display: 'flex',
         justifyContent: 'center',
-        padding: 'theme.spacing(1) 0',
     },
     item: {
         flex: 1,

--- a/app/client/src/features/events/Questions/QuestionList/QuestionList.tsx
+++ b/app/client/src/features/events/Questions/QuestionList/QuestionList.tsx
@@ -48,10 +48,8 @@ const useStyles = makeStyles((theme) => ({
         flex: 1,
         display: 'flex',
         flexDirection: 'column',
-    },
-    cardFooter: {
-        alignItems: 'center',
-        justifyContent: 'space-between'
+        paddingTop: theme.spacing(0.5),
+        borderRadius: '10px'
     },
     filler: {
         visibility: 'hidden'
@@ -110,7 +108,7 @@ export function QuestionList({ className, style, fragmentRef }: Props) {
                                         <QuestionAuthor fragmentRef={question} />
                                         {question.refQuestion && <QuestionQuote fragmentRef={question.refQuestion} />}
                                         <QuestionContent fragmentRef={question} />
-                                        <Grid container className={classes.cardFooter}>
+                                        <Grid container alignItems='center' justify='space-between'>
                                             {isModerator && <QuestionStats fragmentRef={question} />}
                                             <QuestionActions
                                                 style={

--- a/app/client/src/features/events/Questions/QuestionList/QuestionList.tsx
+++ b/app/client/src/features/events/Questions/QuestionList/QuestionList.tsx
@@ -40,14 +40,22 @@ const useStyles = makeStyles((theme) => ({
         flex: '1 1 100%',
     },
     questionActions: {
-        padding: 0,
-        color: theme.palette.primary.light,
+        display: 'flex',
+        justifyContent: 'center',
+        padding: 'theme.spacing(1) 0',
     },
     item: {
         flex: 1,
         display: 'flex',
         flexDirection: 'column',
     },
+    cardFooter: {
+        alignItems: 'center',
+        justifyContent: 'space-between'
+    },
+    filler: {
+        visibility: 'hidden'
+    }
 }));
 
 export function QuestionList({ className, style, fragmentRef }: Props) {
@@ -102,15 +110,27 @@ export function QuestionList({ className, style, fragmentRef }: Props) {
                                         <QuestionAuthor fragmentRef={question} />
                                         {question.refQuestion && <QuestionQuote fragmentRef={question.refQuestion} />}
                                         <QuestionContent fragmentRef={question} />
-                                        {isModerator && <QuestionStats fragmentRef={question} />}
-                                        <QuestionActions
-                                            className={classes.questionActions}
-                                            like={!isModerator && Boolean(user)}
-                                            quote={!isModerator && Boolean(user)}
-                                            queue={isModerator && Boolean(user)}
-                                            connections={connections}
-                                            fragmentRef={question}
-                                        />
+                                        <Grid container className={classes.cardFooter}>
+                                            {isModerator && <QuestionStats fragmentRef={question} />}
+                                            <QuestionActions
+                                                style={
+                                                    !isModerator 
+                                                        ? { width: '100%'} 
+                                                        : { width: '100%', maxWidth: '10rem'}
+                                                }
+                                                className={classes.questionActions}
+                                                like={!isModerator && Boolean(user)}
+                                                quote={!isModerator && Boolean(user)}
+                                                queue={isModerator && Boolean(user)}
+                                                connections={connections}
+                                                fragmentRef={question}
+                                            />
+                                            {isModerator && // filler to justify moderator queue button
+                                                <span className={classes.filler}>
+                                                    <QuestionStats fragmentRef={question} />
+                                                </span>
+                                            }
+                                        </Grid>
                                     </Card>
                                 </ListItem>
                             ))}

--- a/app/client/src/features/events/Questions/QuestionStats.tsx
+++ b/app/client/src/features/events/Questions/QuestionStats.tsx
@@ -1,8 +1,17 @@
 import { graphql, useFragment } from 'react-relay';
-import { Badge, CardContent } from '@material-ui/core';
+import { Typography, CardContent } from '@material-ui/core';
 import ThumbUp from '@material-ui/icons/ThumbUp';
+import { makeStyles } from '@material-ui/core/styles';
 
 import type { QuestionStatsFragment$key } from '@local/__generated__/QuestionStatsFragment.graphql';
+
+const useStyles = makeStyles((theme) => ({
+    stats: {
+        display: 'flex',
+        gap: theme.spacing(0.5),
+        alignItems: 'center'
+    },
+}));
 
 export interface QuestionStatsProps {
     fragmentRef: QuestionStatsFragment$key;
@@ -17,12 +26,12 @@ export const QUESTION_STATS_FRAGMENT = graphql`
 
 export function QuestionStats({ fragmentRef }: QuestionStatsProps) {
     const data = useFragment(QUESTION_STATS_FRAGMENT, fragmentRef);
+    const classes = useStyles();
 
     return (
-        <CardContent>
-            <Badge showZero badgeContent={data.likedByCount}>
-                <ThumbUp color='disabled' />
-            </Badge>
+        <CardContent className={classes.stats}>
+            <ThumbUp fontSize='small' htmlColor='#8EAFFF' />
+            <Typography>{data.likedByCount}</Typography>
         </CardContent>
     );
 }

--- a/app/client/src/features/events/Questions/QuestionStats.tsx
+++ b/app/client/src/features/events/Questions/QuestionStats.tsx
@@ -9,7 +9,11 @@ const useStyles = makeStyles((theme) => ({
     stats: {
         display: 'flex',
         gap: theme.spacing(0.5),
-        alignItems: 'center'
+        alignItems: 'center',
+        width: 'min-content', // minimized width and height since the icon had too much of a height difference to buttons
+        height: 'min-content',
+        paddingTop: 0,
+        paddingBottom: '0 !important' // added !important for filler icon (for some reason, CSS wasn't being applied)
     },
 }));
 

--- a/app/client/src/features/events/Questions/QuestionStats.tsx
+++ b/app/client/src/features/events/Questions/QuestionStats.tsx
@@ -15,6 +15,9 @@ const useStyles = makeStyles((theme) => ({
         paddingTop: 0,
         paddingBottom: '0 !important' // added !important for filler icon (for some reason, CSS wasn't being applied)
     },
+    icon: {
+        color: theme.palette.custom.lightBlue
+    }
 }));
 
 export interface QuestionStatsProps {
@@ -34,7 +37,7 @@ export function QuestionStats({ fragmentRef }: QuestionStatsProps) {
 
     return (
         <CardContent className={classes.stats}>
-            <ThumbUp fontSize='small' htmlColor='#8EAFFF' />
+            <ThumbUp fontSize='small' className={classes.icon} />
             <Typography>{data.likedByCount}</Typography>
         </CardContent>
     );


### PR DESCRIPTION
<!-- Please follow the provided template -->
### 1. Please briefly explain what it is you coded
Restyled question list and queue based on Figma design.

Nodes referenced:
- [Question queue](https://www.figma.com/file/UPYJBD7iZboz6nFtLk2MOa/Prytaneum-Recreation?node-id=977%3A1398)
- [Question list](https://www.figma.com/file/UPYJBD7iZboz6nFtLk2MOa/Prytaneum-Recreation?node-id=986%3A2050) (Note that I didn't add a play/pause button since I was unsure of how it would function and I thought it would be a different feature to be done in a separate PR)

### 2. Please briefly explain your approach (new components added? modified? removed?)
Use a combination of Material UI components to restyle question list and queue. Modified some mutations to allow variables to be used in certain components (i.e. last name for question cards, enqueue/dequeue functionality for upcoming questions, etc.) Created a separate component for the current question to be displayed at the top of the event sidebar.

### 3. Any packages added/updated/removed
N/A

### (Optional) 4. Any feature recommendations/insights/questions/comments/etc.?