### PR TITLE
Prytaneum Ingress HOTFIX

### DIFF
--- a/k8s/ingress/development/prytaneum-ingress.yml
+++ b/k8s/ingress/development/prytaneum-ingress.yml
@@ -27,6 +27,13 @@ spec:
                             name: prytaneum-server-service
                             port:
                                 number: 80
+                    path: /graphql
+                    pathType: ImplementationSpecific
+                  - backend:
+                        service:
+                            name: prytaneum-server-service
+                            port:
+                                number: 80
                     path: /graphql/*
                     pathType: ImplementationSpecific
                   - backend:

--- a/k8s/ingress/production/prytaneum-ingress.yml
+++ b/k8s/ingress/production/prytaneum-ingress.yml
@@ -27,6 +27,13 @@ spec:
                             name: prytaneum-server-service
                             port:
                                 number: 80
+                    path: /graphql
+                    pathType: ImplementationSpecific
+                  - backend:
+                        service:
+                            name: prytaneum-server-service
+                            port:
+                                number: 80
                     path: /graphql/*
                     pathType: ImplementationSpecific
                   - backend:


### PR DESCRIPTION
- When adding wildcard graphql path, the default `/graphql` path was removed causing errors for prytaneum.
- Adding it back while keeping the api and wildcard paths should fix this.