### PR TITLE
Event UI: Layout padding adjustment

### DIFF
--- a/app/client/src/pages/_app.tsx
+++ b/app/client/src/pages/_app.tsx
@@ -50,6 +50,7 @@ export default function App({ Component, pageProps }: AppProps) {
                                     <Layout
                                         hideSideNav={pageProps.hideSideNav}
                                         ContainerProps={pageProps.containerProps}
+                                        disablePadding={pageProps.disablePadding}
                                     >
                                         <Component {...pageProps} />
                                     </Layout>

--- a/app/client/src/pages/events/[id]/live.tsx
+++ b/app/client/src/pages/events/[id]/live.tsx
@@ -1,14 +1,28 @@
 import * as React from 'react';
 import { NextPage } from 'next';
 import { useRouter } from 'next/router';
+import { Theme } from '@mui/material/styles';
+import makeStyles from '@mui/styles/makeStyles';
 
 import { ConditionalRender } from '@local/components';
 import { PreloadedEventLive, EventLiveLoader } from '@local/features/events';
+
+const useStyles = makeStyles((theme: Theme) => ({
+    root: {
+        width: '100%',
+        height: '100%',
+        padding: theme.spacing(0, 3), // add side padding since layout padding is disabled
+        [theme.breakpoints.down('lg')]: {
+            padding: theme.spacing(3, 3, 0, 3), // add top padding so event video doesn't touch navbar
+        },
+    },
+}));
 
 export async function getServerSideProps() {
     const baseProps = {
         hideSideNav: true,
         containerProps: { maxWidth: 'xl' },
+        disablePadding: true
     };
 
     return { props: baseProps };
@@ -16,10 +30,11 @@ export async function getServerSideProps() {
 
 const Live: NextPage = () => {
     const router = useRouter();
+    const classes = useStyles();
     if (!router.isReady) return <EventLiveLoader />;
 
     return (
-        <>
+        <div className={classes.root}>
             <ConditionalRender client>
                 <React.Suspense fallback={<EventLiveLoader />}>
                     <PreloadedEventLive eventId={router.query.id as string} token={router.query.token as string} />
@@ -28,7 +43,7 @@ const Live: NextPage = () => {
             <ConditionalRender server>
                 <EventLiveLoader />
             </ConditionalRender>
-        </>
+        </div>
     );
 };
 


### PR DESCRIPTION
- Passed in `disablePadding` attribute in `_app.tsx` in order to disable the padding for the event live page
- Adjust the padding on the event live page so that there is only horizontal padding
  - This way, the questions aren't prematurely clipped at the top or bottom of the page
  - Also added top padding for mobile screens to offset the event video from touching the navbar