### PR TITLE
Hotfix

### DIFF
--- a/app/client/src/features/accounts/RegisterForm.tsx
+++ b/app/client/src/features/accounts/RegisterForm.tsx
@@ -130,7 +130,10 @@ export function RegisterForm({ onSuccess, onFailure, secondaryActions }: Props) 
                         name='password'
                         required
                         error={Boolean(errors.password)}
-                        helperText={errors.password || 'Passwords must be at least 8 characters'}
+                        helperText={
+                            errors.password ||
+                            'Passwords must be at least 8 characters long and contain at least one lowercase letter, capital letter, number, and symbol.'
+                        }
                         type={isPassVisible ? 'text' : 'password'}
                         value={form.password}
                         onChange={handleChange('password')}

--- a/app/client/src/features/accounts/UserMenu/UserMenu.tsx
+++ b/app/client/src/features/accounts/UserMenu/UserMenu.tsx
@@ -189,8 +189,8 @@ export function UserMenu({ className, queryRef }: UserMenuProps) {
                             <LoginForm
                                 close={close}
                                 onSuccess={() => {
-                                    close();
                                     router.reload();
+                                    close();
                                 }}
                             />
                         </DialogContent>
@@ -205,7 +205,12 @@ export function UserMenu({ className, queryRef }: UserMenuProps) {
                     </Button>
                     <ResponsiveDialog open={type === 'register'} onClose={close}>
                         <DialogContent>
-                            <RegisterForm onSuccess={close} />
+                            <RegisterForm
+                                onSuccess={() => {
+                                    router.reload();
+                                    close();
+                                }}
+                            />
                         </DialogContent>
                     </ResponsiveDialog>
                 </>

--- a/app/e2e/playwright.config.ts
+++ b/app/e2e/playwright.config.ts
@@ -24,8 +24,8 @@ const config: PlaywrightTestConfig = {
     },
     /* Fail the build on CI if you accidentally left test.only in the source code. */
     forbidOnly: !!process.env.CI,
-    /* Retry on CI only */
-    retries: process.env.CI ? 3 : 0,
+    /* How many times tests are retried if they fail */
+    retries: process.env.CI ? 3 : 1,
     /* Amount of workers based on number of browsers being tested */
     workers: process.env.CI ? 1 : 6,
     /* Reporter to use. See https://playwright.dev/docs/test-reporters */


### PR DESCRIPTION
- Better helper text for password field on registration
- Reload should trigger in production properly now, before registering didn't reload at all and the login dialogue was being closed before reload could run. (Not 100% sure this was cause for subscription issue for new users but need to test)