### PR TITLE
Event UI: Question/Feedback Forms

### DIFF
--- a/app/client/src/__generated__/LiveFeedbackDialogMutation.graphql.ts
+++ b/app/client/src/__generated__/LiveFeedbackDialogMutation.graphql.ts
@@ -4,18 +4,17 @@
 
 import { ConcreteRequest } from "relay-runtime";
 
-export type CreateQuestion = {
+export type CreateFeedback = {
     eventId: string;
-    isFollowUp?: boolean | null | undefined;
-    isQuote?: boolean | null | undefined;
-    question: string;
-    refQuestion?: string | null | undefined;
+    isReply?: boolean | null | undefined;
+    message: string;
+    refFeedbackId?: string | null | undefined;
 };
-export type AskQuestionMutationVariables = {
-    input: CreateQuestion;
+export type LiveFeedbackDialogMutationVariables = {
+    input: CreateFeedback;
 };
-export type AskQuestionMutationResponse = {
-    readonly createQuestion: {
+export type LiveFeedbackDialogMutationResponse = {
+    readonly createFeedback: {
         readonly isError: boolean;
         readonly message: string;
         readonly body: {
@@ -23,7 +22,7 @@ export type AskQuestionMutationResponse = {
             readonly node: {
                 readonly id: string;
                 readonly createdAt: Date | null;
-                readonly question: string | null;
+                readonly message: string;
                 readonly createdBy: {
                     readonly id: string;
                     readonly firstName: string | null;
@@ -31,20 +30,20 @@ export type AskQuestionMutationResponse = {
                 } | null;
             };
         } | null;
-    };
+    } | null;
 };
-export type AskQuestionMutation = {
-    readonly response: AskQuestionMutationResponse;
-    readonly variables: AskQuestionMutationVariables;
+export type LiveFeedbackDialogMutation = {
+    readonly response: LiveFeedbackDialogMutationResponse;
+    readonly variables: LiveFeedbackDialogMutationVariables;
 };
 
 
 
 /*
-mutation AskQuestionMutation(
-  $input: CreateQuestion!
+mutation LiveFeedbackDialogMutation(
+  $input: CreateFeedback!
 ) {
-  createQuestion(input: $input) {
+  createFeedback(input: $input) {
     isError
     message
     body {
@@ -52,7 +51,7 @@ mutation AskQuestionMutation(
       node {
         id
         createdAt
-        question
+        message
         createdBy {
           id
           firstName
@@ -76,10 +75,17 @@ v1 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
+  "name": "message",
+  "storageKey": null
+},
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v2 = [
+v3 = [
   {
     "alias": null,
     "args": [
@@ -89,9 +95,9 @@ v2 = [
         "variableName": "input"
       }
     ],
-    "concreteType": "EventQuestionMutationResponse",
+    "concreteType": "EventFeedbackMutationResponse",
     "kind": "LinkedField",
-    "name": "createQuestion",
+    "name": "createFeedback",
     "plural": false,
     "selections": [
       {
@@ -101,17 +107,11 @@ v2 = [
         "name": "isError",
         "storageKey": null
       },
+      (v1/*: any*/),
       {
         "alias": null,
         "args": null,
-        "kind": "ScalarField",
-        "name": "message",
-        "storageKey": null
-      },
-      {
-        "alias": null,
-        "args": null,
-        "concreteType": "EventQuestionEdge",
+        "concreteType": "EventLiveFeedbackEdge",
         "kind": "LinkedField",
         "name": "body",
         "plural": false,
@@ -126,12 +126,12 @@ v2 = [
           {
             "alias": null,
             "args": null,
-            "concreteType": "EventQuestion",
+            "concreteType": "EventLiveFeedback",
             "kind": "LinkedField",
             "name": "node",
             "plural": false,
             "selections": [
-              (v1/*: any*/),
+              (v2/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -139,13 +139,7 @@ v2 = [
                 "name": "createdAt",
                 "storageKey": null
               },
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "question",
-                "storageKey": null
-              },
+              (v1/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -154,7 +148,7 @@ v2 = [
                 "name": "createdBy",
                 "plural": false,
                 "selections": [
-                  (v1/*: any*/),
+                  (v2/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -187,8 +181,8 @@ return {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Fragment",
     "metadata": null,
-    "name": "AskQuestionMutation",
-    "selections": (v2/*: any*/),
+    "name": "LiveFeedbackDialogMutation",
+    "selections": (v3/*: any*/),
     "type": "Mutation",
     "abstractKey": null
   },
@@ -196,18 +190,18 @@ return {
   "operation": {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Operation",
-    "name": "AskQuestionMutation",
-    "selections": (v2/*: any*/)
+    "name": "LiveFeedbackDialogMutation",
+    "selections": (v3/*: any*/)
   },
   "params": {
-    "cacheID": "d00f5cead282251c8c50d706a2b7819c",
+    "cacheID": "0fd65316097a0c3286b26d5731454620",
     "id": null,
     "metadata": {},
-    "name": "AskQuestionMutation",
+    "name": "LiveFeedbackDialogMutation",
     "operationKind": "mutation",
-    "text": "mutation AskQuestionMutation(\n  $input: CreateQuestion!\n) {\n  createQuestion(input: $input) {\n    isError\n    message\n    body {\n      cursor\n      node {\n        id\n        createdAt\n        question\n        createdBy {\n          id\n          firstName\n          lastName\n        }\n      }\n    }\n  }\n}\n"
+    "text": "mutation LiveFeedbackDialogMutation(\n  $input: CreateFeedback!\n) {\n  createFeedback(input: $input) {\n    isError\n    message\n    body {\n      cursor\n      node {\n        id\n        createdAt\n        message\n        createdBy {\n          id\n          firstName\n          lastName\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();
-(node as any).hash = '12c8dcac98bfb6588516e97ac05305e3';
+(node as any).hash = '53578347c2e1adc77d260d62d39abf16';
 export default node;

--- a/app/client/src/__generated__/QuestionDialogMutation.graphql.ts
+++ b/app/client/src/__generated__/QuestionDialogMutation.graphql.ts
@@ -4,17 +4,18 @@
 
 import { ConcreteRequest } from "relay-runtime";
 
-export type CreateFeedback = {
+export type CreateQuestion = {
     eventId: string;
-    isReply?: boolean | null | undefined;
-    message: string;
-    refFeedbackId?: string | null | undefined;
+    isFollowUp?: boolean | null | undefined;
+    isQuote?: boolean | null | undefined;
+    question: string;
+    refQuestion?: string | null | undefined;
 };
-export type SubmitLiveFeedbackMutationVariables = {
-    input: CreateFeedback;
+export type QuestionDialogMutationVariables = {
+    input: CreateQuestion;
 };
-export type SubmitLiveFeedbackMutationResponse = {
-    readonly createFeedback: {
+export type QuestionDialogMutationResponse = {
+    readonly createQuestion: {
         readonly isError: boolean;
         readonly message: string;
         readonly body: {
@@ -22,7 +23,7 @@ export type SubmitLiveFeedbackMutationResponse = {
             readonly node: {
                 readonly id: string;
                 readonly createdAt: Date | null;
-                readonly message: string;
+                readonly question: string | null;
                 readonly createdBy: {
                     readonly id: string;
                     readonly firstName: string | null;
@@ -30,20 +31,20 @@ export type SubmitLiveFeedbackMutationResponse = {
                 } | null;
             };
         } | null;
-    } | null;
+    };
 };
-export type SubmitLiveFeedbackMutation = {
-    readonly response: SubmitLiveFeedbackMutationResponse;
-    readonly variables: SubmitLiveFeedbackMutationVariables;
+export type QuestionDialogMutation = {
+    readonly response: QuestionDialogMutationResponse;
+    readonly variables: QuestionDialogMutationVariables;
 };
 
 
 
 /*
-mutation SubmitLiveFeedbackMutation(
-  $input: CreateFeedback!
+mutation QuestionDialogMutation(
+  $input: CreateQuestion!
 ) {
-  createFeedback(input: $input) {
+  createQuestion(input: $input) {
     isError
     message
     body {
@@ -51,7 +52,7 @@ mutation SubmitLiveFeedbackMutation(
       node {
         id
         createdAt
-        message
+        question
         createdBy {
           id
           firstName
@@ -75,17 +76,10 @@ v1 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "message",
-  "storageKey": null
-},
-v2 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v3 = [
+v2 = [
   {
     "alias": null,
     "args": [
@@ -95,9 +89,9 @@ v3 = [
         "variableName": "input"
       }
     ],
-    "concreteType": "EventFeedbackMutationResponse",
+    "concreteType": "EventQuestionMutationResponse",
     "kind": "LinkedField",
-    "name": "createFeedback",
+    "name": "createQuestion",
     "plural": false,
     "selections": [
       {
@@ -107,11 +101,17 @@ v3 = [
         "name": "isError",
         "storageKey": null
       },
-      (v1/*: any*/),
       {
         "alias": null,
         "args": null,
-        "concreteType": "EventLiveFeedbackEdge",
+        "kind": "ScalarField",
+        "name": "message",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "EventQuestionEdge",
         "kind": "LinkedField",
         "name": "body",
         "plural": false,
@@ -126,12 +126,12 @@ v3 = [
           {
             "alias": null,
             "args": null,
-            "concreteType": "EventLiveFeedback",
+            "concreteType": "EventQuestion",
             "kind": "LinkedField",
             "name": "node",
             "plural": false,
             "selections": [
-              (v2/*: any*/),
+              (v1/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -139,7 +139,13 @@ v3 = [
                 "name": "createdAt",
                 "storageKey": null
               },
-              (v1/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "question",
+                "storageKey": null
+              },
               {
                 "alias": null,
                 "args": null,
@@ -148,7 +154,7 @@ v3 = [
                 "name": "createdBy",
                 "plural": false,
                 "selections": [
-                  (v2/*: any*/),
+                  (v1/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -181,8 +187,8 @@ return {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Fragment",
     "metadata": null,
-    "name": "SubmitLiveFeedbackMutation",
-    "selections": (v3/*: any*/),
+    "name": "QuestionDialogMutation",
+    "selections": (v2/*: any*/),
     "type": "Mutation",
     "abstractKey": null
   },
@@ -190,18 +196,18 @@ return {
   "operation": {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Operation",
-    "name": "SubmitLiveFeedbackMutation",
-    "selections": (v3/*: any*/)
+    "name": "QuestionDialogMutation",
+    "selections": (v2/*: any*/)
   },
   "params": {
-    "cacheID": "b1390731fc095265360c3aadf82c2aa5",
+    "cacheID": "21f2dd9d5acd685c8446ea89974d0417",
     "id": null,
     "metadata": {},
-    "name": "SubmitLiveFeedbackMutation",
+    "name": "QuestionDialogMutation",
     "operationKind": "mutation",
-    "text": "mutation SubmitLiveFeedbackMutation(\n  $input: CreateFeedback!\n) {\n  createFeedback(input: $input) {\n    isError\n    message\n    body {\n      cursor\n      node {\n        id\n        createdAt\n        message\n        createdBy {\n          id\n          firstName\n          lastName\n        }\n      }\n    }\n  }\n}\n"
+    "text": "mutation QuestionDialogMutation(\n  $input: CreateQuestion!\n) {\n  createQuestion(input: $input) {\n    isError\n    message\n    body {\n      cursor\n      node {\n        id\n        createdAt\n        question\n        createdBy {\n          id\n          firstName\n          lastName\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();
-(node as any).hash = 'f5314b45540745841310fd8a809d1b87';
+(node as any).hash = '28eef0dd4276b1f1cb82758a031d2353';
 export default node;

--- a/app/client/src/components/ResponsiveDialog/ResponsiveDialog.tsx
+++ b/app/client/src/components/ResponsiveDialog/ResponsiveDialog.tsx
@@ -33,6 +33,7 @@ const Transition = React.forwardRef(function Transition(props: SlideProps, ref: 
 export type ResponsiveDialogProps = {
     title?: string;
     toolbar?: React.ReactElement;
+    currDialog?: string;
     onClose?: () => void;
 } & DialogProps;
 
@@ -79,6 +80,21 @@ export function useResponsiveDialog(initialState?: boolean) {
 
     // tuple state first, then helper functions -- order based on probable usage ie open/close will be used more than toggle
     return [isOpen, open, close, toggle] as const;
+}
+
+/**
+ * Helper hook for using linked dialogs
+ */
+export function useLinkedResponsiveDialog() {
+    // dialog state
+    const [openDialog, setState] = React.useState('');
+
+    // helper functions
+    const open = React.useCallback((currDialog?: string) => setState(currDialog || ''), [setState]);
+    const close = React.useCallback(() => setState(''), [setState]);
+
+    // tuple state first, then helper functions -- order based on probable usage ie open/close will be used more than toggle
+    return [openDialog, open, close] as const;
 }
 
 ResponsiveDialog.defaultProps = {

--- a/app/client/src/components/ResponsiveDialog/ResponsiveDialog.tsx
+++ b/app/client/src/components/ResponsiveDialog/ResponsiveDialog.tsx
@@ -82,17 +82,17 @@ export function useResponsiveDialog(initialState?: boolean) {
 }
 
 /**
- * Helper hook for using linked dialogs
+ * Helper hook for using linked dialogs (one dialog that can be used to open another)
  */
 export function useLinkedResponsiveDialog() {
-    // dialog state
+    // dialog state -- openDialog is the id of the current dialog that is open
     const [openDialog, setState] = React.useState('');
 
     // helper functions
     const open = React.useCallback((currDialog?: string) => setState(currDialog || ''), [setState]);
     const close = React.useCallback(() => setState(''), [setState]);
 
-    // tuple state first, then helper functions -- order based on probable usage ie open/close will be used more than toggle
+    // tuple state first, then helper functions
     return [openDialog, open, close] as const;
 }
 

--- a/app/client/src/components/ResponsiveDialog/ResponsiveDialog.tsx
+++ b/app/client/src/components/ResponsiveDialog/ResponsiveDialog.tsx
@@ -33,7 +33,6 @@ const Transition = React.forwardRef(function Transition(props: SlideProps, ref: 
 export type ResponsiveDialogProps = {
     title?: string;
     toolbar?: React.ReactElement;
-    currDialog?: string;
     onClose?: () => void;
 } & DialogProps;
 

--- a/app/client/src/features/events/EventSidebar/EventSidebar.tsx
+++ b/app/client/src/features/events/EventSidebar/EventSidebar.tsx
@@ -95,18 +95,27 @@ export const EventSidebar = ({ fragmentRef }: EventSidebarProps) => {
     const data = useFragment(EVENT_SIDEBAR_FRAGMENT, fragmentRef);
     const [openDialog, open, close] = useLinkedResponsiveDialog();
 
+    // create dialog ids using a combination of the eventId and actual dialog title
+    const feedbackDialogId = data.id + '-feedback';
+    const questionDialogId = data.id + '-question';
+
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const handleTabChange = (e: React.ChangeEvent<any>, newTabIndex: number) => {
         e.preventDefault();
         setTabIndex(newTabIndex);
     };
 
-    const handleOpenLinkedFeedbackForm = () => {
-        open('feedback');
+    // helper functions to open linked dialog within initially opened dialog
+    const handleOpenLinkedFeedbackDialog = () => {
+        // open feedback dialog from question dialog
+        open(feedbackDialogId);
+        // switch to feedback tab (conditionally determined by user role)
         setTabIndex(data.isViewerModerator ? 2 : 1);
     }
-    const handleOpenLinkedQuestionForm = () => {
-        open('question');
+    const handleOpenLinkedQuestionDialog = () => {
+        // open question dialog from feedback dialog
+        open(questionDialogId);
+        // switch to question list tab (conditionally determined by user role)
         setTabIndex(data.isViewerModerator ? 1 : 0);
     }
 
@@ -145,14 +154,14 @@ export const EventSidebar = ({ fragmentRef }: EventSidebarProps) => {
                     displayFeedbackButton ? (
                         <SubmitLiveFeedback
                             className={classes.fullWidth}
-                            open={() => open('feedback')}
+                            open={() => open(feedbackDialogId)}
                             // eventId={data.id}
                             // connectionKey='useLiveFeedbackListFragment_liveFeedback'
                         />
                     ) : (
                         <AskQuestion
                             className={classes.fullWidth}
-                            open={() => open('question')}
+                            open={() => open(questionDialogId)}
                             // eventId={data.id}
                             // connectionKey='useQuestionListFragment_questions'
                         />
@@ -189,16 +198,16 @@ export const EventSidebar = ({ fragmentRef }: EventSidebarProps) => {
 
             {/* relocate dialogs to allow one to open another */}
             <LiveFeedbackDialog
-                isOpen={openDialog === 'feedback'}
+                isOpen={openDialog === feedbackDialogId}
                 openDialog={openDialog}
-                openLinked={handleOpenLinkedQuestionForm}
+                openLinked={handleOpenLinkedQuestionDialog}
                 close={close}
                 eventId={data.id}
             />
             <QuestionDialog
-                isOpen={openDialog === 'question'}
+                isOpen={openDialog === questionDialogId}
                 openDialog={openDialog}
-                openLinked={handleOpenLinkedFeedbackForm}
+                openLinked={handleOpenLinkedFeedbackDialog}
                 close={close}
                 eventId={data.id}
             />

--- a/app/client/src/features/events/EventSidebar/EventSidebar.tsx
+++ b/app/client/src/features/events/EventSidebar/EventSidebar.tsx
@@ -199,14 +199,12 @@ export const EventSidebar = ({ fragmentRef }: EventSidebarProps) => {
             {/* relocate dialogs to allow one to open another */}
             <LiveFeedbackDialog
                 isOpen={openDialog === feedbackDialogId}
-                openDialog={openDialog}
                 openLinked={handleOpenLinkedQuestionDialog}
                 close={close}
                 eventId={data.id}
             />
             <QuestionDialog
                 isOpen={openDialog === questionDialogId}
-                openDialog={openDialog}
                 openLinked={handleOpenLinkedFeedbackDialog}
                 close={close}
                 eventId={data.id}

--- a/app/client/src/features/events/EventSidebar/EventSidebar.tsx
+++ b/app/client/src/features/events/EventSidebar/EventSidebar.tsx
@@ -16,6 +16,9 @@ import { LiveFeedbackList } from '@local/features/events/LiveFeedback/LiveFeedba
 import { SubmitLiveFeedback } from '@local/features/events/LiveFeedback/SubmitLiveFeedback';
 import { EventDetailsCard } from '../EventDetailsCard';
 import { SpeakerList } from '../Speakers';
+import { useLinkedResponsiveDialog } from '@local/components/ResponsiveDialog';
+import { LiveFeedbackDialog } from '../LiveFeedback/LiveFeedbackDialog';
+import { QuestionDialog } from '../Questions/AskQuestion/QuestionDialog';
 
 export const EVENT_SIDEBAR_FRAGMENT = graphql`
     fragment EventSidebarFragment on Event {
@@ -90,12 +93,22 @@ export const EventSidebar = ({ fragmentRef }: EventSidebarProps) => {
     const [tabIndex, setTabIndex] = React.useState<number>(0);
     const [displayFeedbackButton, setDisplayFeedbackButton] = React.useState<boolean>(false);
     const data = useFragment(EVENT_SIDEBAR_FRAGMENT, fragmentRef);
+    const [openDialog, open, close] = useLinkedResponsiveDialog();
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const handleTabChange = (e: React.ChangeEvent<any>, newTabIndex: number) => {
         e.preventDefault();
         setTabIndex(newTabIndex);
     };
+
+    const handleOpenLinkedFeedbackForm = () => {
+        open('feedback');
+        setTabIndex(data.isViewerModerator ? 2 : 1);
+    }
+    const handleOpenLinkedQuestionForm = () => {
+        open('question');
+        setTabIndex(data.isViewerModerator ? 1 : 0);
+    }
 
     // const tabVisibility = React.useMemo(() => getTabVisibility(data), [data]);
     // const tabs = React.useMemo(() => buildTabs(tabVisibility), [tabVisibility]);
@@ -132,13 +145,15 @@ export const EventSidebar = ({ fragmentRef }: EventSidebarProps) => {
                     displayFeedbackButton ? (
                         <SubmitLiveFeedback
                             className={classes.fullWidth}
-                            eventId={data.id}
+                            open={() => open('feedback')}
+                            // eventId={data.id}
                             // connectionKey='useLiveFeedbackListFragment_liveFeedback'
                         />
                     ) : (
                         <AskQuestion
                             className={classes.fullWidth}
-                            eventId={data.id}
+                            open={() => open('question')}
+                            // eventId={data.id}
                             // connectionKey='useQuestionListFragment_questions'
                         />
                     )
@@ -171,6 +186,22 @@ export const EventSidebar = ({ fragmentRef }: EventSidebarProps) => {
                     <LiveFeedbackList fragmentRef={data} />
                 </TabPanel>
             </Grid>
+
+            {/* relocate dialogs to allow one to open another */}
+            <LiveFeedbackDialog
+                isOpen={openDialog === 'feedback'}
+                openDialog={openDialog}
+                openLinked={handleOpenLinkedQuestionForm}
+                close={close}
+                eventId={data.id}
+            />
+            <QuestionDialog
+                isOpen={openDialog === 'question'}
+                openDialog={openDialog}
+                openLinked={handleOpenLinkedFeedbackForm}
+                close={close}
+                eventId={data.id}
+            />
         </Grid>
     );
 };

--- a/app/client/src/features/events/LiveFeedback/LiveFeedbackDialog.tsx
+++ b/app/client/src/features/events/LiveFeedback/LiveFeedbackDialog.tsx
@@ -9,9 +9,8 @@ import { LiveFeedbackForm, TLiveFeedbackFormState } from './LiveFeedbackForm';
 
 interface Props {
     isOpen: boolean;
-    openDialog: string;
-    openLinked: () => void;
-    close: () => void;
+    openLinked: () => void; // opens linked dialog
+    close: () => void; // closes current dialog
     eventId: string;
 }
 

--- a/app/client/src/features/events/LiveFeedback/LiveFeedbackDialog.tsx
+++ b/app/client/src/features/events/LiveFeedback/LiveFeedbackDialog.tsx
@@ -1,0 +1,54 @@
+import * as React from 'react';
+import { DialogContent } from '@material-ui/core';
+import { useMutation, graphql } from 'react-relay';
+
+import type { SubmitLiveFeedbackMutation } from '@local/__generated__/SubmitLiveFeedbackMutation.graphql';
+import { ResponsiveDialog } from '@local/components/ResponsiveDialog';
+import { LiveFeedbackForm, TLiveFeedbackFormState } from './LiveFeedbackForm';
+
+interface Props {
+    isOpen: boolean;
+    close: () => void;
+    eventId: string;
+}
+
+export const SUBMIT_LIVE_FEEDBACK_MUTATION = graphql`
+    mutation SubmitLiveFeedbackMutation($input: CreateFeedback!) {
+        createFeedback(input: $input) {
+            isError
+            message
+            body {
+                cursor
+                node {
+                    id
+                    createdAt
+                    message
+                    createdBy {
+                        id
+                        firstName
+                        lastName
+                    }
+                }
+            }
+        }
+    }
+`;
+
+export function LiveFeedbackDialog({ isOpen, close, eventId }: Props) {
+    const [commit] = useMutation<SubmitLiveFeedbackMutation>(SUBMIT_LIVE_FEEDBACK_MUTATION);
+
+    function handleSubmit(form: TLiveFeedbackFormState) {
+        commit({
+            variables: { input: { ...form, eventId } },
+            onCompleted: close,
+        });
+    }
+
+    return (
+        <ResponsiveDialog open={isOpen} onClose={close}>
+            <DialogContent>
+                <LiveFeedbackForm onCancel={close} onSubmit={handleSubmit} eventId={eventId} />
+            </DialogContent>
+        </ResponsiveDialog>
+    );
+}

--- a/app/client/src/features/events/LiveFeedback/LiveFeedbackDialog.tsx
+++ b/app/client/src/features/events/LiveFeedback/LiveFeedbackDialog.tsx
@@ -60,3 +60,7 @@ export function LiveFeedbackDialog({ isOpen, openLinked, close, eventId }: Props
         </ResponsiveDialog>
     );
 }
+
+LiveFeedbackDialog.defaultProps = {
+    openLinked: null
+}

--- a/app/client/src/features/events/LiveFeedback/LiveFeedbackDialog.tsx
+++ b/app/client/src/features/events/LiveFeedback/LiveFeedbackDialog.tsx
@@ -1,9 +1,8 @@
 import * as React from 'react';
 import { DialogContent } from '@material-ui/core';
-import { useMutation } from 'react-relay';
+import { useMutation, graphql } from 'react-relay';
 
-import type { SubmitLiveFeedbackMutation } from '@local/__generated__/SubmitLiveFeedbackMutation.graphql';
-import { SUBMIT_LIVE_FEEDBACK_MUTATION } from './SubmitLiveFeedback'
+import type { LiveFeedbackDialogMutation } from '@local/__generated__/LiveFeedbackDialogMutation.graphql';
 import { ResponsiveDialog } from '@local/components/ResponsiveDialog';
 import { LiveFeedbackForm, TLiveFeedbackFormState } from './LiveFeedbackForm';
 
@@ -14,8 +13,30 @@ interface Props {
     eventId: string;
 }
 
+export const LIVE_FEEDBACK_DIALOG_MUTATION = graphql`
+    mutation LiveFeedbackDialogMutation($input: CreateFeedback!) {
+        createFeedback(input: $input) {
+            isError
+            message
+            body {
+                cursor
+                node {
+                    id
+                    createdAt
+                    message
+                    createdBy {
+                        id
+                        firstName
+                        lastName
+                    }
+                }
+            }
+        }
+    }
+`;
+
 export function LiveFeedbackDialog({ isOpen, openLinked, close, eventId }: Props) {
-    const [commit] = useMutation<SubmitLiveFeedbackMutation>(SUBMIT_LIVE_FEEDBACK_MUTATION);
+    const [commit] = useMutation<LiveFeedbackDialogMutation>(LIVE_FEEDBACK_DIALOG_MUTATION);
 
     function handleSubmit(form: TLiveFeedbackFormState) {
         commit({

--- a/app/client/src/features/events/LiveFeedback/LiveFeedbackDialog.tsx
+++ b/app/client/src/features/events/LiveFeedback/LiveFeedbackDialog.tsx
@@ -8,6 +8,8 @@ import { LiveFeedbackForm, TLiveFeedbackFormState } from './LiveFeedbackForm';
 
 interface Props {
     isOpen: boolean;
+    openDialog: string;
+    openLinked: () => void;
     close: () => void;
     eventId: string;
 }
@@ -34,7 +36,7 @@ export const SUBMIT_LIVE_FEEDBACK_MUTATION = graphql`
     }
 `;
 
-export function LiveFeedbackDialog({ isOpen, close, eventId }: Props) {
+export function LiveFeedbackDialog({ isOpen, openLinked, close, eventId }: Props) {
     const [commit] = useMutation<SubmitLiveFeedbackMutation>(SUBMIT_LIVE_FEEDBACK_MUTATION);
 
     function handleSubmit(form: TLiveFeedbackFormState) {
@@ -45,9 +47,17 @@ export function LiveFeedbackDialog({ isOpen, close, eventId }: Props) {
     }
 
     return (
-        <ResponsiveDialog open={isOpen} onClose={close}>
+        <ResponsiveDialog
+            open={isOpen}
+            currDialog='feedback'
+            onClose={close}
+        >
             <DialogContent>
-                <LiveFeedbackForm onCancel={close} onSubmit={handleSubmit} eventId={eventId} />
+                <LiveFeedbackForm
+                    openLinked={openLinked}
+                    onCancel={close}
+                    onSubmit={handleSubmit}
+                />
             </DialogContent>
         </ResponsiveDialog>
     );

--- a/app/client/src/features/events/LiveFeedback/LiveFeedbackDialog.tsx
+++ b/app/client/src/features/events/LiveFeedback/LiveFeedbackDialog.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import { DialogContent } from '@material-ui/core';
-import { useMutation, graphql } from 'react-relay';
+import { useMutation } from 'react-relay';
 
 import type { SubmitLiveFeedbackMutation } from '@local/__generated__/SubmitLiveFeedbackMutation.graphql';
+import { SUBMIT_LIVE_FEEDBACK_MUTATION } from './SubmitLiveFeedback'
 import { ResponsiveDialog } from '@local/components/ResponsiveDialog';
 import { LiveFeedbackForm, TLiveFeedbackFormState } from './LiveFeedbackForm';
 
@@ -13,28 +14,6 @@ interface Props {
     close: () => void;
     eventId: string;
 }
-
-export const SUBMIT_LIVE_FEEDBACK_MUTATION = graphql`
-    mutation SubmitLiveFeedbackMutation($input: CreateFeedback!) {
-        createFeedback(input: $input) {
-            isError
-            message
-            body {
-                cursor
-                node {
-                    id
-                    createdAt
-                    message
-                    createdBy {
-                        id
-                        firstName
-                        lastName
-                    }
-                }
-            }
-        }
-    }
-`;
 
 export function LiveFeedbackDialog({ isOpen, openLinked, close, eventId }: Props) {
     const [commit] = useMutation<SubmitLiveFeedbackMutation>(SUBMIT_LIVE_FEEDBACK_MUTATION);
@@ -49,7 +28,6 @@ export function LiveFeedbackDialog({ isOpen, openLinked, close, eventId }: Props
     return (
         <ResponsiveDialog
             open={isOpen}
-            currDialog='feedback'
             onClose={close}
         >
             <DialogContent>

--- a/app/client/src/features/events/LiveFeedback/LiveFeedbackForm.tsx
+++ b/app/client/src/features/events/LiveFeedback/LiveFeedbackForm.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { Button, Link, Grid } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
-import { useResponsiveDialog } from '@local/components/ResponsiveDialog';
 
 import { Form } from '@local/components/Form';
 import { FormTitle } from '@local/components/FormTitle';
@@ -9,15 +8,14 @@ import { FormContent } from '@local/components/FormContent';
 import { FormActions } from '@local/components/FormActions';
 import { TextField } from '@local/components/TextField';
 import { useForm } from '@local/features/core';
-import { QuestionDialog } from '../Questions/AskQuestion/QuestionDialog';
 
 export type TLiveFeedbackFormState = { message: string };
 
 export interface LiveFeedbackFormProps {
     reply?: React.ReactNode;
     onSubmit?: (state: TLiveFeedbackFormState) => void;
+    openLinked: () => void;
     onCancel?: () => void;
-    eventId: string;
 }
 
 const useStyles = makeStyles((theme) => ({
@@ -38,75 +36,64 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 // TODO: eliminate inline styles
-export function LiveFeedbackForm({ reply, onSubmit, onCancel, eventId }: LiveFeedbackFormProps) {
+export function LiveFeedbackForm({ reply, onSubmit, openLinked, onCancel }: LiveFeedbackFormProps) {
     const classes = useStyles();
-    const [isOpen, open, close] = useResponsiveDialog();
     // form related hooks
     const [form, errors, handleSubmit, handleChange] = useForm({
         message: '',
     });
 
-    const handleOpenQuestion = () => { open(); if (onCancel) onCancel(); };
-
     const isFeedbackValid = React.useMemo(() => form.message.trim().length !== 0, [form]);
 
     return (
-        <>
-            <QuestionDialog
-                isOpen={isOpen}
-                close={close}
-                eventId={eventId}
-            />
-
-            <Form onSubmit={handleSubmit(onSubmit)} className={classes.form}>
-                <FormTitle title={reply ? 'Live Feedback Reply Form' : 'Live Feedback Form'} />
-                {reply}
-                <FormContent>
-                    <TextField
-                        id='feedback-field'
-                        name={reply ? 'feedback-reply' : 'feedback'}
-                        label={reply ? 'Feedback Reply' : 'Your Feedback'}
-                        autoFocus
-                        error={Boolean(errors.message)}
-                        helperText={errors.message}
-                        required
-                        multiline
-                        value={form.message}
-                        onChange={handleChange('message')}
-                        className={classes.input}
-                    />
-                </FormContent>
-                <FormActions disableGrow gridProps={{ justify: 'space-between' }}>
-                    <Link
-                        variant='body1'
-                        underline='always'
-                        onClick={handleOpenQuestion}
-                        className={classes.link}
-                    >
-                        Have a question instead?
-                    </Link>
-                    <Grid container spacing={1}>
-                        {onCancel && (
-                            <Grid item>
-                                <Button onClick={onCancel} className={classes.button}>
-                                    Cancel
-                                </Button>
-                            </Grid>
-                        )}
+        <Form onSubmit={handleSubmit(onSubmit)} className={classes.form}>
+            <FormTitle title={reply ? 'Live Feedback Reply Form' : 'Live Feedback Form'} />
+            {reply}
+            <FormContent>
+                <TextField
+                    id='feedback-field'
+                    name={reply ? 'feedback-reply' : 'feedback'}
+                    label={reply ? 'Feedback Reply' : 'Your Feedback'}
+                    autoFocus
+                    error={Boolean(errors.message)}
+                    helperText={errors.message}
+                    required
+                    multiline
+                    value={form.message}
+                    onChange={handleChange('message')}
+                    className={classes.input}
+                />
+            </FormContent>
+            <FormActions disableGrow gridProps={{ justify: 'space-between' }}>
+                <Link
+                    variant='body1'
+                    underline='always'
+                    onClick={openLinked}
+                    className={classes.link}
+                >
+                    Have a question instead?
+                </Link>
+                <Grid container spacing={1}>
+                    {onCancel && (
                         <Grid item>
-                            <Button
-                                disabled={!isFeedbackValid}
-                                type='submit'
-                                variant='contained'
-                                color='primary'
-                                className={classes.button}
-                            >
-                                {reply ? 'Reply' : 'Ask'}
+                            <Button onClick={onCancel} className={classes.button}>
+                                Cancel
                             </Button>
                         </Grid>
+                    )}
+                    <Grid item>
+                        <Button
+                            disabled={!isFeedbackValid}
+                            type='submit'
+                            variant='contained'
+                            color='primary'
+                            className={classes.button}
+                        >
+                            {reply ? 'Reply' : 'Ask'}
+                        </Button>
                     </Grid>
-                </FormActions>
-            </Form>
-        </>
+                </Grid>
+            </FormActions>
+        </Form>
     );
 }

--- a/app/client/src/features/events/LiveFeedback/LiveFeedbackForm.tsx
+++ b/app/client/src/features/events/LiveFeedback/LiveFeedbackForm.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
-import { Button } from '@material-ui/core';
+import { Button, Link, Grid } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
+import { useResponsiveDialog } from '@local/components/ResponsiveDialog';
 
 import { Form } from '@local/components/Form';
 import { FormTitle } from '@local/components/FormTitle';
@@ -7,6 +9,7 @@ import { FormContent } from '@local/components/FormContent';
 import { FormActions } from '@local/components/FormActions';
 import { TextField } from '@local/components/TextField';
 import { useForm } from '@local/features/core';
+import { QuestionDialog } from '../Questions/AskQuestion/QuestionDialog';
 
 export type TLiveFeedbackFormState = { message: string };
 
@@ -14,45 +17,96 @@ export interface LiveFeedbackFormProps {
     reply?: React.ReactNode;
     onSubmit?: (state: TLiveFeedbackFormState) => void;
     onCancel?: () => void;
+    eventId: string;
 }
 
+const useStyles = makeStyles((theme) => ({
+    form: {
+        paddingTop: theme.spacing(2)
+    },
+    input: {
+        ['& fieldset']: {
+            borderRadius: 9999,
+        },
+    },
+    button: {
+        borderRadius: '10px'
+    },
+    link: {
+        cursor: 'pointer'
+    }
+}));
+
 // TODO: eliminate inline styles
-export function LiveFeedbackForm({ reply, onSubmit, onCancel }: LiveFeedbackFormProps) {
+export function LiveFeedbackForm({ reply, onSubmit, onCancel, eventId }: LiveFeedbackFormProps) {
+    const classes = useStyles();
+    const [isOpen, open, close] = useResponsiveDialog();
     // form related hooks
     const [form, errors, handleSubmit, handleChange] = useForm({
         message: '',
     });
 
+    const handleOpenQuestion = () => { open(); if (onCancel) onCancel(); };
+
     const isFeedbackValid = React.useMemo(() => form.message.trim().length !== 0, [form]);
 
     return (
-        <Form onSubmit={handleSubmit(onSubmit)}>
-            <FormTitle title={reply ? 'Live Feedback Reply Form' : 'Live Feedback Form'} />
-            {reply}
-            <FormContent>
-                <TextField
-                    id='feedback-field'
-                    name={reply ? 'feedback-reply' : 'feedback'}
-                    label={reply ? 'Feedback Reply...' : 'Your Feedback...'}
-                    autoFocus
-                    error={Boolean(errors.message)}
-                    helperText={errors.message}
-                    required
-                    multiline
-                    value={form.message}
-                    onChange={handleChange('message')}
-                />
-            </FormContent>
-            <FormActions disableGrow gridProps={{ justify: 'flex-end' }}>
-                {onCancel && (
-                    <Button color='primary' onClick={onCancel}>
-                        Cancel
-                    </Button>
-                )}
-                <Button disabled={!isFeedbackValid} type='submit' variant='contained' color='primary'>
-                    {reply ? 'Reply' : 'Ask'}
-                </Button>
-            </FormActions>
-        </Form>
+        <>
+            <QuestionDialog
+                isOpen={isOpen}
+                close={close}
+                eventId={eventId}
+            />
+
+            <Form onSubmit={handleSubmit(onSubmit)} className={classes.form}>
+                <FormTitle title={reply ? 'Live Feedback Reply Form' : 'Live Feedback Form'} />
+                {reply}
+                <FormContent>
+                    <TextField
+                        id='feedback-field'
+                        name={reply ? 'feedback-reply' : 'feedback'}
+                        label={reply ? 'Feedback Reply' : 'Your Feedback'}
+                        autoFocus
+                        error={Boolean(errors.message)}
+                        helperText={errors.message}
+                        required
+                        multiline
+                        value={form.message}
+                        onChange={handleChange('message')}
+                        className={classes.input}
+                    />
+                </FormContent>
+                <FormActions disableGrow gridProps={{ justify: 'space-between' }}>
+                    <Link
+                        variant='body1'
+                        underline='always'
+                        onClick={handleOpenQuestion}
+                        className={classes.link}
+                    >
+                        Have a question instead?
+                    </Link>
+                    <Grid container spacing={1}>
+                        {onCancel && (
+                            <Grid item>
+                                <Button onClick={onCancel} className={classes.button}>
+                                    Cancel
+                                </Button>
+                            </Grid>
+                        )}
+                        <Grid item>
+                            <Button
+                                disabled={!isFeedbackValid}
+                                type='submit'
+                                variant='contained'
+                                color='primary'
+                                className={classes.button}
+                            >
+                                {reply ? 'Reply' : 'Ask'}
+                            </Button>
+                        </Grid>
+                    </Grid>
+                </FormActions>
+            </Form>
+        </>
     );
 }

--- a/app/client/src/features/events/LiveFeedback/LiveFeedbackForm.tsx
+++ b/app/client/src/features/events/LiveFeedback/LiveFeedbackForm.tsx
@@ -14,7 +14,7 @@ export type TLiveFeedbackFormState = { message: string };
 export interface LiveFeedbackFormProps {
     reply?: React.ReactNode;
     onSubmit?: (state: TLiveFeedbackFormState) => void;
-    openLinked: () => void;
+    openLinked: () => void; // opens linked dialog
     onCancel?: () => void;
 }
 
@@ -24,7 +24,7 @@ const useStyles = makeStyles((theme) => ({
     },
     input: {
         ['& fieldset']: {
-            borderRadius: 9999,
+            borderRadius: 9999, // round text field
         },
     },
     button: {

--- a/app/client/src/features/events/LiveFeedback/LiveFeedbackForm.tsx
+++ b/app/client/src/features/events/LiveFeedback/LiveFeedbackForm.tsx
@@ -97,3 +97,7 @@ export function LiveFeedbackForm({ reply, onSubmit, openLinked, onCancel }: Live
         </Form>
     );
 }
+
+LiveFeedbackForm.defaultProps = {
+    openLinked: null
+}

--- a/app/client/src/features/events/LiveFeedback/SubmitLiveFeedback.tsx
+++ b/app/client/src/features/events/LiveFeedback/SubmitLiveFeedback.tsx
@@ -1,15 +1,37 @@
 import * as React from 'react';
 import { Button } from '@material-ui/core';
+import { graphql } from 'react-relay';
 import QuestionAnswerIcon from '@material-ui/icons/QuestionAnswer';
 import LockIcon from '@material-ui/icons/Lock';
 
 import { useUser } from '@local/features/accounts';
-// import { LiveFeedbackDialog } from './LiveFeedbackDialog';
 
 interface Props {
     className?: string;
     open: () => void;
 }
+
+export const SUBMIT_LIVE_FEEDBACK_MUTATION = graphql`
+    mutation SubmitLiveFeedbackMutation($input: CreateFeedback!) {
+        createFeedback(input: $input) {
+            isError
+            message
+            body {
+                cursor
+                node {
+                    id
+                    createdAt
+                    message
+                    createdBy {
+                        id
+                        firstName
+                        lastName
+                    }
+                }
+            }
+        }
+    }
+`;
 
 export function SubmitLiveFeedback({ open, className }: Props) {
     const [user] = useUser();

--- a/app/client/src/features/events/LiveFeedback/SubmitLiveFeedback.tsx
+++ b/app/client/src/features/events/LiveFeedback/SubmitLiveFeedback.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { Button } from '@material-ui/core';
-import { graphql } from 'react-relay';
 import QuestionAnswerIcon from '@material-ui/icons/QuestionAnswer';
 import LockIcon from '@material-ui/icons/Lock';
 
@@ -10,28 +9,6 @@ interface Props {
     className?: string;
     open: () => void;
 }
-
-export const SUBMIT_LIVE_FEEDBACK_MUTATION = graphql`
-    mutation SubmitLiveFeedbackMutation($input: CreateFeedback!) {
-        createFeedback(input: $input) {
-            isError
-            message
-            body {
-                cursor
-                node {
-                    id
-                    createdAt
-                    message
-                    createdBy {
-                        id
-                        firstName
-                        lastName
-                    }
-                }
-            }
-        }
-    }
-`;
 
 export function SubmitLiveFeedback({ open, className }: Props) {
     const [user] = useUser();

--- a/app/client/src/features/events/LiveFeedback/SubmitLiveFeedback.tsx
+++ b/app/client/src/features/events/LiveFeedback/SubmitLiveFeedback.tsx
@@ -1,60 +1,28 @@
 import * as React from 'react';
-import { Button, DialogContent } from '@material-ui/core';
+import { Button } from '@material-ui/core';
 import QuestionAnswerIcon from '@material-ui/icons/QuestionAnswer';
 import LockIcon from '@material-ui/icons/Lock';
-import { useMutation, graphql } from 'react-relay';
 
-import type { SubmitLiveFeedbackMutation } from '@local/__generated__/SubmitLiveFeedbackMutation.graphql';
-import { ResponsiveDialog, useResponsiveDialog } from '@local/components/ResponsiveDialog';
+import { useResponsiveDialog } from '@local/components/ResponsiveDialog';
 import { useUser } from '@local/features/accounts';
-import { LiveFeedbackForm, TLiveFeedbackFormState } from './LiveFeedbackForm';
+import { LiveFeedbackDialog } from './LiveFeedbackDialog';
 
 interface Props {
     className?: string;
     eventId: string;
 }
 
-export const SUBMIT_LIVE_FEEDBACK_MUTATION = graphql`
-    mutation SubmitLiveFeedbackMutation($input: CreateFeedback!) {
-        createFeedback(input: $input) {
-            isError
-            message
-            body {
-                cursor
-                node {
-                    id
-                    createdAt
-                    message
-                    createdBy {
-                        id
-                        firstName
-                        lastName
-                    }
-                }
-            }
-        }
-    }
-`;
-
 export function SubmitLiveFeedback({ className, eventId }: Props) {
     const [isOpen, open, close] = useResponsiveDialog();
     const [user] = useUser();
-    const [commit] = useMutation<SubmitLiveFeedbackMutation>(SUBMIT_LIVE_FEEDBACK_MUTATION);
-
-    function handleSubmit(form: TLiveFeedbackFormState) {
-        commit({
-            variables: { input: { ...form, eventId } },
-            onCompleted: close,
-        });
-    }
 
     return (
         <>
-            <ResponsiveDialog open={isOpen} onClose={close}>
-                <DialogContent>
-                    <LiveFeedbackForm onCancel={close} onSubmit={handleSubmit} />
-                </DialogContent>
-            </ResponsiveDialog>
+            <LiveFeedbackDialog
+                isOpen={isOpen}
+                close={close}
+                eventId={eventId}
+            />
 
             <Button
                 className={className}

--- a/app/client/src/features/events/LiveFeedback/SubmitLiveFeedback.tsx
+++ b/app/client/src/features/events/LiveFeedback/SubmitLiveFeedback.tsx
@@ -3,37 +3,27 @@ import { Button } from '@material-ui/core';
 import QuestionAnswerIcon from '@material-ui/icons/QuestionAnswer';
 import LockIcon from '@material-ui/icons/Lock';
 
-import { useResponsiveDialog } from '@local/components/ResponsiveDialog';
 import { useUser } from '@local/features/accounts';
-import { LiveFeedbackDialog } from './LiveFeedbackDialog';
+// import { LiveFeedbackDialog } from './LiveFeedbackDialog';
 
 interface Props {
     className?: string;
-    eventId: string;
+    open: () => void;
 }
 
-export function SubmitLiveFeedback({ className, eventId }: Props) {
-    const [isOpen, open, close] = useResponsiveDialog();
+export function SubmitLiveFeedback({ open, className }: Props) {
     const [user] = useUser();
 
     return (
-        <>
-            <LiveFeedbackDialog
-                isOpen={isOpen}
-                close={close}
-                eventId={eventId}
-            />
-
-            <Button
-                className={className}
-                disabled={!user}
-                variant='contained'
-                color='primary'
-                onClick={open}
-                startIcon={user ? <QuestionAnswerIcon /> : <LockIcon />}
-            >
-                {user ? 'Submit Live Feedback' : 'Sign in to submit live feedback'}
-            </Button>
-        </>
+        <Button
+            className={className}
+            disabled={!user}
+            variant='contained'
+            color='primary'
+            onClick={open}
+            startIcon={user ? <QuestionAnswerIcon /> : <LockIcon />}
+        >
+            {user ? 'Submit Live Feedback' : 'Sign in to submit live feedback'}
+        </Button>
     );
 }

--- a/app/client/src/features/events/Questions/AskQuestion/AskQuestion.tsx
+++ b/app/client/src/features/events/Questions/AskQuestion/AskQuestion.tsx
@@ -1,33 +1,52 @@
 import * as React from 'react';
 import { Button } from '@material-ui/core';
+import { graphql } from 'react-relay';
 import QuestionAnswerIcon from '@material-ui/icons/QuestionAnswer';
 import LockIcon from '@material-ui/icons/Lock';
 
 import { useUser } from '@local/features/accounts';
-// import { QuestionDialog } from './QuestionDialog'
 
 export interface AskQuestionProps {
     className?: string;
     open: () => void;
 }
 
+export const ASK_QUESTION_MUTATION = graphql`
+    mutation AskQuestionMutation($input: CreateQuestion!) {
+        createQuestion(input: $input) {
+            isError
+            message
+            body {
+                cursor
+                node {
+                    id
+                    createdAt
+                    question
+                    createdBy {
+                        id
+                        firstName
+                        lastName
+                    }
+                }
+            }
+        }
+    }
+`;
+
 function AskQuestion({ open, className }: AskQuestionProps) {
     const [user] = useUser();
 
     return (
-        <>
-
-            <Button
-                className={className}
-                disabled={!user}
-                variant='contained'
-                color='primary'
-                onClick={open}
-                startIcon={user ? <QuestionAnswerIcon /> : <LockIcon />}
-            >
-                {user ? 'Ask a Question' : 'Sign in to ask a question'}
-            </Button>
-        </>
+        <Button
+            className={className}
+            disabled={!user}
+            variant='contained'
+            color='primary'
+            onClick={open}
+            startIcon={user ? <QuestionAnswerIcon /> : <LockIcon />}
+        >
+            {user ? 'Ask a Question' : 'Sign in to ask a question'}
+        </Button>
     );
 }
 

--- a/app/client/src/features/events/Questions/AskQuestion/AskQuestion.tsx
+++ b/app/client/src/features/events/Questions/AskQuestion/AskQuestion.tsx
@@ -3,26 +3,19 @@ import { Button } from '@material-ui/core';
 import QuestionAnswerIcon from '@material-ui/icons/QuestionAnswer';
 import LockIcon from '@material-ui/icons/Lock';
 
-import { useResponsiveDialog } from '@local/components/ResponsiveDialog';
 import { useUser } from '@local/features/accounts';
-import { QuestionDialog } from './QuestionDialog'
+// import { QuestionDialog } from './QuestionDialog'
 
 export interface AskQuestionProps {
     className?: string;
-    eventId: string;
+    open: () => void;
 }
 
-function AskQuestion({ className, eventId }: AskQuestionProps) {
-    const [isOpen, open, close] = useResponsiveDialog();
+function AskQuestion({ open, className }: AskQuestionProps) {
     const [user] = useUser();
 
     return (
         <>
-            <QuestionDialog
-                isOpen={isOpen}
-                close={close}
-                eventId={eventId}
-            />
 
             <Button
                 className={className}

--- a/app/client/src/features/events/Questions/AskQuestion/AskQuestion.tsx
+++ b/app/client/src/features/events/Questions/AskQuestion/AskQuestion.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { Button } from '@material-ui/core';
-import { graphql } from 'react-relay';
 import QuestionAnswerIcon from '@material-ui/icons/QuestionAnswer';
 import LockIcon from '@material-ui/icons/Lock';
 
@@ -10,28 +9,6 @@ export interface AskQuestionProps {
     className?: string;
     open: () => void;
 }
-
-export const ASK_QUESTION_MUTATION = graphql`
-    mutation AskQuestionMutation($input: CreateQuestion!) {
-        createQuestion(input: $input) {
-            isError
-            message
-            body {
-                cursor
-                node {
-                    id
-                    createdAt
-                    question
-                    createdBy {
-                        id
-                        firstName
-                        lastName
-                    }
-                }
-            }
-        }
-    }
-`;
 
 function AskQuestion({ open, className }: AskQuestionProps) {
     const [user] = useUser();

--- a/app/client/src/features/events/Questions/AskQuestion/AskQuestion.tsx
+++ b/app/client/src/features/events/Questions/AskQuestion/AskQuestion.tsx
@@ -1,65 +1,28 @@
 import * as React from 'react';
-import { Button, DialogContent } from '@material-ui/core';
+import { Button } from '@material-ui/core';
 import QuestionAnswerIcon from '@material-ui/icons/QuestionAnswer';
 import LockIcon from '@material-ui/icons/Lock';
-import { useMutation, graphql } from 'react-relay';
 
-import type { AskQuestionMutation } from '@local/__generated__/AskQuestionMutation.graphql';
-import { ResponsiveDialog, useResponsiveDialog } from '@local/components/ResponsiveDialog';
-import { useSnack } from '@local/features/core';
+import { useResponsiveDialog } from '@local/components/ResponsiveDialog';
 import { useUser } from '@local/features/accounts';
-import { QuestionForm, TQuestionFormState } from '../QuestionForm';
+import { QuestionDialog } from './QuestionDialog'
 
 export interface AskQuestionProps {
     className?: string;
     eventId: string;
 }
 
-export const ASK_QUESTION_MUTATION = graphql`
-    mutation AskQuestionMutation($input: CreateQuestion!) {
-        createQuestion(input: $input) {
-            isError
-            message
-            body {
-                cursor
-                node {
-                    id
-                    createdAt
-                    question
-                    createdBy {
-                        id
-                        firstName
-                        lastName
-                    }
-                }
-            }
-        }
-    }
-`;
-
 function AskQuestion({ className, eventId }: AskQuestionProps) {
     const [isOpen, open, close] = useResponsiveDialog();
     const [user] = useUser();
-    const [commit] = useMutation<AskQuestionMutation>(ASK_QUESTION_MUTATION);
-    const { displaySnack } = useSnack();
-
-    function handleSubmit(form: TQuestionFormState) {
-        commit({
-            variables: { input: { ...form, eventId, isFollowUp: false, isQuote: false } },
-            onCompleted(payload) {
-                if (payload.createQuestion.isError) displaySnack('Something went wrong!');
-                else close();
-            },
-        });
-    }
 
     return (
         <>
-            <ResponsiveDialog open={isOpen} onClose={close}>
-                <DialogContent>
-                    <QuestionForm onCancel={close} onSubmit={handleSubmit} />
-                </DialogContent>
-            </ResponsiveDialog>
+            <QuestionDialog
+                isOpen={isOpen}
+                close={close}
+                eventId={eventId}
+            />
 
             <Button
                 className={className}
@@ -69,7 +32,7 @@ function AskQuestion({ className, eventId }: AskQuestionProps) {
                 onClick={open}
                 startIcon={user ? <QuestionAnswerIcon /> : <LockIcon />}
             >
-                {user ? 'Ask My Question' : 'Sign in to ask a question'}
+                {user ? 'Ask a Question' : 'Sign in to ask a question'}
             </Button>
         </>
     );

--- a/app/client/src/features/events/Questions/AskQuestion/QuestionDialog.tsx
+++ b/app/client/src/features/events/Questions/AskQuestion/QuestionDialog.tsx
@@ -1,9 +1,8 @@
 import * as React from 'react';
 import { DialogContent } from '@material-ui/core';
-import { useMutation } from 'react-relay';
+import { useMutation, graphql } from 'react-relay';
 
-import type { AskQuestionMutation } from '@local/__generated__/AskQuestionMutation.graphql';
-import { ASK_QUESTION_MUTATION } from './AskQuestion'
+import type { QuestionDialogMutation } from '@local/__generated__/QuestionDialogMutation.graphql';
 import { ResponsiveDialog } from '@local/components/ResponsiveDialog';
 import { useSnack } from '@local/features/core';
 import { QuestionForm, TQuestionFormState } from '../QuestionForm';
@@ -15,8 +14,30 @@ export interface Props {
     eventId: string;
 }
 
+export const QUESTION_DIALOG_MUTATION = graphql`
+    mutation QuestionDialogMutation($input: CreateQuestion!) {
+        createQuestion(input: $input) {
+            isError
+            message
+            body {
+                cursor
+                node {
+                    id
+                    createdAt
+                    question
+                    createdBy {
+                        id
+                        firstName
+                        lastName
+                    }
+                }
+            }
+        }
+    }
+`;
+
 export function QuestionDialog({ isOpen, openLinked, close, eventId }: Props) {
-    const [commit] = useMutation<AskQuestionMutation>(ASK_QUESTION_MUTATION);
+    const [commit] = useMutation<QuestionDialogMutation>(QUESTION_DIALOG_MUTATION);
     const { displaySnack } = useSnack();
 
     function handleSubmit(form: TQuestionFormState) {

--- a/app/client/src/features/events/Questions/AskQuestion/QuestionDialog.tsx
+++ b/app/client/src/features/events/Questions/AskQuestion/QuestionDialog.tsx
@@ -45,7 +45,7 @@ export function QuestionDialog({ isOpen, openLinked, close, eventId }: Props) {
             variables: { input: { ...form, eventId, isFollowUp: false, isQuote: false } },
             onCompleted(payload) {
                 if (payload.createQuestion.isError) displaySnack('Something went wrong!');
-                else close;
+                else close();
             },
         });
     }

--- a/app/client/src/features/events/Questions/AskQuestion/QuestionDialog.tsx
+++ b/app/client/src/features/events/Questions/AskQuestion/QuestionDialog.tsx
@@ -10,9 +10,8 @@ import { QuestionForm, TQuestionFormState } from '../QuestionForm';
 
 export interface Props {
     isOpen: boolean;
-    openDialog: string;
-    openLinked: () => void;
-    close: () => void;
+    openLinked: () => void; // opens linked dialog
+    close: () => void; // closes current dialog
     eventId: string;
 }
 

--- a/app/client/src/features/events/Questions/AskQuestion/QuestionDialog.tsx
+++ b/app/client/src/features/events/Questions/AskQuestion/QuestionDialog.tsx
@@ -1,0 +1,61 @@
+import * as React from 'react';
+import { DialogContent } from '@material-ui/core';
+import { useMutation, graphql } from 'react-relay';
+
+import type { AskQuestionMutation } from '@local/__generated__/AskQuestionMutation.graphql';
+import { ResponsiveDialog } from '@local/components/ResponsiveDialog';
+import { useSnack } from '@local/features/core';
+import { QuestionForm, TQuestionFormState } from '../QuestionForm';
+
+export interface Props {
+    isOpen: boolean;
+    close: () => void;
+    eventId: string;
+}
+
+export const ASK_QUESTION_MUTATION = graphql`
+    mutation AskQuestionMutation($input: CreateQuestion!) {
+        createQuestion(input: $input) {
+            isError
+            message
+            body {
+                cursor
+                node {
+                    id
+                    createdAt
+                    question
+                    createdBy {
+                        id
+                        firstName
+                        lastName
+                    }
+                }
+            }
+        }
+    }
+`;
+
+export function QuestionDialog({ isOpen, close, eventId }: Props) {
+    const [commit] = useMutation<AskQuestionMutation>(ASK_QUESTION_MUTATION);
+    const { displaySnack } = useSnack();
+
+    function handleSubmit(form: TQuestionFormState) {
+        commit({
+            variables: { input: { ...form, eventId, isFollowUp: false, isQuote: false } },
+            onCompleted(payload) {
+                if (payload.createQuestion.isError) displaySnack('Something went wrong!');
+                else close();
+            },
+        });
+    }
+
+    return (
+        <>
+            <ResponsiveDialog open={isOpen} onClose={close}>
+                <DialogContent>
+                    <QuestionForm onCancel={close} onSubmit={handleSubmit} eventId={eventId} />
+                </DialogContent>
+            </ResponsiveDialog>
+        </>
+    );
+}

--- a/app/client/src/features/events/Questions/AskQuestion/QuestionDialog.tsx
+++ b/app/client/src/features/events/Questions/AskQuestion/QuestionDialog.tsx
@@ -65,3 +65,7 @@ export function QuestionDialog({ isOpen, openLinked, close, eventId }: Props) {
         </ResponsiveDialog>
     );
 }
+
+QuestionDialog.defaultProps = {
+    openLinked: null
+}

--- a/app/client/src/features/events/Questions/AskQuestion/QuestionDialog.tsx
+++ b/app/client/src/features/events/Questions/AskQuestion/QuestionDialog.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import { DialogContent } from '@material-ui/core';
-import { useMutation, graphql } from 'react-relay';
+import { useMutation } from 'react-relay';
 
 import type { AskQuestionMutation } from '@local/__generated__/AskQuestionMutation.graphql';
+import { ASK_QUESTION_MUTATION } from './AskQuestion'
 import { ResponsiveDialog } from '@local/components/ResponsiveDialog';
 import { useSnack } from '@local/features/core';
 import { QuestionForm, TQuestionFormState } from '../QuestionForm';
@@ -14,28 +15,6 @@ export interface Props {
     close: () => void;
     eventId: string;
 }
-
-export const ASK_QUESTION_MUTATION = graphql`
-    mutation AskQuestionMutation($input: CreateQuestion!) {
-        createQuestion(input: $input) {
-            isError
-            message
-            body {
-                cursor
-                node {
-                    id
-                    createdAt
-                    question
-                    createdBy {
-                        id
-                        firstName
-                        lastName
-                    }
-                }
-            }
-        }
-    }
-`;
 
 export function QuestionDialog({ isOpen, openLinked, close, eventId }: Props) {
     const [commit] = useMutation<AskQuestionMutation>(ASK_QUESTION_MUTATION);
@@ -52,20 +31,17 @@ export function QuestionDialog({ isOpen, openLinked, close, eventId }: Props) {
     }
 
     return (
-        <>
-            <ResponsiveDialog
-                open={isOpen}
-                currDialog='question'
-                onClose={close}
-            >
-                <DialogContent>
-                    <QuestionForm
-                        openLinked={openLinked}
-                        onCancel={close}
-                        onSubmit={handleSubmit}
-                    />
-                </DialogContent>
-            </ResponsiveDialog>
-        </>
+        <ResponsiveDialog
+            open={isOpen}
+            onClose={close}
+        >
+            <DialogContent>
+                <QuestionForm
+                    openLinked={openLinked}
+                    onCancel={close}
+                    onSubmit={handleSubmit}
+                />
+            </DialogContent>
+        </ResponsiveDialog>
     );
 }

--- a/app/client/src/features/events/Questions/AskQuestion/QuestionDialog.tsx
+++ b/app/client/src/features/events/Questions/AskQuestion/QuestionDialog.tsx
@@ -9,6 +9,8 @@ import { QuestionForm, TQuestionFormState } from '../QuestionForm';
 
 export interface Props {
     isOpen: boolean;
+    openDialog: string;
+    openLinked: () => void;
     close: () => void;
     eventId: string;
 }
@@ -35,7 +37,7 @@ export const ASK_QUESTION_MUTATION = graphql`
     }
 `;
 
-export function QuestionDialog({ isOpen, close, eventId }: Props) {
+export function QuestionDialog({ isOpen, openLinked, close, eventId }: Props) {
     const [commit] = useMutation<AskQuestionMutation>(ASK_QUESTION_MUTATION);
     const { displaySnack } = useSnack();
 
@@ -44,16 +46,24 @@ export function QuestionDialog({ isOpen, close, eventId }: Props) {
             variables: { input: { ...form, eventId, isFollowUp: false, isQuote: false } },
             onCompleted(payload) {
                 if (payload.createQuestion.isError) displaySnack('Something went wrong!');
-                else close();
+                else close;
             },
         });
     }
 
     return (
         <>
-            <ResponsiveDialog open={isOpen} onClose={close}>
+            <ResponsiveDialog
+                open={isOpen}
+                currDialog='question'
+                onClose={close}
+            >
                 <DialogContent>
-                    <QuestionForm onCancel={close} onSubmit={handleSubmit} eventId={eventId} />
+                    <QuestionForm
+                        openLinked={openLinked}
+                        onCancel={close}
+                        onSubmit={handleSubmit}
+                    />
                 </DialogContent>
             </ResponsiveDialog>
         </>

--- a/app/client/src/features/events/Questions/QuestionForm/QuestionForm.tsx
+++ b/app/client/src/features/events/Questions/QuestionForm/QuestionForm.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
-import { Button } from '@material-ui/core';
+import { Button, Link, Grid } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
+import { useResponsiveDialog } from '@local/components/ResponsiveDialog';
 
 import { Form } from '@local/components/Form';
 import { FormTitle } from '@local/components/FormTitle';
@@ -7,6 +9,7 @@ import { FormContent } from '@local/components/FormContent';
 import { FormActions } from '@local/components/FormActions';
 import { TextField } from '@local/components/TextField';
 import { useForm } from '@local/features/core';
+import { LiveFeedbackDialog } from '../../LiveFeedback/LiveFeedbackDialog';
 
 export type TQuestionFormState = { question: string };
 
@@ -14,45 +17,96 @@ export interface QuestionFormProps {
     quote?: React.ReactNode;
     onSubmit?: (state: TQuestionFormState) => void;
     onCancel?: () => void;
+    eventId: string;
 }
 
+const useStyles = makeStyles((theme) => ({
+    form: {
+        paddingTop: theme.spacing(2)
+    },
+    input: {
+        ['& fieldset']: {
+            borderRadius: 9999,
+        },
+    },
+    button: {
+        borderRadius: '10px'
+    },
+    link: {
+        cursor: 'pointer'
+    }
+}));
+
 // TODO: eliminate inline styles
-export function QuestionForm({ quote, onSubmit, onCancel }: QuestionFormProps) {
+export function QuestionForm({ quote, onSubmit, onCancel, eventId }: QuestionFormProps) {
+    const classes = useStyles();
+    const [isOpen, open, close] = useResponsiveDialog();
     // form related hooks
     const [form, errors, handleSubmit, handleChange] = useForm({
         question: '',
     });
 
+    const handleOpenFeedback = () => { open(); if (onCancel) onCancel(); };
+
     const isQuestionValid = React.useMemo(() => form.question.trim().length !== 0, [form]);
 
     return (
-        <Form onSubmit={handleSubmit(onSubmit)}>
-            <FormTitle title='Question Form' />
-            {quote}
-            <FormContent>
-                <TextField
-                    id='question-field'
-                    name='question'
-                    label='Your Question...'
-                    autoFocus
-                    error={Boolean(errors.question)}
-                    helperText={errors.question}
-                    required
-                    multiline
-                    value={form.question}
-                    onChange={handleChange('question')}
-                />
-            </FormContent>
-            <FormActions disableGrow gridProps={{ justify: 'flex-end' }}>
-                {onCancel && (
-                    <Button color='primary' onClick={onCancel}>
-                        Cancel
-                    </Button>
-                )}
-                <Button disabled={!isQuestionValid} type='submit' variant='contained' color='primary'>
-                    Ask
-                </Button>
-            </FormActions>
-        </Form>
+        <>
+            <LiveFeedbackDialog
+                isOpen={isOpen}
+                close={close}
+                eventId={eventId}
+            />
+            
+            <Form onSubmit={handleSubmit(onSubmit)} className={classes.form}>
+                <FormTitle title='Question Form' />
+                {quote}
+                <FormContent>
+                    <TextField
+                        id='question-field'
+                        name='question'
+                        label='Your Question'
+                        autoFocus
+                        error={Boolean(errors.question)}
+                        helperText={errors.question}
+                        required
+                        multiline
+                        value={form.question}
+                        onChange={handleChange('question')}
+                        className={classes.input}
+                    />
+                </FormContent>
+                <FormActions disableGrow gridProps={{ justify: 'space-between' }}>
+                    <Link
+                        variant='body1'
+                        underline='always'
+                        onClick={handleOpenFeedback}
+                        className={classes.link}
+                    >
+                        Have feedback instead?
+                    </Link>
+                    <Grid container spacing={1}>
+                        {onCancel && (
+                            <Grid item>
+                                <Button onClick={onCancel} className={classes.button}>
+                                    Cancel
+                                </Button>
+                            </Grid>
+                        )}
+                        <Grid item>
+                            <Button
+                                disabled={!isQuestionValid}
+                                type='submit'
+                                variant='contained'
+                                color='primary'
+                                className={classes.button}
+                            >
+                                Ask
+                            </Button>
+                        </Grid>
+                    </Grid>
+                </FormActions>
+            </Form>
+        </>
     );
 }

--- a/app/client/src/features/events/Questions/QuestionForm/QuestionForm.tsx
+++ b/app/client/src/features/events/Questions/QuestionForm/QuestionForm.tsx
@@ -14,7 +14,7 @@ export type TQuestionFormState = { question: string };
 export interface QuestionFormProps {
     quote?: React.ReactNode;
     onSubmit?: (state: TQuestionFormState) => void;
-    openLinked: () => void; // opensl inked dialog
+    openLinked: () => void; // opens linked dialog
     onCancel?: () => void;
 }
 
@@ -96,4 +96,8 @@ export function QuestionForm({ quote, onSubmit, openLinked, onCancel }: Question
             </FormActions>
         </Form>
     );
+}
+
+QuestionForm.defaultProps = {
+    openLinked: null
 }

--- a/app/client/src/features/events/Questions/QuestionForm/QuestionForm.tsx
+++ b/app/client/src/features/events/Questions/QuestionForm/QuestionForm.tsx
@@ -14,7 +14,7 @@ export type TQuestionFormState = { question: string };
 export interface QuestionFormProps {
     quote?: React.ReactNode;
     onSubmit?: (state: TQuestionFormState) => void;
-    openLinked: () => void;
+    openLinked: () => void; // opensl inked dialog
     onCancel?: () => void;
 }
 
@@ -24,7 +24,7 @@ const useStyles = makeStyles((theme) => ({
     },
     input: {
         ['& fieldset']: {
-            borderRadius: 9999,
+            borderRadius: 9999, // rounded text field
         },
     },
     button: {

--- a/app/client/src/features/events/Questions/QuestionForm/QuestionForm.tsx
+++ b/app/client/src/features/events/Questions/QuestionForm/QuestionForm.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { Button, Link, Grid } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
-import { useResponsiveDialog } from '@local/components/ResponsiveDialog';
 
 import { Form } from '@local/components/Form';
 import { FormTitle } from '@local/components/FormTitle';
@@ -9,15 +8,14 @@ import { FormContent } from '@local/components/FormContent';
 import { FormActions } from '@local/components/FormActions';
 import { TextField } from '@local/components/TextField';
 import { useForm } from '@local/features/core';
-import { LiveFeedbackDialog } from '../../LiveFeedback/LiveFeedbackDialog';
 
 export type TQuestionFormState = { question: string };
 
 export interface QuestionFormProps {
     quote?: React.ReactNode;
     onSubmit?: (state: TQuestionFormState) => void;
+    openLinked: () => void;
     onCancel?: () => void;
-    eventId: string;
 }
 
 const useStyles = makeStyles((theme) => ({
@@ -38,75 +36,64 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 // TODO: eliminate inline styles
-export function QuestionForm({ quote, onSubmit, onCancel, eventId }: QuestionFormProps) {
+export function QuestionForm({ quote, onSubmit, openLinked, onCancel }: QuestionFormProps) {
     const classes = useStyles();
-    const [isOpen, open, close] = useResponsiveDialog();
     // form related hooks
     const [form, errors, handleSubmit, handleChange] = useForm({
         question: '',
     });
 
-    const handleOpenFeedback = () => { open(); if (onCancel) onCancel(); };
-
     const isQuestionValid = React.useMemo(() => form.question.trim().length !== 0, [form]);
 
     return (
-        <>
-            <LiveFeedbackDialog
-                isOpen={isOpen}
-                close={close}
-                eventId={eventId}
-            />
-            
-            <Form onSubmit={handleSubmit(onSubmit)} className={classes.form}>
-                <FormTitle title='Question Form' />
-                {quote}
-                <FormContent>
-                    <TextField
-                        id='question-field'
-                        name='question'
-                        label='Your Question'
-                        autoFocus
-                        error={Boolean(errors.question)}
-                        helperText={errors.question}
-                        required
-                        multiline
-                        value={form.question}
-                        onChange={handleChange('question')}
-                        className={classes.input}
-                    />
-                </FormContent>
-                <FormActions disableGrow gridProps={{ justify: 'space-between' }}>
-                    <Link
-                        variant='body1'
-                        underline='always'
-                        onClick={handleOpenFeedback}
-                        className={classes.link}
-                    >
-                        Have feedback instead?
-                    </Link>
-                    <Grid container spacing={1}>
-                        {onCancel && (
-                            <Grid item>
-                                <Button onClick={onCancel} className={classes.button}>
-                                    Cancel
-                                </Button>
-                            </Grid>
-                        )}
+        <Form onSubmit={handleSubmit(onSubmit)} className={classes.form}>
+            <FormTitle title='Question Form' />
+            {quote}
+            <FormContent>
+                <TextField
+                    id='question-field'
+                    name='question'
+                    label='Your Question'
+                    autoFocus
+                    error={Boolean(errors.question)}
+                    helperText={errors.question}
+                    required
+                    multiline
+                    value={form.question}
+                    onChange={handleChange('question')}
+                    className={classes.input}
+                />
+            </FormContent>
+            <FormActions disableGrow gridProps={{ justify: 'space-between' }}>
+                <Link
+                    variant='body1'
+                    underline='always'
+                    onClick={openLinked}
+                    className={classes.link}
+                >
+                    Have feedback instead?
+                </Link>
+                <Grid container spacing={1}>
+                    {onCancel && (
                         <Grid item>
-                            <Button
-                                disabled={!isQuestionValid}
-                                type='submit'
-                                variant='contained'
-                                color='primary'
-                                className={classes.button}
-                            >
-                                Ask
+                            <Button onClick={onCancel} className={classes.button}>
+                                Cancel
                             </Button>
                         </Grid>
+                    )}
+                    <Grid item>
+                        <Button
+                            disabled={!isQuestionValid}
+                            type='submit'
+                            variant='contained'
+                            color='primary'
+                            className={classes.button}
+                        >
+                            Ask
+                        </Button>
                     </Grid>
-                </FormActions>
-            </Form>
-        </>
+                </Grid>
+            </FormActions>
+        </Form>
     );
 }


### PR DESCRIPTION
<!-- Please follow the provided template -->
### 1. Please briefly explain what it is you coded
Restyled and linked question and feedback forms based on Figma design.

Nodes referenced:
- [Question form](https://www.figma.com/file/UPYJBD7iZboz6nFtLk2MOa/Prytaneum-Recreation?node-id=1382%3A1513)
- [Feedback form](https://www.figma.com/file/UPYJBD7iZboz6nFtLk2MOa/Prytaneum-Recreation?node-id=1410%3A1493)

### 2. Please briefly explain your approach (new components added? modified? removed?)
Modified CSS styling. Relocated question and feedback dialogs to be within the main file for the event sidebar to allow either to be visible no matter which tab (queue, questions, or feedback) is viewed. Added a function within the ResponsiveDialog component to allow a dialog to open another dialog by setting the state to the name/id of the dialog rather than a boolean value.

### 3. Any packages added/updated/removed
N/A

### (Optional) 4. Any feature recommendations/insights/questions/comments/etc.?