### PR TITLE
Deployment Workflow Update

### DIFF
--- a/.github/workflows/client-prod-deploy.yml
+++ b/.github/workflows/client-prod-deploy.yml
@@ -5,7 +5,7 @@ on:
         branches:
             - prod
         paths:
-          - 'app/client/**'
+            - 'app/client/**'
 env:
     PROJECT_ID: ${{ secrets.GKE_PROJECT_ID }}
     GKE_CLUSTER: prytaneum-dev-cluster
@@ -24,12 +24,17 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
+
+            - id: 'auth'
+              uses: 'google-github-actions/auth@v0.8.0'
+              with:
+                  credentials_json: '${{ secrets.GKE_SA_KEY }}'
 
             # Setup gcloud CLI
-            - uses: google-github-actions/setup-gcloud@v0.2.0
+            - name: 'Set up Cloud SDK'
+              uses: google-github-actions/setup-gcloud@v0.6.0
               with:
-                  service_account_key: ${{ secrets.GKE_SA_KEY }}
                   project_id: ${{ secrets.GKE_PROJECT_ID }}
 
             # Configure Docker to use the gcloud command-line tool as a credential
@@ -37,11 +42,11 @@ jobs:
             - run: |-
                   gcloud --quiet auth configure-docker
             # Get the GKE credentials so we can deploy to the cluster
-            - uses: google-github-actions/get-gke-credentials@v0.2.1
+            - id: 'get-credentials'
+              uses: google-github-actions/get-gke-credentials@v0.7.0
               with:
                   cluster_name: ${{ env.GKE_CLUSTER }}
                   location: ${{ env.GKE_ZONE }}
-                  credentials: ${{ secrets.GKE_SA_KEY }}
 
             # Build the Client
             - name: Build Client
@@ -86,34 +91,29 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
+
+            - id: 'auth'
+              uses: 'google-github-actions/auth@v0.8.0'
+              with:
+                  credentials_json: '${{ secrets.GKE_SA_KEY }}'
 
             # Setup gcloud CLI
-            - uses: google-github-actions/setup-gcloud@v0.2.0
+            - name: 'Set up Cloud SDK'
+              uses: google-github-actions/setup-gcloud@v0.6.0
               with:
-                  service_account_key: ${{ secrets.GKE_SA_KEY }}
                   project_id: ${{ secrets.GKE_PROJECT_ID }}
 
             # Configure Docker to use the gcloud command-line tool as a credential
             # helper for authentication
             - run: |-
                   gcloud --quiet auth configure-docker
-            # Get the GKE credentials so we can deploy to the cluster
-            - uses: google-github-actions/get-gke-credentials@v0.2.1
+            # Get the GKE credentials
+            - id: 'get-credentials'
+              uses: google-github-actions/get-gke-credentials@v0.7.0
               with:
                   cluster_name: ${{ env.GKE_CLUSTER }}
                   location: ${{ env.GKE_ZONE }}
-                  credentials: ${{ secrets.GKE_SA_KEY }}
-
-            - name: Kustomize & Deploy Ingress
-              run: |-
-                  cd ./k8s/ingress/production
-                  kubectl apply -f ./prytaneum-ingress.yml
-
-            - name: Deploy Certificate
-              run: |-
-                  cd ./k8s/cert
-                  kubectl apply -f ./prytaneum-managed-certificate-dev.yml
 
             - name: Set kubectl context
               run: |-

--- a/.github/workflows/client-staging-deploy.yml
+++ b/.github/workflows/client-staging-deploy.yml
@@ -27,10 +27,15 @@ jobs:
             - name: Checkout
               uses: actions/checkout@v3
 
-            # Setup gcloud CLI
-            - uses: google-github-actions/setup-gcloud@v0.6.0
+            - id: 'auth'
+              uses: 'google-github-actions/auth@v0.8.0'
               with:
-                  service_account_key: ${{ secrets.GKE_SA_KEY }}
+                  credentials_json: '${{ secrets.GKE_SA_KEY }}'
+
+            # Setup gcloud CLI
+            - name: 'Set up Cloud SDK'
+              uses: google-github-actions/setup-gcloud@v0.6.0
+              with:
                   project_id: ${{ secrets.GKE_PROJECT_ID }}
 
             # Configure Docker to use the gcloud command-line tool as a credential
@@ -38,11 +43,11 @@ jobs:
             - run: |-
                   gcloud --quiet auth configure-docker
             # Get the GKE credentials so we can deploy to the cluster
-            - uses: google-github-actions/get-gke-credentials@v0.7.0
+            - id: 'get-credentials'
+              uses: google-github-actions/get-gke-credentials@v0.7.0
               with:
                   cluster_name: ${{ env.GKE_CLUSTER }}
                   location: ${{ env.GKE_ZONE }}
-                  credentials: ${{ secrets.GKE_SA_KEY }}
 
             # Build the Client
             - name: Build Client
@@ -83,34 +88,29 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
+
+            - id: 'auth'
+              uses: 'google-github-actions/auth@v0.8.0'
+              with:
+                  credentials_json: '${{ secrets.GKE_SA_KEY }}'
 
             # Setup gcloud CLI
-            - uses: google-github-actions/setup-gcloud@v0.2.0
+            - name: 'Set up Cloud SDK'
+              uses: google-github-actions/setup-gcloud@v0.6.0
               with:
-                  service_account_key: ${{ secrets.GKE_SA_KEY }}
                   project_id: ${{ secrets.GKE_PROJECT_ID }}
 
             # Configure Docker to use the gcloud command-line tool as a credential
             # helper for authentication
             - run: |-
                   gcloud --quiet auth configure-docker
-            # Get the GKE credentials so we can deploy to the cluster
-            - uses: google-github-actions/get-gke-credentials@v0.2.1
+            # Get the GKE credentials
+            - id: 'get-credentials'
+              uses: google-github-actions/get-gke-credentials@v0.7.0
               with:
                   cluster_name: ${{ env.GKE_CLUSTER }}
                   location: ${{ env.GKE_ZONE }}
-                  credentials: ${{ secrets.GKE_SA_KEY }}
-
-            - name: Kustomize & Deploy Ingress
-              run: |-
-                  cd ./k8s/ingress/development
-                  kubectl apply -f ./prytaneum-ingress.yml
-
-            - name: Deploy Certificate
-              run: |-
-                  cd ./k8s/cert
-                  kubectl apply -f ./prytaneum-managed-certificate-dev.yml
 
             - name: Set kubectl context
               run: |-

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -5,6 +5,10 @@ on:
         branches:
             - staging
             - prod
+        paths:
+            - '/app/client/**'
+            - '/app/server/**'
+            - '/app/e2e/**'
 
 jobs:
     e2e:
@@ -41,6 +45,9 @@ jobs:
 
             - name: Run Playwright tests
               run: yarn workspace @app/e2e run test:ci
+
+            - name: Generate Allure Report
+              run: yarn workspace @app/e2e run allure:generate-report
 
             - uses: actions/upload-artifact@v2
               if: always()

--- a/.github/workflows/ingress-prod-deploy.yml
+++ b/.github/workflows/ingress-prod-deploy.yml
@@ -1,0 +1,65 @@
+name: Deploy prod ingress
+
+on:
+    push:
+        branches:
+            - prod
+        paths:
+            - 'k8s/ingress/production/**'
+            - 'k8s/cert/**'
+
+env:
+    GKE_CLUSTER: prytaneum-dev-cluster
+    GKE_ZONE: us-central1-a
+    NAMESPACE: development
+    GOOGLE_ANALYTICS_ID: ${{ secrets.DEV_GOOGLE_ANALYTICS_ID }}
+
+jobs:
+    deploy:
+        name: Deploy
+        runs-on: ubuntu-latest
+        environment: development
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v3
+
+            - id: 'auth'
+              uses: 'google-github-actions/auth@v0.8.0'
+              with:
+                  credentials_json: '${{ secrets.GKE_SA_KEY }}'
+
+            # Setup gcloud CLI
+            - name: 'Set up Cloud SDK'
+              uses: google-github-actions/setup-gcloud@v0.6.0
+              with:
+                  project_id: ${{ secrets.GKE_PROJECT_ID }}
+
+            # Configure Docker to use the gcloud command-line tool as a credential
+            # helper for authentication
+            - run: |-
+                  gcloud --quiet auth configure-docker
+            # Get the GKE credentials so we can deploy to the cluster
+            - id: 'get-credentials'
+              uses: google-github-actions/get-gke-credentials@v0.7.0
+              with:
+                  cluster_name: ${{ env.GKE_CLUSTER }}
+                  location: ${{ env.GKE_ZONE }}
+
+            - name: Kustomize & Deploy Ingress
+              run: |-
+                  cd ./k8s/ingress/development
+                  kubectl apply -f ./prytaneum-ingress.yml
+
+            - name: Deploy Certificate
+              run: |-
+                  cd ./k8s/cert
+                  kubectl apply -f ./prytaneum-managed-certificate-dev.yml
+
+            - name: Set kubectl context
+              run: |-
+                  kubectl config set-context --current --namespace=$NAMESPACE
+
+            - name: Deployment Rollout Check
+              run: |-
+                  kubectl get services -o wide

--- a/.github/workflows/ingress-staging-deploy.yml
+++ b/.github/workflows/ingress-staging-deploy.yml
@@ -1,0 +1,65 @@
+name: Deploy staging ingress
+
+on:
+    push:
+        branches:
+            - staging
+        paths:
+            - 'k8s/ingress/development/**'
+            - 'k8s/cert/**'
+
+env:
+    GKE_CLUSTER: prytaneum-dev-cluster
+    GKE_ZONE: us-central1-a
+    NAMESPACE: development
+    GOOGLE_ANALYTICS_ID: ${{ secrets.DEV_GOOGLE_ANALYTICS_ID }}
+
+jobs:
+    deploy:
+        name: Deploy
+        runs-on: ubuntu-latest
+        environment: development
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v3
+
+            - id: 'auth'
+              uses: 'google-github-actions/auth@v0.8.0'
+              with:
+                  credentials_json: '${{ secrets.GKE_SA_KEY }}'
+
+            # Setup gcloud CLI
+            - name: 'Set up Cloud SDK'
+              uses: google-github-actions/setup-gcloud@v0.6.0
+              with:
+                  project_id: ${{ secrets.GKE_PROJECT_ID }}
+
+            # Configure Docker to use the gcloud command-line tool as a credential
+            # helper for authentication
+            - run: |-
+                  gcloud --quiet auth configure-docker
+            # Get the GKE credentials so we can deploy to the cluster
+            - id: 'get-credentials'
+              uses: google-github-actions/get-gke-credentials@v0.7.0
+              with:
+                  cluster_name: ${{ env.GKE_CLUSTER }}
+                  location: ${{ env.GKE_ZONE }}
+
+            - name: Kustomize & Deploy Ingress
+              run: |-
+                  cd ./k8s/ingress/development
+                  kubectl apply -f ./prytaneum-ingress.yml
+
+            - name: Deploy Certificate
+              run: |-
+                  cd ./k8s/cert
+                  kubectl apply -f ./prytaneum-managed-certificate-dev.yml
+
+            - name: Set kubectl context
+              run: |-
+                  kubectl config set-context --current --namespace=$NAMESPACE
+
+            - name: Deployment Rollout Check
+              run: |-
+                  kubectl get services -o wide

--- a/.github/workflows/server-prod-deploy.yml
+++ b/.github/workflows/server-prod-deploy.yml
@@ -23,12 +23,17 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
+
+            - id: 'auth'
+              uses: 'google-github-actions/auth@v0.8.0'
+              with:
+                  credentials_json: '${{ secrets.GKE_SA_KEY }}'
 
             # Setup gcloud CLI
-            - uses: google-github-actions/setup-gcloud@v0.2.0
+            - name: 'Set up Cloud SDK'
+              uses: google-github-actions/setup-gcloud@v0.6.0
               with:
-                  service_account_key: ${{ secrets.GKE_SA_KEY }}
                   project_id: ${{ secrets.GKE_PROJECT_ID }}
 
             # Configure Docker to use the gcloud command-line tool as a credential
@@ -36,11 +41,11 @@ jobs:
             - run: |-
                   gcloud --quiet auth configure-docker
             # Get the GKE credentials so we can deploy to the cluster
-            - uses: google-github-actions/get-gke-credentials@v0.2.1
+            - id: 'get-credentials'
+              uses: google-github-actions/get-gke-credentials@v0.7.0
               with:
                   cluster_name: ${{ env.GKE_CLUSTER }}
                   location: ${{ env.GKE_ZONE }}
-                  credentials: ${{ secrets.GKE_SA_KEY }}
 
             # Build the Server
             - name: Build Server
@@ -82,34 +87,29 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
+
+            - id: 'auth'
+              uses: 'google-github-actions/auth@v0.8.0'
+              with:
+                  credentials_json: '${{ secrets.GKE_SA_KEY }}'
 
             # Setup gcloud CLI
-            - uses: google-github-actions/setup-gcloud@v0.2.0
+            - name: 'Set up Cloud SDK'
+              uses: google-github-actions/setup-gcloud@v0.6.0
               with:
-                  service_account_key: ${{ secrets.GKE_SA_KEY }}
                   project_id: ${{ secrets.GKE_PROJECT_ID }}
 
             # Configure Docker to use the gcloud command-line tool as a credential
             # helper for authentication
             - run: |-
                   gcloud --quiet auth configure-docker
-            # Get the GKE credentials so we can deploy to the cluster
-            - uses: google-github-actions/get-gke-credentials@v0.2.1
+            # Get the GKE credentials
+            - id: 'get-credentials'
+              uses: google-github-actions/get-gke-credentials@v0.7.0
               with:
                   cluster_name: ${{ env.GKE_CLUSTER }}
                   location: ${{ env.GKE_ZONE }}
-                  credentials: ${{ secrets.GKE_SA_KEY }}
-
-            - name: Kustomize & Deploy Ingress
-              run: |-
-                  cd ./k8s/ingress/production
-                  kubectl apply -f ./prytaneum-ingress.yml
-
-            - name: Deploy Certificate
-              run: |-
-                  cd ./k8s/cert
-                  kubectl apply -f ./prytaneum-managed-certificate-dev.yml
 
             - name: Set kubectl context
               run: |-

--- a/.github/workflows/server-staging-deploy.yml
+++ b/.github/workflows/server-staging-deploy.yml
@@ -25,10 +25,15 @@ jobs:
             - name: Checkout
               uses: actions/checkout@v3
 
-            # Setup gcloud CLI
-            - uses: google-github-actions/setup-gcloud@v0.6.0
+            - id: 'auth'
+              uses: 'google-github-actions/auth@v0.8.0'
               with:
-                  service_account_key: ${{ secrets.GKE_SA_KEY }}
+                  credentials_json: '${{ secrets.GKE_SA_KEY }}'
+
+            # Setup gcloud CLI
+            - name: 'Set up Cloud SDK'
+              uses: google-github-actions/setup-gcloud@v0.6.0
+              with:
                   project_id: ${{ secrets.GKE_PROJECT_ID }}
 
             # Configure Docker to use the gcloud command-line tool as a credential
@@ -36,11 +41,11 @@ jobs:
             - run: |-
                   gcloud --quiet auth configure-docker
             # Get the GKE credentials so we can deploy to the cluster
-            - uses: google-github-actions/get-gke-credentials@v0.7.0
+            - id: 'get-credentials'
+              uses: google-github-actions/get-gke-credentials@v0.7.0
               with:
                   cluster_name: ${{ env.GKE_CLUSTER }}
                   location: ${{ env.GKE_ZONE }}
-                  credentials: ${{ secrets.GKE_SA_KEY }}
 
             # Build the Server
             - name: Build Server
@@ -78,12 +83,17 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
+
+            - id: 'auth'
+              uses: 'google-github-actions/auth@v0.8.0'
+              with:
+                  credentials_json: '${{ secrets.GKE_SA_KEY }}'
 
             # Setup gcloud CLI
-            - uses: google-github-actions/setup-gcloud@v0.6.0
+            - name: 'Set up Cloud SDK'
+              uses: google-github-actions/setup-gcloud@v0.6.0
               with:
-                  service_account_key: ${{ secrets.GKE_SA_KEY }}
                   project_id: ${{ secrets.GKE_PROJECT_ID }}
 
             # Configure Docker to use the gcloud command-line tool as a credential
@@ -91,11 +101,11 @@ jobs:
             - run: |-
                   gcloud --quiet auth configure-docker
             # Get the GKE credentials so we can deploy to the cluster
-            - uses: google-github-actions/get-gke-credentials@v0.7.0
+            - id: 'get-credentials'
+              uses: google-github-actions/get-gke-credentials@v0.7.0
               with:
                   cluster_name: ${{ env.GKE_CLUSTER }}
                   location: ${{ env.GKE_ZONE }}
-                  credentials: ${{ secrets.GKE_SA_KEY }}
 
             - name: Set kubectl context
               run: |-


### PR DESCRIPTION
- Ingress/Cert only need to be applied when there are changes to them so they were moved to their own workflow.
- Updated all the actions for deployment to latest versions and removed deprecated items from gcloud actions. Replaced by new [auth action](https://github.com/google-github-actions/get-gke-credentials#authorization)
- e2e workflow should now generate an allure report and only trigger when there are changes to the paths: /app/client, /app/server, and /app/e2e