### PR TITLE
Updating staging deployment to use different redis cluster

### DIFF
--- a/k8s/server/development/prytaneum-server-configmap.yml
+++ b/k8s/server/development/prytaneum-server-configmap.yml
@@ -11,5 +11,5 @@ data:
   SERVER_PORT: "3002"
   GCP_PROJECT_ID: prytaneum-project
   PUB_SUB_PREFIX: projects/prytaneum-project/topics/
-  REDIS_HOST: dev-redis-cluster.redis.svc.cluster.local
+  REDIS_HOST: staging-redis-cluster.development.svc.cluster.local
   REDIS_PORT: "6379"

--- a/k8s/server/development/prytaneum-server-deployment.yml
+++ b/k8s/server/development/prytaneum-server-deployment.yml
@@ -95,8 +95,8 @@ spec:
             - name: REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  key: REDIS_PASSWORD
-                  name: redis-secret
+                  key: redis-password
+                  name: staging-redis-cluster
             - name: "GOOGLE_APPLICATION_CREDENTIALS"
               value: "/var/secrets/google/key.json"
           volumeMounts:


### PR DESCRIPTION
Up until now prod and staging have been sharing a cluster, but now it will have it's own cluster to perform redis testing without disrupting production.