### PR TITLE
Workflow change

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,7 +3,6 @@ name: Test end-to-end
 on:
     pull_request:
         branches:
-            - staging
             - prod
         paths:
             - 'app/client/**'

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,1 +1,26 @@
-module.exports = {extends: ['@commitlint/config-conventional']}
+module.exports = {
+    extends: ['@commitlint/config-conventional'],
+    rules: {
+        'type-enum': [
+            2,
+            'always',
+            [
+                'feat',
+                'fix',
+                'docs',
+                'style',
+                'refactor',
+                'perf',
+                'test',
+                'build',
+                'ci',
+                'chore',
+                'revert',
+                'workflow',
+                'wip',
+                'config',
+                'package',
+            ],
+        ],
+    },
+};


### PR DESCRIPTION
- e2e tests are currently pretty slow and can be run much faster client side, important to check before moving into production but overkill for every pull request update. If I can get parallelization working for the e2e tests or turbo setup to the point that the tests are cached and fast then this can be reverted. 
- More options for commit lint type field.