### PR TITLE
Prytaneum Workflow Change

### DIFF
--- a/.github/workflows/client-deploy.yml
+++ b/.github/workflows/client-deploy.yml
@@ -106,7 +106,6 @@ jobs:
                   kubectl rollout status deployment/prytaneum-client
                   kubectl get services -o wide
     prod:
-        if: github.event.inputs.releaseType == 'prod'
         name: Deploy to Production
         runs-on: ubuntu-latest
         environment:

--- a/.github/workflows/server-deploy.yml
+++ b/.github/workflows/server-deploy.yml
@@ -115,7 +115,6 @@ jobs:
                   kubectl rollout status deployment/prytaneum-server
                   kubectl get services -o wide
     prod:
-        if: github.event.inputs.releaseType == 'prod'
         name: Deploy to Production
         runs-on: ubuntu-latest
         environment:


### PR DESCRIPTION
Removing manual release trigger requirement for prod deployment in favor of using the environment rules, preventing prod deployment until manual review/authorization.