### PR TITLE
Image Memory Leak Fix

### DIFF
--- a/app/client/.eslintrc.js
+++ b/app/client/.eslintrc.js
@@ -44,6 +44,7 @@ module.exports = {
         'react/require-default-props': 'off',
         'import/no-anonymous-default-export': 'off',
         'react/display-name': [0, { ignoreTranspilerName: true }],
+        '@next/next/no-img-element': 'off',
     },
     overrides: [
         {

--- a/app/client/next.config.js
+++ b/app/client/next.config.js
@@ -3,8 +3,9 @@ module.exports = {
     images: {
         domains: ['storage.googleapis.com'],
         minimumCacheTTL: 31536000,
+        unoptimized: true, // To fix memory leak issue | REF: https://github.com/vercel/next.js/issues/44685
     },
     typescript: {
-        tsconfigPath: './tsconfig.prod.json'
-    }
+        tsconfigPath: './tsconfig.prod.json',
+    },
 };

--- a/app/client/src/components/Dialog.tsx
+++ b/app/client/src/components/Dialog.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import Image from 'next/image';
 import { Dialog, DialogTitle, IconButton } from '@mui/material';
 import { styled } from '@mui/material/styles';
 
@@ -35,7 +34,7 @@ export function StyledDialogTitle(props: DialogTitleProps) {
                         color: (theme) => theme.palette.grey[500],
                     }}
                 >
-                    <Image src='/static/Close_Button.svg' alt='Close Button' width='27px' height='27px' />
+                    <img src='/static/Close_Button.svg' alt='Close Button' width='27px' height='27px' />
                 </IconButton>
             ) : null}
         </DialogTitle>

--- a/app/client/src/features/guides/getting-started-guide.tsx
+++ b/app/client/src/features/guides/getting-started-guide.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import Image from 'next/image';
 import { Chip, Grid, Link, Paper, Typography } from '@mui/material';
 import BookOutlinedIcon from '@mui/icons-material/BookOutlined';
 import makeStyles from '@mui/styles/makeStyles';
@@ -50,6 +49,9 @@ const useStyles = makeStyles((theme) => ({
         width: '100%',
         padding: theme.spacing(2),
     },
+    contain: {
+        objectFit: 'contain',
+    },
 }));
 
 export default function GettingStartedGuide() {
@@ -58,11 +60,11 @@ export default function GettingStartedGuide() {
     return (
         <Grid container alignItems='center' className={classes.root} justifyContent='center' spacing={4}>
             <Grid item xs={4} sm={3}>
-                <Image
+                <img
+                    className={classes.contain}
                     src='/static/prytaneum_logo.svg'
-                    width={1107}
-                    height={1108}
-                    objectFit='contain'
+                    width='100%'
+                    height='100%'
                     alt='Prytaneum Logo'
                 />
             </Grid>

--- a/app/client/src/features/guides/moderator-guide.tsx
+++ b/app/client/src/features/guides/moderator-guide.tsx
@@ -1,6 +1,4 @@
-/* eslint-disable @next/next/no-img-element */
 import * as React from 'react';
-import Image from 'next/image';
 import {
     Button,
     Chip,
@@ -97,8 +95,8 @@ const useStyles = makeStyles(() => ({
         zIndex: 100,
     },
     contain: {
-        objectFit: 'contain'
-    }
+        objectFit: 'contain',
+    },
 }));
 
 export default function ModeratorGuide() {
@@ -159,11 +157,11 @@ export default function ModeratorGuide() {
     return (
         <Grid container alignItems='center' className={classes.root} justifyContent='center' spacing={4}>
             <Grid item xs={4} sm={3}>
-                <Image
+                <img
+                    className={classes.contain}
                     src='/static/prytaneum_logo.svg'
-                    width={1107}
-                    height={1108}
-                    objectFit='contain'
+                    width='100%'
+                    height='100%'
                     alt='Prytaneum Logo'
                 />
             </Grid>

--- a/app/client/src/features/guides/organizer-guide.tsx
+++ b/app/client/src/features/guides/organizer-guide.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @next/next/no-img-element */
 import * as React from 'react';
 import { Grid, Link, Typography } from '@mui/material';
 import BookOutlinedIcon from '@mui/icons-material/BookOutlined';
@@ -30,7 +29,7 @@ const useStyles = makeStyles((theme) => ({
         gap: '0.5rem',
     },
     formWidth: {
-        maxWidth: '560'
+        maxWidth: '560',
     },
     icon: {
         fontSize: '2.25rem',
@@ -44,8 +43,8 @@ const useStyles = makeStyles((theme) => ({
         padding: theme.spacing(2),
     },
     contain: {
-        objectFit: 'contain'
-    }
+        objectFit: 'contain',
+    },
 }));
 
 export default function OrganizerGuide() {
@@ -74,9 +73,10 @@ export default function OrganizerGuide() {
         <Grid container alignItems='center' className={classes.root} justifyContent='center' spacing={4}>
             <Grid item xs={4} sm={3}>
                 <img
+                    className={classes.contain}
                     src='/static/prytaneum_logo.svg'
                     width='100%'
-                    className={classes.contain}
+                    height='100%'
                     alt='Prytaneum Logo'
                 />
             </Grid>
@@ -116,14 +116,9 @@ export default function OrganizerGuide() {
             <Grid item xs={12} className={classes.section}>
                 <Typography variant='body1' className={classes.paragraph}>
                     If you don&#39;t have an organization yet, you can create one by clicking the{' '}
-                    <img
-                        src='/static/fab.svg'
-                        width={27}
-                        className={classes.contain}
-                        alt='Fab Icon'
-                    />{' '}
-                    in the bottom right corner of the page. Selecting an organization will show you the
-                    organization&#39;s events and members. Here, you can create new events and invite new members.
+                    <img src='/static/fab.svg' width={27} className={classes.contain} alt='Fab Icon' /> in the bottom
+                    right corner of the page. Selecting an organization will show you the organization&#39;s events and
+                    members. Here, you can create new events and invite new members.
                 </Typography>
             </Grid>
             <Grid item xs={12} className={classes.centeredSection}>

--- a/app/client/src/features/guides/participant-guide.tsx
+++ b/app/client/src/features/guides/participant-guide.tsx
@@ -1,6 +1,4 @@
-/* eslint-disable @next/next/no-img-element */
 import * as React from 'react';
-import Image from 'next/image';
 import {
     Button,
     Chip,
@@ -95,8 +93,8 @@ const useStyles = makeStyles(() => ({
         zIndex: 100,
     },
     contain: {
-        objectFit: 'contain'
-    }
+        objectFit: 'contain',
+    },
 }));
 
 export default function ParticipantGuide() {
@@ -152,11 +150,11 @@ export default function ParticipantGuide() {
     return (
         <Grid container alignItems='center' className={classes.root} justifyContent='center' spacing={4}>
             <Grid item xs={4} sm={3}>
-                <Image
+                <img
+                    className={classes.contain}
                     src='/static/prytaneum_logo.svg'
-                    width={1107}
-                    height={1108}
-                    objectFit='contain'
+                    width='100%'
+                    height='100%'
                     alt='Prytaneum Logo'
                 />
             </Grid>

--- a/app/client/src/features/guides/template.tsx
+++ b/app/client/src/features/guides/template.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import Image from 'next/image';
 import { Grid, Link, Typography } from '@mui/material';
 import BookOutlinedIcon from '@mui/icons-material/BookOutlined';
 import makeStyles from '@mui/styles/makeStyles';
@@ -28,6 +27,9 @@ const useStyles = makeStyles(() => ({
     icon: {
         fontSize: '2.25rem',
     },
+    contain: {
+        objectFit: 'contain',
+    },
 }));
 
 export default function Guide() {
@@ -36,11 +38,11 @@ export default function Guide() {
     return (
         <Grid container alignItems='center' className={classes.root} justifyContent='center' spacing={4}>
             <Grid item xs={4} sm={3}>
-                <Image
+                <img
+                    className={classes.contain}
                     src='/static/prytaneum_logo.svg'
-                    width={1107}
-                    height={1108}
-                    objectFit='contain'
+                    width='100%'
+                    height='100%'
                     alt='Prytaneum Logo'
                 />
             </Grid>

--- a/app/client/src/features/landing/CallToAction/CallToAction.tsx
+++ b/app/client/src/features/landing/CallToAction/CallToAction.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import Image from 'next/image';
 import { Grid, Typography, Button } from '@mui/material';
 import makeStyles from '@mui/styles/makeStyles';
 import { useRouter } from 'next/router';
@@ -38,6 +37,9 @@ const useStyles = makeStyles((theme) => ({
             fontSize: 20,
         },
     },
+    contain: {
+        objectFit: 'contain',
+    },
 }));
 
 export function CallToAction() {
@@ -48,13 +50,13 @@ export function CallToAction() {
     return (
         <>
             <Grid item xs={12} md={6} className={classes.header}>
-                <Image
+                <img
+                    className={classes.contain}
                     data-test-id='landing-prytanum-logo'
                     alt='Prytaneum Logo'
                     src='/static/prytaneum_logo2.svg'
-                    width={3483}
-                    height={665}
-                    objectFit='contain'
+                    width='100%'
+                    height='100%'
                 />
                 <Typography variant='h5' className={classes.subtitle}>
                     A crucial tool for a better democracy.
@@ -81,12 +83,12 @@ export function CallToAction() {
                 )}
             </Grid>
             <Grid item xs={12} md={6}>
-                <Image
+                <img
+                    className={classes.contain}
                     alt='Prytaneum Landing Graphic'
                     src='/static/prytaneum_landing_graphic.svg'
-                    width={3292}
-                    height={2097}
-                    objectFit='contain'
+                    width='100%'
+                    height='100%'
                 />
             </Grid>
         </>

--- a/app/client/src/features/landing/InteractiveDemo/InteractiveDemo.tsx
+++ b/app/client/src/features/landing/InteractiveDemo/InteractiveDemo.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import Image from 'next/image';
 import { Grid, Typography, Paper, Button, IconButton, Avatar, InputAdornment, Chip, TextField } from '@mui/material';
 import QuestionAnswerIcon from '@mui/icons-material/QuestionAnswer';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
@@ -241,6 +240,9 @@ const useStyles = makeStyles((theme) => ({
             display: 'none',
         },
     },
+    contain: {
+        objectFit: 'contain',
+    },
 }));
 
 interface WindowProps {
@@ -300,12 +302,12 @@ function Tabs() {
         <Grid container item xs={12} className={classes.windowheader}>
             <div className={classes.tabs}>
                 <div className={classes.logo}>
-                    <Image
+                    <img
+                        className={classes.contain}
                         alt='Prytaneum Logo'
                         src='/static/prytaneum_logo.svg'
-                        width={50}
-                        height={49}
-                        objectFit='contain'
+                        width='100%'
+                        height='100%'
                     />
                 </div>
                 <div>Home</div>
@@ -329,10 +331,22 @@ function MeetingDisplay() {
         <Grid item xs={12} lg={7}>
             <div className={classes.windowdisplay}>
                 <Grid item xs={6}>
-                    <Image alt='Speaker Camera' src='/static/cam1.png' width={1146} height={648} objectFit='contain' />
+                    <img
+                        className={classes.contain}
+                        alt='Speaker Camera'
+                        src='/static/cam1.png'
+                        width='100%'
+                        height='100%'
+                    />
                 </Grid>
                 <Grid item xs={6}>
-                    <Image alt='Speaker Camera' src='/static/cam2.png' width={1146} height={648} objectFit='contain' />
+                    <img
+                        className={classes.contain}
+                        alt='Speaker Camera'
+                        src='/static/cam2.png'
+                        width='100%'
+                        height='100%'
+                    />
                 </Grid>
             </div>
             <div className={classes.windowtitle}>

--- a/app/client/src/features/landing/Landing.tsx
+++ b/app/client/src/features/landing/Landing.tsx
@@ -1,14 +1,13 @@
 import * as React from 'react';
-import Image from 'next/image';
 import { Grid } from '@mui/material';
 import PeopleAltOutlinedIcon from '@mui/icons-material/PeopleAltOutlined';
 import RecordVoiceOverOutlinedIcon from '@mui/icons-material/RecordVoiceOverOutlined';
 import SupervisedUserCircleOutlinedIcon from '@mui/icons-material/SupervisedUserCircleOutlined';
 import makeStyles from '@mui/styles/makeStyles';
-import { CallToAction } from '@local/features/landing/CallToAction'
-import { Blurb } from '@local/features/landing/Blurb'
+import { CallToAction } from '@local/features/landing/CallToAction';
+import { Blurb } from '@local/features/landing/Blurb';
 import { Carousel } from '@local/features/landing/Carousel';
-import { ParticipantDemo, ModeratorDemo } from '@local/features/landing/InteractiveDemo'
+import { ParticipantDemo, ModeratorDemo } from '@local/features/landing/InteractiveDemo';
 // import { ScrollButton } from '@local/features/promo/ScrollButton'
 // import { ConditionalRender } from '@local/components';
 
@@ -34,7 +33,7 @@ const useStyles = makeStyles((theme) => ({
     },
     downarrow: {
         fontSize: '4rem',
-        transform: 'rotate(-90deg)'
+        transform: 'rotate(-90deg)',
     },
     // sentinel: {
     //     paddingTop: theme.spacing(4), // offset for scroll
@@ -49,122 +48,84 @@ export default function Landing() {
             key='blurb1'
             title='Participant Role'
             icon={<PeopleAltOutlinedIcon />}
-            paragraphs={
-                [
-                    'The residents who want to engage in discussion on a policy topic. Participants can type and ask questions; they can like, quote, and reply to other participant\'s questions; they can participate in breakout rooms.',
-                ]
-            }
+            paragraphs={[
+                // eslint-disable-next-line quotes
+                "The residents who want to engage in discussion on a policy topic. Participants can type and ask questions; they can like, quote, and reply to other participant's questions; they can participate in breakout rooms.",
+            ]}
         />,
         <Blurb
             key='blurb2'
             title='Moderator Role'
             icon={<SupervisedUserCircleOutlinedIcon />}
-            paragraphs={
-                [
-                    'The mediators who handle participants\' questions to be answered by the speaker. Moderators see the full question list and the question queue that was  curated by the moderator assistants; they select which question to ask next;  they ask the question on the video call for the speaker to respond. Moderators interact with the speaker via a streaming service of the organizer\'s choice.',
-                ]
-            }
+            paragraphs={[
+                // eslint-disable-next-line quotes
+                "The mediators who handle participants' questions to be answered by the speaker. Moderators see the full question list and the question queue that was  curated by the moderator assistants; they select which question to ask next;  they ask the question on the video call for the speaker to respond. Moderators interact with the speaker via a streaming service of the organizer's choice.",
+            ]}
         />,
         <Blurb
             key='blurb3'
             title='Speaker Role'
             icon={<RecordVoiceOverOutlinedIcon />}
-            paragraphs={
-                [
-                    'The main speaker of a discussion. The speaker does not see the question list or  the question queue. Instead, meetings appear like an ordinary video call with  the moderator. The speaker interacts with the moderators via a streaming service  of the organizer\'s choice.',
-                ]
-            }
+            paragraphs={[
+                // eslint-disable-next-line quotes
+                "The main speaker of a discussion. The speaker does not see the question list or  the question queue. Instead, meetings appear like an ordinary video call with  the moderator. The speaker interacts with the moderators via a streaming service  of the organizer's choice.",
+            ]}
         />,
-    ]
+    ];
 
     const views = [
-        <ParticipantDemo
-            key='view1'
-            title='Participant View'
-            shadow='10px 10px 0 0 #4056a1'
-            scale='scale(0.95)'
-        />,
-        <ModeratorDemo
-            key='view2'
-            title='Moderator View'
-            shadow='10px 10px 0 0 #8eafff'
-            scale='scale(0.95)'
-        />,
-    ]
+        <ParticipantDemo key='view1' title='Participant View' shadow='10px 10px 0 0 #4056a1' scale='scale(0.95)' />,
+        <ModeratorDemo key='view2' title='Moderator View' shadow='10px 10px 0 0 #8eafff' scale='scale(0.95)' />,
+    ];
 
     // const sentinelRef = React.useRef<HTMLDivElement | null>(null);
 
-    return <>
-        <Grid container alignItems='center' justifyContent='center' spacing={2} className={classes.landing}>
-            <CallToAction />
-            {/* TODO: Fix auto-scroll
+    return (
+        <>
+            <Grid container alignItems='center' justifyContent='center' spacing={2} className={classes.landing}>
+                <CallToAction />
+                {/* TODO: Fix auto-scroll
             <ConditionalRender client>
                 <ScrollButton sentinelRef={sentinelRef}/>
             </ConditionalRender> */}
-        </Grid>
-        {/* <div ref={sentinelRef} className={classes.sentinel}> */}
-        <Grid container alignItems='center' justifyContent='center' spacing={2} className={classes.root}>
-            <Blurb
-                title='What is Prytaneum?'
-                paragraphs={
-                    [
+            </Grid>
+            {/* <div ref={sentinelRef} className={classes.sentinel}> */}
+            <Grid container alignItems='center' justifyContent='center' spacing={2} className={classes.root}>
+                <Blurb
+                    title='What is Prytaneum?'
+                    paragraphs={[
                         'Prytaneum is an open-source, highly-interactive online town hall platform powered by artificial intelligence and an innovative user interface.',
-                        'Our town hall platform enables constructive, virtual dialogue between government officials and their constituents - creating opportunities for democratic engagement that is not available through commercially available webinar or streaming platforms.'
-                    ]
-                }
-            />
-            <Grid item xs={12}>
-                <ParticipantDemo
-                    shadow='10px 10px 0 0 #f5c64f'
-                    scale='scale(0.95)'
+                        'Our town hall platform enables constructive, virtual dialogue between government officials and their constituents - creating opportunities for democratic engagement that is not available through commercially available webinar or streaming platforms.',
+                    ]}
                 />
+                <Grid item xs={12}>
+                    <ParticipantDemo shadow='10px 10px 0 0 #f5c64f' scale='scale(0.95)' />
+                </Grid>
             </Grid>
-        </Grid>
-        {/* </div> */}
-        <Grid container alignItems='center' justifyContent='center' spacing={2} className={classes.root}>
-            <Blurb
-                title='A better solution for remote public engagement.'
-            />
-            <Carousel cards={views} />
-        </Grid>
-        <Grid container alignItems='center' justifyContent='center' spacing={2} className={classes.root}>
-            <Blurb
-                paragraphs={
-                    [
+            {/* </div> */}
+            <Grid container alignItems='center' justifyContent='center' spacing={2} className={classes.root}>
+                <Blurb title='A better solution for remote public engagement.' />
+                <Carousel cards={views} />
+            </Grid>
+            <Grid container alignItems='center' justifyContent='center' spacing={2} className={classes.root}>
+                <Blurb
+                    paragraphs={[
                         'Just like any town hall, Prytaneum offers roles to fit the needs of any attendee: organizer, speaker, moderator, moderator assistant, and participant. Prytaneum complements these roles by promoting constructive engagement through the user interface and “pro-social” algorithm.',
-                    ]
-                }
-            />
-            <Carousel cards={roles} />
-        </Grid>
-        <Grid container alignItems='center' justifyContent='center' spacing={3} className={classes.root}>
-            <Grid item>
-                <Image
-                    src='/static/democracy_fund_logo.svg'
-                    width={280}
-                    height={200}
-                    objectFit='contain'
-                    alt='democracy fund logo'
+                    ]}
                 />
+                <Carousel cards={roles} />
             </Grid>
-            <Grid item>
-                <Image
-                    src='/static/prytaneum_logo.svg'
-                    width={150}
-                    height={200}
-                    objectFit='contain'
-                    alt='prytaneum logo'
-                />
+            <Grid container alignItems='center' justifyContent='center' spacing={3} className={classes.root}>
+                <Grid item>
+                    <img src='/static/democracy_fund_logo.svg' width={280} height={200} alt='democracy fund logo' />
+                </Grid>
+                <Grid item>
+                    <img src='/static/prytaneum_logo.svg' width={150} height={200} alt='prytaneum logo' />
+                </Grid>
+                <Grid item>
+                    <img src='/static/ucr_tecd_logo.svg' width={450} height={200} alt='ucr tecd logo' />
+                </Grid>
             </Grid>
-            <Grid item>
-                <Image
-                    src='/static/ucr_tecd_logo.svg'
-                    width={450}
-                    height={200}
-                    objectFit='contain'
-                    alt='ucr tecd logo'
-                />
-            </Grid>
-        </Grid>
-    </>;
+        </>
+    );
 }

--- a/app/client/src/layout/AppBar/Title.tsx
+++ b/app/client/src/layout/AppBar/Title.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @next/next/no-img-element */
 import * as React from 'react';
 import makeStyles from '@mui/styles/makeStyles';
 

--- a/app/client/src/pages/aboutus.tsx
+++ b/app/client/src/pages/aboutus.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import Image from 'next/image';
 import { Grid, Typography } from '@mui/material';
 import { makeStyles } from '@mui/styles';
 
@@ -18,7 +17,10 @@ const useStyles = makeStyles((theme) => ({
         textAlign: 'center',
     },
     paragraph: {
-        fontSize: 'large'
+        fontSize: 'large',
+    },
+    contain: {
+        objectFit: 'contain',
     },
 }));
 
@@ -29,13 +31,12 @@ export default function AboutUs() {
         <Grid container className={classes.root} alignItems='center' spacing={2}>
             <Grid container item xs={12} direction='column' alignItems='center' spacing={1}>
                 <Grid item xs={4} sm={3} md={2}>
-                    <Image
-                        src='/static/prytaneum_logo.svg' 
-                        width={400}
-                        height={400}
-                        objectFit='contain'
+                    <img
+                        className={classes.contain}
+                        src='/static/prytaneum_logo.svg'
+                        width='100%'
+                        height='100%'
                         alt='Prytaneum Logo'
-                        priority
                     />
                 </Grid>
                 <Grid item>
@@ -44,70 +45,61 @@ export default function AboutUs() {
                     </Typography>
                 </Grid>
                 <Grid item>
-                    <Typography variant='h4'>
-                        Our Journey
-                    </Typography>
+                    <Typography variant='h4'>Our Journey</Typography>
                 </Grid>
             </Grid>
             <Grid container item xs={12} alignItems='center' spacing={2}>
                 <Grid item sm={5} md={3}>
-                    <Image
-                        src='/static/directors.png' 
-                        width={257}
-                        height={273}
-                        objectFit='contain'
+                    <img
+                        className={classes.contain}
+                        src='/static/directors.png'
+                        width='100%'
+                        height='100%'
                         alt='Directors'
-                        priority
                     />
                 </Grid>
                 <Grid container item sm={7} md={9} spacing={2}>
                     <Grid item>
                         <Typography variant='body1' className={classes.paragraph}>
-                            Built by the University of California, Riverside&apos;s Technology, 
-                            Communication and Democracy Lab (TeCD-Lab), the Prytaneum was spearheaded 
-                            by lab director Prof. <b>Kevin Esterling</b> and associate director 
-                            Prof. <b>Mariam Salloum</b>. 
+                            Built by the University of California, Riverside&apos;s Technology, Communication and
+                            Democracy Lab (TeCD-Lab), the Prytaneum was spearheaded by lab director Prof.{' '}
+                            <b>Kevin Esterling</b> and associate director Prof. <b>Mariam Salloum</b>.
                         </Typography>
                     </Grid>
                     <Grid item>
                         <Typography variant='body1' className={classes.paragraph}>
-                            In collaboration with the Congressional Management Foundation,  Prof. 
-                            Esterling and Prof. Salloum co-led the Connecting to Congress (C2C) 
-                            research team that received a grant from the National Science Foundation 
-                            (NSF) to work with the U.S. Congress on developing new technology for 
-                            constituent engagement. The C2C idea was that, in today’s society, it is 
-                            hard for individuals to feel like their voice is heard on important 
-                            policies.
+                            In collaboration with the Congressional Management Foundation, Prof. Esterling and Prof.
+                            Salloum co-led the Connecting to Congress (C2C) research team that received a grant from the
+                            National Science Foundation (NSF) to work with the U.S. Congress on developing new
+                            technology for constituent engagement. The C2C idea was that, in today’s society, it is hard
+                            for individuals to feel like their voice is heard on important policies.
                         </Typography>
                     </Grid>
                 </Grid>
                 <Grid item>
                     <Typography variant='body1' className={classes.paragraph}>
-                        With seed funding from the Democracy Fund, the UCR TeCD-Lab developed 
-                        the <b>Prytaneum project</b>, the result of over a decade of research into 
-                        the best practices for online town halls. This new, open source online town hall 
-                        platform meets the requirements identified in the extensive C2C research, 
-                        and creates a setting for a many-participant, interactive event that lends 
-                        itself to collaborative, constructive exchanges between government officials 
-                        and constituents.
+                        With seed funding from the Democracy Fund, the UCR TeCD-Lab developed the{' '}
+                        <b>Prytaneum project</b>, the result of over a decade of research into the best practices for
+                        online town halls. This new, open source online town hall platform meets the requirements
+                        identified in the extensive C2C research, and creates a setting for a many-participant,
+                        interactive event that lends itself to collaborative, constructive exchanges between government
+                        officials and constituents.
                     </Typography>
                 </Grid>
                 <Grid item>
                     <Typography variant='body1' className={classes.paragraph}>
-                        The C2C research team published their findings  from the NSF study, Politics 
-                        with the People: Building a Directly Representative Democracy (Neblo, 
-                        Esterling, and Lazer 2018). In it they give recommendations for the design 
-                        features that make for a good online town hall experience. 
+                        The C2C research team published their findings from the NSF study, Politics with the People:
+                        Building a Directly Representative Democracy (Neblo, Esterling, and Lazer 2018). In it they give
+                        recommendations for the design features that make for a good online town hall experience.
                     </Typography>
                 </Grid>
                 <Grid item>
                     <Typography variant='body1' className={classes.paragraph}>
-                        In particular, the online platform should reduce barriers to participating 
-                        such that it is easy for everyone in the community to participate 
-                        interactively. The elected official should participate in the session 
-                        through streaming video and audio, so that the constituents can feel the 
-                        direct connection with the elected official and authenticate that it is in 
-                        fact the elected official with whom they are talking.
+                        In particular, the online platform should reduce barriers to participating such that it is easy
+                        for everyone in the community to participate interactively. The elected official should
+                        participate in the session through streaming video and audio, so that the constituents can feel
+                        the direct connection with the elected official and authenticate that it is in fact the elected
+                        official with whom they are talking.
                     </Typography>
                 </Grid>
             </Grid>

--- a/app/client/src/pages/login.tsx
+++ b/app/client/src/pages/login.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import Image from 'next/image';
 import { Grid, Paper, Link } from '@mui/material';
 import makeStyles from '@mui/styles/makeStyles';
 import { useRouter } from 'next/router';
@@ -44,6 +43,9 @@ const useStyles = makeStyles((theme) => ({
             color: theme.palette.primary.main,
         },
     },
+    contain: {
+        objectFit: 'contain',
+    },
 }));
 
 export default function Login() {
@@ -59,11 +61,11 @@ export default function Login() {
     return (
         <Grid container alignItems='center' className={classes.root} justifyContent='center'>
             <Grid item md={7}>
-                <Image
+                <img
+                    className={classes.contain}
                     src='/static/login_illustration.png'
-                    width={697}
-                    height={383}
-                    objectFit='contain'
+                    width='100%'
+                    height='100%'
                     alt='Login Illustation'
                 />
             </Grid>

--- a/app/client/src/pages/register.tsx
+++ b/app/client/src/pages/register.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import Image from 'next/image';
 import { Grid, Paper, Link } from '@mui/material';
 import makeStyles from '@mui/styles/makeStyles';
 import { useRouter } from 'next/router';
@@ -44,6 +43,9 @@ const useStyles = makeStyles((theme) => ({
             color: theme.palette.primary.main,
         },
     },
+    contain: {
+        objectFit: 'contain',
+    },
 }));
 
 export default function RegisterPage() {
@@ -59,11 +61,11 @@ export default function RegisterPage() {
     return (
         <Grid container alignItems='center' className={classes.root} justifyContent='center'>
             <Grid item md={7}>
-                <Image
+                <img
+                    className={classes.contain}
                     src='/static/login_illustration.png'
-                    width={697}
-                    height={383}
-                    objectFit='contain'
+                    width='100%'
+                    height='100%'
                     alt='Register Illustration'
                 />
             </Grid>


### PR DESCRIPTION
- There is a [known issue](https://github.com/vercel/next.js/issues/44685) with the next/image library not releasing memory in deployment. 
- Until this bug if officially fixed, all Image tags have been replaced with html img tags. Also set image to unoptimized in next config as suggested in the github issue.
- The performance improvements that next/image and sharp are suppose to provide were not even functional in our deployment, so this change should not hinder performance (it may even improve it).
![Screenshot from 2023-04-04 13-15-17](https://user-images.githubusercontent.com/14946745/229911628-b5d76e5d-d4c6-42a5-8ca0-9bcce4590024.png)