### PR TITLE
Server CI Fix

### DIFF
--- a/.github/workflows/server-build-lint-test.yml
+++ b/.github/workflows/server-build-lint-test.yml
@@ -25,11 +25,11 @@ jobs:
             - name: Yarn Install
               run: yarn install
 
-            # Build the client via docker so we are as close to the real build as possible.
+            # Build the server via docker so we are as close to the real build as possible.
             - name: Docker build
               run: |-
                   docker build \
-                    -f ./docker/Dockerfile.client \
+                    -f ./docker/Dockerfile.server \
                     --build-arg GITHUB_SHA="$GITHUB_SHA" \
                     --build-arg GITHUB_REF="$GITHUB_REF" \
                     --build-arg GRAPHQL_URL="123" \


### PR DESCRIPTION
- The server-build-lint-test workflow was building the client dockerfile and not the server dockerfile as it should be. 