### PR TITLE
Docker-Compose Fix

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
         volumes:
             - type: bind
               source: .
-              target: /usr/monorepo
+              target: /usr/monorepo:rw
         working_dir: /usr/monorepo
         ports:
             - 8080:8080
@@ -16,6 +16,7 @@ services:
             - DATABASE_URL=postgresql://postgres:postgrespassword@db:5432
     db:
         container_name: db
+        user: postgres
         image: postgres:13
         restart: always
         volumes:


### PR DESCRIPTION
The volume mounting on the previous version of the docker-compose file was updating the owner of some files to root, which was causing issues when running other commands such as e2e testing locally. Adding a rw flag to the target seems to have fixed this issue, keeping the original owner for files.