### PR TITLE
chore(gql url): updated to using default arg in prod

### DIFF
--- a/.github/workflows/client-deploy.yml
+++ b/.github/workflows/client-deploy.yml
@@ -149,7 +149,6 @@ jobs:
                     --tag "gcr.io/$PROJECT_ID/$CLIENT_IMAGE:$GITHUB_SHA" \
                     --build-arg GITHUB_SHA="$GITHUB_SHA" \
                     --build-arg GITHUB_REF="$GITHUB_REF" \
-                    --build-arg GRAPHQL_URL="$GRAPHQL_URL" \
                     --build-arg DEPLOYMENT_ENV="production" \
                     --build-arg GOOGLE_ANALYTICS_ID="$GOOGLE_ANALYTICS_ID" \
                     .

--- a/docker/Dockerfile.client
+++ b/docker/Dockerfile.client
@@ -27,6 +27,8 @@ WORKDIR /usr/monorepo
 ENV NODE_ENV production
 ENV HOST 0.0.0.0
 ENV PORT 3000
+ARG GRAPHQL_URL=https://prytaneum.io/graphql
+ENV NEXT_PUBLIC_GRAPHQL_URL ${GRAPHQL_URL}
 ARG DEPLOYMENT_ENV=production
 ENV DEPLOYMENT_ENV ${DEPLOYMENT_ENV}
 ENV NEXT_SHARP_PATH=/usr/monorepo/app/client/sharp


### PR DESCRIPTION
- Seemed to be the wrong value in some deployed pods, trying to leave it default to docker arg.
- Also added CLIENT_IMAGE as a github action env variable to be sure that published images are unique (Thought being that this bug could be caused by some of the pods referring to the wrong dev image when meant to use the prod image)