### PR TITLE
Dashboard + Event Routing Time Fix

### DIFF
--- a/app/client/src/features/dashboard/useDashboardEvents.ts
+++ b/app/client/src/features/dashboard/useDashboardEvents.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { graphql, useRefetchableFragment } from 'react-relay';
-import { isAfter } from 'date-fns';
+import { isAfter, isBefore } from 'date-fns';
 
 import type { useDashboardEventsFragment$key } from '@local/__generated__/useDashboardEventsFragment.graphql';
 import type { DashboardEventsRefreshQuery } from '@local/__generated__/DashboardEventsRefreshQuery.graphql';
@@ -66,9 +66,13 @@ export function useDashboardEvents({ fragmentRef }: TArgs) {
 
     const currentEvents = React.useMemo(() => {
         return eventList.filter(({ node: event }) => {
-            return Boolean(event.isActive);
+            if (!event.startDateTime || !event.endDateTime) return Boolean(event.isActive);
+            return (
+                Boolean(event.isActive) ||
+                (isBefore(new Date(event.startDateTime), now) && isAfter(new Date(event.endDateTime), now))
+            );
         });
-    }, [eventList]);
+    }, [eventList, now]);
 
     const upcomingEvents = React.useMemo(() => {
         return eventList.filter(({ node: event }) => {

--- a/app/client/src/features/events/EventLive.tsx
+++ b/app/client/src/features/events/EventLive.tsx
@@ -137,10 +137,16 @@ function EventLive({ node, validateInvite, tokenProvided }: EventLiveProps) {
             setRouteChecked(true);
             return;
         }
-        if (eventData.startDateTime !== null) {
+        const { startDateTime, endDateTime } = eventData;
+        if (startDateTime !== null && endDateTime !== null) {
             const now = new Date();
-            const startTime = new Date(eventData.startDateTime);
-            if (now > startTime) {
+            const startTime = new Date(startDateTime);
+            const endTime = new Date(endDateTime);
+            const eventLengthInSeconds = (endTime.getTime() - startTime.getTime()) / 1000;
+            const eventLengthInMinutes = eventLengthInSeconds / 60;
+            const middleTime = new Date();
+            middleTime.setMinutes(startTime.getMinutes() + eventLengthInMinutes / 2);
+            if (now > middleTime) {
                 router.push(`/events/${eventId}/post`);
             } else {
                 router.push(`/events/${eventId}/pre`);
@@ -148,7 +154,7 @@ function EventLive({ node, validateInvite, tokenProvided }: EventLiveProps) {
         } else {
             router.push(`/events/${eventId}/pre`);
         }
-    }, [eventId, isLive, isModerator, router, eventData.startDateTime]);
+    }, [eventId, isLive, isModerator, router, eventData]);
 
     // styles
     const classes = useStyles();


### PR DESCRIPTION
- Rather than just using the start/end time, we can use the middle time between them to route (ie. if the event is less than halfway over then route to pre, if it is more than halfway over route to post)
- Current events now displaying even if they aren't active yet