### PR TITLE
Prompt Responses List Re-Rendering Bugfix

### DIFF
--- a/app/client/src/features/core/useRefresh.tsx
+++ b/app/client/src/features/core/useRefresh.tsx
@@ -7,17 +7,27 @@ interface useRefreshProps {
 
 export function useRefresh({ refreshInterval, callback }: useRefreshProps) {
     const [isRefreshing, setIsRefreshing] = React.useState(false);
+    const [refreshPaused, setRefreshPaused] = React.useState(false);
+
+    const pauseRefresh = React.useCallback(() => {
+        setRefreshPaused(true);
+    }, [setRefreshPaused]);
+
+    const resumeRefresh = React.useCallback(() => {
+        setRefreshPaused(false);
+    }, [setRefreshPaused]);
+
     const refresh = React.useCallback(() => {
-        if (isRefreshing) return;
+        if (isRefreshing || refreshPaused) return;
         setIsRefreshing(true);
         callback();
         setIsRefreshing(false);
-    }, [isRefreshing, setIsRefreshing, callback]);
+    }, [refreshPaused, isRefreshing, callback]);
 
     React.useEffect(() => {
         const interval = setInterval(refresh, refreshInterval);
         return () => clearInterval(interval);
     }, [refresh, refreshInterval]);
 
-    return;
+    return { pauseRefresh, resumeRefresh };
 }

--- a/app/client/src/features/events/EventContext.ts
+++ b/app/client/src/features/events/EventContext.ts
@@ -15,6 +15,8 @@ interface TEventContext {
      * is the current user a moderator
      */
     isModerator: boolean;
+    pauseParentRefreshing: () => void;
+    resumeParentRefreshing: () => void;
 }
 
 // if value is null, then there is no context within the parent tree

--- a/app/client/src/features/events/EventLive.tsx
+++ b/app/client/src/features/events/EventLive.tsx
@@ -105,12 +105,24 @@ function EventLive({ node, validateInvite, tokenProvided }: EventLiveProps) {
     const { displaySnack } = useSnack();
     const [routeChecked, setRouteChecked] = React.useState(false);
     const [validationChecked, setValidationChecked] = React.useState(false);
-    const { eventData, isLive, setIsLive } = useEventDetails({ fragmentRef: node });
+    const { eventData, isLive, setIsLive, pauseEventDetailsRefresh, resumeEventDetailsRefresh } = useEventDetails({
+        fragmentRef: node,
+    });
     const isModerator = Boolean(node.isViewerModerator);
     const { user } = useUser();
     const { id: eventId } = eventData;
 
-    usePingEvent(eventId);
+    const { pausePingEvent, resumePingEvent } = usePingEvent(eventId);
+
+    const pauseParentRefreshing = React.useCallback(() => {
+        pauseEventDetailsRefresh();
+        pausePingEvent();
+    }, [pauseEventDetailsRefresh, pausePingEvent]);
+
+    const resumeParentRefreshing = React.useCallback(() => {
+        resumeEventDetailsRefresh();
+        resumePingEvent();
+    }, [resumeEventDetailsRefresh, resumePingEvent]);
 
     // Handle private events and token validation
     React.useEffect(() => {
@@ -191,7 +203,14 @@ function EventLive({ node, validateInvite, tokenProvided }: EventLiveProps) {
     if (!routeChecked || !validationChecked) return <Loader />;
 
     return (
-        <EventContext.Provider value={{ eventId: node.id, isModerator: Boolean(node.isViewerModerator) }}>
+        <EventContext.Provider
+            value={{
+                eventId: node.id,
+                isModerator: Boolean(node.isViewerModerator),
+                pauseParentRefreshing,
+                resumeParentRefreshing,
+            }}
+        >
             <Grid component={motion.div} key='townhall-live' container className={classes.root} onScroll={handleScroll}>
                 {!isMdUp && <div ref={topRef} />}
                 <Grid container item md={8} direction='column' wrap='nowrap'>

--- a/app/client/src/features/events/EventLiveModeratorView.tsx
+++ b/app/client/src/features/events/EventLiveModeratorView.tsx
@@ -62,7 +62,9 @@ interface EventLiveProps {
 
 function EventLiveModeratorView({ node }: EventLiveProps) {
     const smallBreakpoint = useMediaQuery('(max-width: 1280px)');
-    const { eventData, isLive, setIsLive } = useEventDetails({ fragmentRef: node });
+    const { eventData, isLive, setIsLive, pauseEventDetailsRefresh, resumeEventDetailsRefresh } = useEventDetails({
+        fragmentRef: node,
+    });
     const { id: eventId } = node;
     type tabs = 'Moderator' | 'Feedback' | 'Broadcast';
     const [tab, setTab] = React.useState<tabs>('Moderator');
@@ -72,7 +74,17 @@ function EventLiveModeratorView({ node }: EventLiveProps) {
         setTab(newTab);
     };
 
-    usePingEvent(eventId);
+    const { pausePingEvent, resumePingEvent } = usePingEvent(eventId);
+
+    const pauseParentRefreshing = React.useCallback(() => {
+        pauseEventDetailsRefresh();
+        pausePingEvent();
+    }, [pauseEventDetailsRefresh, pausePingEvent]);
+
+    const resumeParentRefreshing = React.useCallback(() => {
+        resumeEventDetailsRefresh();
+        resumePingEvent();
+    }, [resumeEventDetailsRefresh, resumePingEvent]);
 
     const feedbackActionButtons = React.useMemo(() => {
         return (
@@ -97,7 +109,14 @@ function EventLiveModeratorView({ node }: EventLiveProps) {
     }, [smallBreakpoint]);
 
     return (
-        <EventContext.Provider value={{ eventId: node.id, isModerator: Boolean(node.isViewerModerator) }}>
+        <EventContext.Provider
+            value={{
+                eventId: node.id,
+                isModerator: Boolean(node.isViewerModerator),
+                pauseParentRefreshing,
+                resumeParentRefreshing,
+            }}
+        >
             <Grid
                 container
                 columns={smallBreakpoint ? 6 : 8}

--- a/app/client/src/features/events/EventPost.tsx
+++ b/app/client/src/features/events/EventPost.tsx
@@ -77,7 +77,14 @@ export function EventPost({ node }: EventPostProps) {
     if (!routeChecked) return <Loader />;
 
     return (
-        <EventContext.Provider value={{ eventId: eventData.id, isModerator: Boolean(eventData.isViewerModerator) }}>
+        <EventContext.Provider
+            value={{
+                eventId: eventData.id,
+                isModerator: Boolean(eventData.isViewerModerator),
+                pauseParentRefreshing: () => {},
+                resumeParentRefreshing: () => {},
+            }}
+        >
             <Paper style={{ width: '100%', height: '100%', padding: '1rem' }}>
                 <Grid container spacing={2} columns={16} height='100%'>
                     {/* Column 1 */}

--- a/app/client/src/features/events/EventPre.tsx
+++ b/app/client/src/features/events/EventPre.tsx
@@ -70,7 +70,14 @@ export function EventPre({ fragmentRef }: EventPreProps) {
     };
 
     return (
-        <EventContext.Provider value={{ eventId: eventData.id, isModerator: Boolean(eventData.isViewerModerator) }}>
+        <EventContext.Provider
+            value={{
+                eventId: eventData.id,
+                isModerator: Boolean(eventData.isViewerModerator),
+                pauseParentRefreshing: () => {},
+                resumeParentRefreshing: () => {},
+            }}
+        >
             <Paper style={{ width: '100%', height: '100%', padding: '1rem' }}>
                 <Grid container spacing={2} columns={16} height='100%'>
                     {/* Column 1 */}

--- a/app/client/src/features/events/EventSettings/EventSettings.tsx
+++ b/app/client/src/features/events/EventSettings/EventSettings.tsx
@@ -73,7 +73,14 @@ export function EventSettings({ queryRef }: Props) {
     if (!data.node || !canView || isLoading) return <Loader />;
 
     return (
-        <EventContext.Provider value={{ eventId: data.node.id, isModerator: Boolean(data.node.isViewerModerator) }}>
+        <EventContext.Provider
+            value={{
+                eventId: data.node.id,
+                isModerator: Boolean(data.node.isViewerModerator),
+                pauseParentRefreshing: () => {},
+                resumeParentRefreshing: () => {},
+            }}
+        >
             <div style={{ width: lgUpBreakpoint ? '80%' : '100%', marginLeft: lgUpBreakpoint ? '250px' : 0 }}>
                 <Typography variant='h2' margin={theme.spacing(0, 0, 2, 0)}>
                     Event Settings

--- a/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackPrompt/LiveFeedbackPromptList.tsx
+++ b/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackPrompt/LiveFeedbackPromptList.tsx
@@ -201,13 +201,16 @@ function LiveFeedbackPromptList({ queryRef, responsesModalStatusRef }: LiveFeedb
     const { prompts } = usePreloadedQuery(LIVE_FEEDBACK_PROMPT_LIST_QUERY, queryRef);
     const [open, setOpen] = React.useState(false);
     const selectedPromptRef = React.useRef<Prompt | null>(null);
+    const { pauseParentRefreshing, resumeParentRefreshing } = useEvent();
 
     const handleOpen = () => {
         setOpen(true);
+        pauseParentRefreshing();
         responsesModalStatusRef.current = true;
     };
     const handleClose = () => {
         setOpen(false);
+        resumeParentRefreshing();
         responsesModalStatusRef.current = false;
     };
 

--- a/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackPromptResponses/LiveFeedbackPromptResponseList.tsx
+++ b/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackPromptResponses/LiveFeedbackPromptResponseList.tsx
@@ -198,7 +198,7 @@ export function PreloadedLiveFeedbackPromptResponseList({ prompt }: PreloadedLiv
     );
     const [isRefreshing, setIsRefreshing] = React.useState(false);
     const { env } = useEnvironment();
-    const REFRESH_INTERVAL = 30000; // 30 seconds
+    // const REFRESH_INTERVAL = 30000; // 30 seconds
     const promptData = {
         promptId: prompt.id,
         prompt: prompt.prompt,
@@ -223,12 +223,13 @@ export function PreloadedLiveFeedbackPromptResponseList({ prompt }: PreloadedLiv
         });
     }, [env, isRefreshing, loadQuery, promptId]);
 
+    // TODO: Update to manual refresh button
     React.useEffect(() => {
         // Fetch data from store and network on initial load
         // This Ensures any cached data is displayed right away but will still be kept up to date
         if (!queryRef) loadQuery({ promptId }, { fetchPolicy: 'store-and-network' });
-        const interval = setInterval(refresh, REFRESH_INTERVAL);
-        return () => clearInterval(interval);
+        // const interval = setInterval(refresh, REFRESH_INTERVAL);
+        // return () => clearInterval(interval);
     }, [loadQuery, promptId, queryRef, refresh]);
 
     React.useEffect(() => {

--- a/app/client/src/features/events/Participants/usePingEvent.ts
+++ b/app/client/src/features/events/Participants/usePingEvent.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import React, { useEffect } from 'react';
 import { useMutation, graphql } from 'react-relay';
 
 import type { usePingEventMutation } from '@local/__generated__/usePingEventMutation.graphql';
@@ -15,7 +15,15 @@ export const PING_EVENT_MUTATION = graphql`
 // Pings the server every 20 seconds to keep the participant active in the event participants list
 export function usePingEvent(eventId: string) {
     const [commit] = useMutation<usePingEventMutation>(PING_EVENT_MUTATION);
+    const [pingPaused, setPingPaused] = React.useState(false);
     const PING_INTERVAL = 20000; // 20 seconds
+
+    const pausePingEvent = React.useCallback(() => {
+        setPingPaused(true);
+    }, [setPingPaused]);
+    const resumePingEvent = React.useCallback(() => {
+        setPingPaused(false);
+    }, [setPingPaused]);
 
     useEffect(() => {
         commit({
@@ -23,6 +31,7 @@ export function usePingEvent(eventId: string) {
         });
 
         const pingInterval = setInterval(() => {
+            if (pingPaused) return;
             commit({
                 variables: { eventId },
             });
@@ -30,7 +39,7 @@ export function usePingEvent(eventId: string) {
 
         return () => clearInterval(pingInterval);
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, []);
+    }, [pingPaused, eventId, commit]);
 
-    return { pingEvent: commit };
+    return { pingEvent: commit, pausePingEvent, resumePingEvent };
 }

--- a/app/client/src/features/events/useEventDetails.ts
+++ b/app/client/src/features/events/useEventDetails.ts
@@ -32,7 +32,7 @@ export function useEventDetails({ fragmentRef }: Props) {
         refetch({}, { fetchPolicy: 'store-and-network' });
     }, [refetch]);
 
-    useRefresh({ refreshInterval: REFRESH_INTERVAL, callback: refresh });
+    const { pauseRefresh, resumeRefresh } = useRefresh({ refreshInterval: REFRESH_INTERVAL, callback: refresh });
 
     React.useEffect(() => {
         if (data.isActive) {
@@ -42,5 +42,11 @@ export function useEventDetails({ fragmentRef }: Props) {
         setIsLive(false);
     }, [data.isActive]);
 
-    return { eventData: data, isLive, setIsLive };
+    return {
+        eventData: data,
+        isLive,
+        setIsLive,
+        pauseEventDetailsRefresh: pauseRefresh,
+        resumeEventDetailsRefresh: resumeRefresh,
+    };
 }


### PR DESCRIPTION
Addresses issue #569 
- The event context now passes functions to pause/resume refreshing for the queries/mutations that were causing the re-renders
- There should no longer be any flickering when on the nested modal, but if a moderator stays on it for long enough they will no longer show up in the participants list since that ping mutation was part of the cause of the flicker. The pinging will resume as soon as they exit the modal though.