### PR TITLE
Updated Pre Commit Hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-yarn workspace @app/client lint
+yarn workspace @app/client build

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,5 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
+yarn workspace @app/client relay
 yarn workspace @app/client build


### PR DESCRIPTION
- The hook now builds the client rather than just linting. This will catch any type errors and will do linting.
- The relay compiler is also run before committing now to catch any relay errors/warnings.