### PR TITLE
Websocket Fix

### DIFF
--- a/app/client/src/features/core/relay.ts
+++ b/app/client/src/features/core/relay.ts
@@ -51,7 +51,7 @@ const initSubscriptionClient = () => {
 
     // For SSG and SSR always create a new subscription client
     if (typeof window === 'undefined') return client;
-    if (!client) subscriptionClient = client;
+    if (!subscriptionClient) subscriptionClient = client;
 
     return client;
 };


### PR DESCRIPTION
The subscription client was never actually being set due to a typo. It should now be set correctly and the client should re-use the connection rather than making a new connection each time a subscription update is made.