### PR TITLE
CI Hotfix

### DIFF
--- a/app/server/src/core/plugins/mercurius.ts
+++ b/app/server/src/core/plugins/mercurius.ts
@@ -8,12 +8,6 @@ import redis from 'mqemitter-redis';
 import { verify } from '@local/lib/jwt';
 import { loadSchema, getPrismaClient } from '../utils';
 
-export const redisEmitter = redis({
-    host: process.env.REDIS_HOST,
-    port: process.env.REDIS_PORT,
-    password: process.env.REDIS_PASSWORD,
-});
-
 /**
  * Helper function for extracting the the authentication JWT from a `FastifyRequest`
  */
@@ -90,7 +84,14 @@ export function attachMercuriusTo(server: FastifyInstance) {
         context: makeRequestContext,
         subscription: {
             context: makeSubscriptionContext,
-            emitter: redisEmitter,
+            emitter:
+                process.env.NODE_ENV === 'production'
+                    ? redis({
+                        host: process.env.REDIS_HOST,
+                        port: process.env.REDIS_PORT,
+                        password: process.env.REDIS_PASSWORD,
+                    })
+                    : undefined,
         },
     });
 

--- a/app/server/src/features/accounts/resolver.integration.test.ts
+++ b/app/server/src/features/accounts/resolver.integration.test.ts
@@ -5,7 +5,6 @@ import { createMercuriusTestClient } from 'mercurius-integration-testing';
 import * as plugins from '@local/core/plugins';
 import * as jwt from '@local/lib/jwt';
 import { toGlobalId } from '../utils';
-import { redisEmitter } from '@local/core/plugins';
 
 const server = getOrCreateServer();
 const testClient = createMercuriusTestClient(server);
@@ -42,7 +41,6 @@ beforeAll(async () => {
 afterAll(async () => {
     await prisma.user.deleteMany();
     await prisma.$disconnect();
-    redisEmitter.close(() => {});
     await server.close();
 });
 

--- a/db/docker-compose.yml
+++ b/db/docker-compose.yml
@@ -15,18 +15,5 @@ services:
             POSTGRES_PASSWORD: postgrespassword
             POSTGRES_DB: postgres
 
-    cache:
-        image: redis:6.2-alpine
-        restart: always
-        ports:
-            - '6379:6379'
-        command: redis-server --save 20 1 --loglevel warning
-        volumes:
-            - cache:/data
-        environment:
-            REDIS_HOST: cache
-            REDIS_PORT: 6379
-            REDIS_PASSWORD:
 volumes:
     db_data:
-    cache:

--- a/db/start-db.sh
+++ b/db/start-db.sh
@@ -10,8 +10,5 @@ export POSTGRES_PORT=3003
 export POSTGRES_USER=postgres
 export POSTGRES_DB=postgres
 export DATABASE_URL="postgresql://$POSTGRES_USER:$POSTGRES_PASSWORD@$POSTGRES_HOST:$POSTGRES_PORT"
-export REDIS_HOST=cache
-export REDIS_PORT=6379
-export REDIS_PASSWORD=
 
 docker-compose -f db/docker-compose.yml up -d --remove-orphans

--- a/db/start-test-db.sh
+++ b/db/start-test-db.sh
@@ -10,8 +10,5 @@ export POSTGRES_PORT=3003
 export POSTGRES_USER=postgres
 export POSTGRES_DB=tests
 export DATABASE_URL="postgresql://$POSTGRES_USER:$POSTGRES_PASSWORD@$POSTGRES_HOST:$POSTGRES_PORT/$POSTGRES_DB"
-export REDIS_HOST=cache
-export REDIS_PORT=6379
-export REDIS_PASSWORD=
 
 docker-compose -f db/docker-compose.yml up -d --remove-orphans


### PR DESCRIPTION
Redis is being created via github action now and is causing conflicts with the redis instance being created via the db docker-compose. Fixed by simply removing it and defaulting the local tests to using the internal mercurious emitter.