### PR TITLE
Dockerfile Optimizations + Workflow Trigger

### DIFF
--- a/.github/workflows/client-build-lint-test.yml
+++ b/.github/workflows/client-build-lint-test.yml
@@ -6,6 +6,7 @@ on:
             - staging
         paths:
             - 'app/client/**'
+            - 'docker/Dockerfile.client'
 
 jobs:
     build:

--- a/.github/workflows/client-prod-deploy.yml
+++ b/.github/workflows/client-prod-deploy.yml
@@ -6,6 +6,7 @@ on:
             - prod
         paths:
             - 'app/client/**'
+            - 'docker/Dockerfile.client'
 env:
     PROJECT_ID: ${{ secrets.GKE_PROJECT_ID }}
     GKE_CLUSTER: prytaneum-dev-cluster

--- a/.github/workflows/client-staging-deploy.yml
+++ b/.github/workflows/client-staging-deploy.yml
@@ -6,6 +6,7 @@ on:
             - staging
         paths:
             - 'app/client/**'
+            - 'docker/Dockerfile.client'
 
 env:
     PROJECT_ID: ${{ secrets.GKE_PROJECT_ID }}

--- a/.github/workflows/server-build-lint-test.yml
+++ b/.github/workflows/server-build-lint-test.yml
@@ -6,6 +6,7 @@ on:
             - staging
         paths:
             - 'app/server/**'
+            - 'docker/Dockerfile.server'
 
 jobs:
     build:

--- a/.github/workflows/server-prod-deploy.yml
+++ b/.github/workflows/server-prod-deploy.yml
@@ -4,6 +4,7 @@ on:
     push:
         branches:
             - prod
+            - 'docker/Dockerfile.server'
 
 env:
     PROJECT_ID: ${{ secrets.GKE_PROJECT_ID }}

--- a/.github/workflows/server-staging-deploy.yml
+++ b/.github/workflows/server-staging-deploy.yml
@@ -4,6 +4,7 @@ on:
     push:
         branches:
             - staging
+            - 'docker/Dockerfile.server'
 
 env:
     PROJECT_ID: ${{ secrets.GKE_PROJECT_ID }}

--- a/docker/Dockerfile.client
+++ b/docker/Dockerfile.client
@@ -1,6 +1,6 @@
 FROM node:16.14.2-alpine AS build-stage
 WORKDIR /usr/monorepo
-# Copy all nessisary files/folders
+# Copy all necessary files/folders
 COPY package.json .
 COPY yarn.lock .
 COPY .yarnrc.yml .

--- a/docker/Dockerfile.client
+++ b/docker/Dockerfile.client
@@ -15,12 +15,11 @@ ARG GRAPHQL_URL=https://prytaneum.io/graphql
 ENV NEXT_PUBLIC_GRAPHQL_URL ${GRAPHQL_URL}
 ARG GOOGLE_ANALYTICS_ID=secret
 ENV NEXT_PUBLIC_GOOGLE_ANALYTICS ${GOOGLE_ANALYTICS_ID}
-ENV NEXT_SHARP_PATH=/usr/monorepo/.yarn/cache/sharp-npm-0.30.6-4067fc2ceb-2560b5769d.zip/node_modules/sharp
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
 RUN apk add --no-cache libc6-compat
 RUN yarn install
 RUN yarn workspace @app/client build
-# Production image, copy all the files and run next
+
 FROM node:16.14.2-alpine AS production-stage
 WORKDIR /usr/monorepo
 # Set appropriate env variables
@@ -29,7 +28,6 @@ ENV HOST 0.0.0.0
 ENV PORT 3000
 ARG DEPLOYMENT_ENV=production
 ENV DEPLOYMENT_ENV ${DEPLOYMENT_ENV}
-ENV NEXT_SHARP_PATH=/usr/monorepo/.yarn/cache/sharp-npm-0.30.6-4067fc2ceb-2560b5769d.zip/node_modules/sharp
 # Monorepo files
 COPY --from=build-stage /usr/monorepo/package.json ./
 COPY --from=build-stage /usr/monorepo/.yarnrc.yml ./
@@ -43,6 +41,7 @@ COPY --from=build-stage /usr/monorepo/app/client/.next ./app/client/.next
 COPY --from=build-stage /usr/monorepo/app/client/public ./app/client/public
 COPY --from=build-stage /usr/monorepo/app/client/next.config.js ./app/client
 COPY --from=build-stage /usr/monorepo/app/client/package.json ./app/client
+# Install only packages necessary for the client to run
 RUN yarn workspaces focus --production @app/client
 EXPOSE 3000
 CMD ["yarn", "workspace", "@app/client", "start"]

--- a/docker/Dockerfile.client
+++ b/docker/Dockerfile.client
@@ -1,6 +1,16 @@
 FROM node:16.14.2-alpine AS build-stage
 WORKDIR /usr/monorepo
-COPY . .
+# Copy all nessisary files/folders
+COPY package.json .
+COPY yarn.lock .
+COPY .yarnrc.yml .
+COPY .yarn ./.yarn
+COPY .nvmrc .
+COPY tsconfig.json .
+COPY .pnp.cjs .
+COPY .pnp.loader.mjs .
+COPY app/client ./app/client
+# Set up build environment variables
 ARG GRAPHQL_URL=https://prytaneum.io/graphql
 ENV NEXT_PUBLIC_GRAPHQL_URL ${GRAPHQL_URL}
 ARG GOOGLE_ANALYTICS_ID=secret
@@ -10,7 +20,6 @@ ENV NEXT_SHARP_PATH=/usr/monorepo/.yarn/cache/sharp-npm-0.30.6-4067fc2ceb-2560b5
 RUN apk add --no-cache libc6-compat
 RUN yarn install
 RUN yarn workspace @app/client build
-
 # Production image, copy all the files and run next
 FROM node:16.14.2-alpine AS production-stage
 WORKDIR /usr/monorepo
@@ -30,11 +39,10 @@ COPY --from=build-stage /usr/monorepo/.nvmrc ./
 COPY --from=build-stage /usr/monorepo/.yarn/releases ./.yarn/releases
 COPY --from=build-stage /usr/monorepo/.yarn/plugins ./.yarn/plugins
 # Client specific files
-COPY --from=build-stage /usr/monorepo/app/client ./app/client
-# COPY --from=build-stage /usr/monorepo/app/client/next.config.js ./app/client
-# COPY --from=build-stage /usr/monorepo/app/client/package.json ./app/client
-# COPY --from=build-stage /usr/monorepo/app/client/.next ./app/client/.next
-# COPY --from=build-stage /usr/monorepo/app/client/public ./app/client/public
+COPY --from=build-stage /usr/monorepo/app/client/.next ./app/client/.next
+COPY --from=build-stage /usr/monorepo/app/client/public ./app/client/public
+COPY --from=build-stage /usr/monorepo/app/client/next.config.js ./app/client
+COPY --from=build-stage /usr/monorepo/app/client/package.json ./app/client
 RUN yarn workspaces focus --production @app/client
 EXPOSE 3000
 CMD ["yarn", "workspace", "@app/client", "start"]

--- a/docker/Dockerfile.server
+++ b/docker/Dockerfile.server
@@ -1,6 +1,6 @@
 FROM node:16.14.2-alpine AS build-stage
 WORKDIR /usr/monorepo
-# Copy all nessisary files/folders
+# Copy all necessary files/folders
 COPY package.json .
 COPY yarn.lock .
 COPY .yarnrc.yml .

--- a/docker/Dockerfile.server
+++ b/docker/Dockerfile.server
@@ -1,7 +1,15 @@
 FROM node:16.14.2-alpine AS build-stage
 WORKDIR /usr/monorepo
-# Copy everything
-COPY . .
+# Copy all nessisary files/folders
+COPY package.json .
+COPY yarn.lock .
+COPY .yarnrc.yml .
+COPY .yarn ./.yarn
+COPY .nvmrc .
+COPY tsconfig.json .
+COPY .pnp.cjs .
+COPY .pnp.loader.mjs .
+COPY app/server ./app/server
 # Rebuild packages necessary.
 RUN yarn install
 # Ensure prisma types are generated appropriately.


### PR DESCRIPTION
- Copies only necessary files/folders instead of everything in monorepo on build stage for client and server
- Client now only copies the required build files and not the entire app/client folder.
- Added trigger so that workflows that build the dockerfiles will run when the corresponding dockerfile is edited. Ensures that any changes to the dockerfiles are tested in PR and are pushed to staging and prodution deployments.