### PR TITLE
fix(roster): remove any empty spaces in email before account creation

### DIFF
--- a/app/cc2c/src/app/api/upload/roster/route.ts
+++ b/app/cc2c/src/app/api/upload/roster/route.ts
@@ -34,7 +34,7 @@ export async function POST(request: NextRequest) {
     // Create users and classes, then add users to classes
     for (const data of usersToRegister) {
         const { student_id, course_id, email, first_name, last_name, research_project_consent } = data;
-        const lowerCaseEmail = email.toLowerCase();
+        const lowerCaseEmail = email.toLowerCase().replace(/ /g, ''); // Remove spaces and make lowercase
         try {
             let _class = { id: '' };
 


### PR DESCRIPTION
- Had an issue where account was being created with an extra space in it from the csv file. This fix should allow for empty spaces and remove them before creating the accounts.