### PR TITLE
CC2C CSV + Teacher Redirect Fixes

### DIFF
--- a/app/cc2c/src/app/dashboard/page.tsx
+++ b/app/cc2c/src/app/dashboard/page.tsx
@@ -1,9 +1,19 @@
 import { Fragment } from 'react';
+import { getServerSession } from 'next-auth';
 
 import { AppBar } from '@local/components';
 import { StudentDashboard } from './StudentDashboard';
+import { authOptions } from '../api/auth/[...nextauth]/route';
+import { UserWithoutPass } from '../api/auth/types';
+import { redirect } from 'next/navigation';
 
 export default async function DashboardPage() {
+    const session = await getServerSession(authOptions);
+    const user = session?.user as UserWithoutPass | undefined;
+    if (!user) redirect('/');
+    if (user.role === 'TEACHER') redirect(`/teacher/dashboard`);
+    if (user.role === 'ADMIN') redirect(`/admin/dashboard`);
+
     return (
         <Fragment>
             <AppBar />

--- a/app/cc2c/src/components/StudentsTable.tsx
+++ b/app/cc2c/src/components/StudentsTable.tsx
@@ -106,8 +106,8 @@ export function StudentsTable({ students, classId }: StudentsTableProps) {
         }
         const csvContent =
             'data:text/csv;charset=utf-8,' +
-            'Email,preWriting,postWriting\n' +
-            `${student?.user.email},${student?.preWriting},${student?.postWriting}`;
+            'email|preWriting|postWriting\n' +
+            `${student?.user.email}|${student?.preWriting}|${student?.postWriting}`;
 
         const encodedUri = encodeURI(csvContent);
         const link = document.createElement('a');
@@ -122,9 +122,9 @@ export function StudentsTable({ students, classId }: StudentsTableProps) {
         setIsLoading(true);
         const csvContent =
             'data:text/csv;charset=utf-8,' +
-            'Email,preWriting,postWriting\n' +
+            'email|preWriting|postWriting\n' +
             students
-                .map((student) => `${student?.user.email},${student?.preWriting},${student?.postWriting}`)
+                .map((student) => `${student?.user.email}|${student?.preWriting}|${student?.postWriting}`)
                 .join('\n');
 
         const encodedUri = encodeURI(csvContent);

--- a/app/cc2c/src/middleware.ts
+++ b/app/cc2c/src/middleware.ts
@@ -50,8 +50,8 @@ export async function middleware(request: NextRequest, _next: NextFetchEvent) {
             const url = new URL(`/auth/signin`, request.url);
             return NextResponse.redirect(url);
         }
-        if (token.role !== 'TEACHER') {
-            const url = new URL(`/`, request.url);
+        if (token.role === 'ADMIN') {
+            const url = new URL(`/admin/dashboard`, request.url);
             return NextResponse.rewrite(url);
         }
     }


### PR DESCRIPTION
- Teacher was having issue seeing their dashboard, kept defaulting to student dasboard for them. I believe it's caused by them having logged into their account when they had the "student" role, and after being promoted the auth JWT stored still has this outdated role, causing them to be redirected wrongly by the middleware. 
- To avoid this edge case in the future there is an additional auth check validating the role with the current session which should redirect correctly even if the token data is stale.
- To avoid issue with writings containing commas, the delimiter has been updated to `|`