### PR TITLE
Hotfix

### DIFF
--- a/app/server/src/features/accounts/methods.ts
+++ b/app/server/src/features/accounts/methods.ts
@@ -134,6 +134,13 @@ export async function register(prisma: PrismaClient, userData: MinimalUser, text
             internalMessage: `A user with the email ${email} already exists.`,
         });
 
+    // TODO remove once shadow user account setup prompt is implemented
+    if (!textPassword)
+        throw new ProtectedError({
+            userMessage: 'Password is required.',
+            internalMessage: 'Shadow account setup is not implemented yet.',
+        });
+
     // It's okay to not have a password, it means this is a user being registered via invitation.
     const encryptedPassword = await maybeValidateAndHashPassword(textPassword);
     return prisma.user.create({

--- a/app/server/src/features/accounts/methods.ts
+++ b/app/server/src/features/accounts/methods.ts
@@ -119,6 +119,21 @@ async function maybeValidateAndHashPassword(password: string | null) {
  */
 export async function register(prisma: PrismaClient, userData: MinimalUser, textPassword: string | null = null) {
     const { email, firstName, lastName } = userData;
+
+    // validiation if no other user exists with the new email
+    const user = await prisma.user.findUnique({ where: { email: email } });
+
+    // https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html#account-creation
+    // This could technically be an attack vector. Say a user creates an account and is trying to see
+    // if a particular email is already registered. We should throw the same type of protected error
+    // that is used on the account creation page.
+    if (!!user)
+        throw new ProtectedError({
+            userMessage: ProtectedError.accountCreationErrorMessage,
+            // This is probably only useful for debugging purposes, but it's still fine to log this anyways.
+            internalMessage: `A user with the email ${email} already exists.`,
+        });
+
     // It's okay to not have a password, it means this is a user being registered via invitation.
     const encryptedPassword = await maybeValidateAndHashPassword(textPassword);
     return prisma.user.create({

--- a/app/server/src/features/accounts/methods.unit.test.ts
+++ b/app/server/src/features/accounts/methods.unit.test.ts
@@ -42,19 +42,19 @@ describe('account methods', () => {
             const expectedOutput = { ...userData };
             expect(output).toEqual(expectedOutput);
         });
+        // TODO Update this test once the shaddow account registration feature is implemented
+        // test('should register new user with null password', async () => {
+        //     // Arrange
+        //     const user = { ...userData, password: null };
+        //     prismaMock.user.create.mockResolvedValueOnce(user);
 
-        test('should register new user with null password', async () => {
-            // Arrange
-            const user = { ...userData, password: null };
-            prismaMock.user.create.mockResolvedValueOnce(user);
+        //     // Act
+        //     const output = await AccountMethods.register(prismaMock, userData, null);
 
-            // Act
-            const output = await AccountMethods.register(prismaMock, userData, null);
-
-            // Assert
-            const expectedOutput = { ...userData, password: null };
-            expect(output).toEqual(expectedOutput);
-        });
+        //     // Assert
+        //     const expectedOutput = { ...userData, password: null };
+        //     expect(output).toEqual(expectedOutput);
+        // });
     });
 
     describe('findUserById', () => {

--- a/app/server/src/features/utils.ts
+++ b/app/server/src/features/utils.ts
@@ -109,8 +109,7 @@ export async function runMutation<TReturn>(cb: TCallback<TReturn>): TRunMutation
                 body: null,
             };
         }
-        getOrCreateServer().log.error('Error is not an instance of ProtectedError!');
-        getOrCreateServer().log.error(e.message);
+        getOrCreateServer().log.error(`Error is not an instance of ProtectedError! Error: ${JSON.stringify(e)}}`);
         return {
             isError: true,
             message: 'Internal server error. Please try again.',


### PR DESCRIPTION
- Since shadow account setup is not implemented yet the feature will be disabled for now so that only existing users can be invited via email. This can be reverted easily once the setup is completed.
- Non protected error messages were not showing up in production logs, so the logging has been updated to try and stringy the error so it is visible in the prod logs.
- Validation checks for existing accounts was missing from the registration (it was only in the update email method) so it has been added. Only internal logs will show a msg relating to account already existing but msg to user is a bit more clear.