### PR TITLE
CC2C Admin menu protections

### DIFF
--- a/app/cc2c/src/components/admin/UsersTable.tsx
+++ b/app/cc2c/src/components/admin/UsersTable.tsx
@@ -252,24 +252,38 @@ export function UsersTable({}: UsersTableProps) {
                                 <TableCell>
                                     <Typography>{user.role.toLocaleLowerCase()}</Typography>
                                 </TableCell>
-                                <TableCell>
-                                    {user.role === 'STUDENT' ? (
+                                {user.role === 'ADMIN' ? (
+                                    <TableCell>
+                                        <React.Fragment />
+                                    </TableCell>
+                                ) : (
+                                    <TableCell>
+                                        {user.role === 'STUDENT' ? (
+                                            <Button
+                                                variant='contained'
+                                                color='primary'
+                                                onClick={handlePromoteUser(user.id)}
+                                            >
+                                                Promote
+                                            </Button>
+                                        ) : (
+                                            <Button
+                                                variant='contained'
+                                                color='primary'
+                                                onClick={handleDemoteUser(user.id)}
+                                            >
+                                                Demote
+                                            </Button>
+                                        )}
                                         <Button
                                             variant='contained'
-                                            color='primary'
-                                            onClick={handlePromoteUser(user.id)}
+                                            color='error'
+                                            onClick={() => handleOpenDialog(user.id)}
                                         >
-                                            Promote
+                                            Delete
                                         </Button>
-                                    ) : (
-                                        <Button variant='contained' color='primary' onClick={handleDemoteUser(user.id)}>
-                                            Demote
-                                        </Button>
-                                    )}
-                                    <Button variant='contained' color='error' onClick={() => handleOpenDialog(user.id)}>
-                                        Delete
-                                    </Button>
-                                </TableCell>
+                                    </TableCell>
+                                )}
                             </TableRow>
                         ))}
                         {emptyRows > 0 && (

--- a/app/cc2c/src/components/admin/actions.ts
+++ b/app/cc2c/src/components/admin/actions.ts
@@ -301,11 +301,23 @@ export async function addTeacherByEmail(formData: FormData) {
 
 export async function deleteUser(userId: string) {
     try {
+        const user = await prisma.user.findUnique({
+            where: {
+                id: userId,
+            },
+        });
+
+        if (!user) throw new Error('User not found');
+
+        // Admins cannot delete themselves
+        if (user.role === 'ADMIN') throw new Error('Cannot delete admin account');
+
         await prisma.user.delete({
             where: {
                 id: userId,
             },
         });
+
         console.log(`User ${userId} deleted`);
         return { isError: false, message: 'User deleted successfully' };
     } catch (error) {


### PR DESCRIPTION
- Admin currently could delete their own account on this table
- Removes the buttons for _promote/demote_ and _delete_ from the admin menu users table for accounts with ADMIN role
- Added check for the ADMIN role for the server action, returning an error if a request to delete the admin is sent.