### PR TITLE
Prytaneum Event Ping Update

### DIFF
--- a/app/client/schema.graphql
+++ b/app/client/schema.graphql
@@ -634,6 +634,7 @@ type Mutation {
   TODO: make this an EventMutationResponse
   """
   nextQuestion(eventId: ID!): Event!
+  participantLeaveEvent(eventId: ID!): ParticipantPingEventMutationResponse!
   participantPingEvent(eventId: ID!): ParticipantPingEventMutationResponse!
 
   """

--- a/app/client/src/__generated__/useLeaveEventMutation.graphql.ts
+++ b/app/client/src/__generated__/useLeaveEventMutation.graphql.ts
@@ -1,0 +1,97 @@
+/**
+ * @generated SignedSource<<1957669e2d74ff4914a045a147fb2e93>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest, Mutation } from 'relay-runtime';
+export type useLeaveEventMutation$variables = {
+  eventId: string;
+};
+export type useLeaveEventMutation$data = {
+  readonly participantLeaveEvent: {
+    readonly isError: boolean;
+    readonly message: string;
+  };
+};
+export type useLeaveEventMutation = {
+  response: useLeaveEventMutation$data;
+  variables: useLeaveEventMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "eventId"
+  }
+],
+v1 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "eventId",
+        "variableName": "eventId"
+      }
+    ],
+    "concreteType": "ParticipantPingEventMutationResponse",
+    "kind": "LinkedField",
+    "name": "participantLeaveEvent",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "isError",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "message",
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "useLeaveEventMutation",
+    "selections": (v1/*: any*/),
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "useLeaveEventMutation",
+    "selections": (v1/*: any*/)
+  },
+  "params": {
+    "cacheID": "f6301fdb83c4af518080fb86309f9016",
+    "id": null,
+    "metadata": {},
+    "name": "useLeaveEventMutation",
+    "operationKind": "mutation",
+    "text": "mutation useLeaveEventMutation(\n  $eventId: ID!\n) {\n  participantLeaveEvent(eventId: $eventId) {\n    isError\n    message\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "fdae7cd1d296059092933167ce8654b0";
+
+export default node;

--- a/app/client/src/features/events/EventLive.tsx
+++ b/app/client/src/features/events/EventLive.tsx
@@ -21,6 +21,7 @@ import { useSnack } from '@local/core';
 import { useUser } from '../accounts';
 import { useEventDetails } from './useEventDetails';
 import { usePingEvent } from './Participants/usePingEvent';
+import { useLeaveEvent } from './Participants/useLeaveEvent';
 
 const useStyles = makeStyles((theme) => ({
     root: {
@@ -112,9 +113,6 @@ function EventLive({ node, validateInvite, tokenProvided }: EventLiveProps) {
     const { user } = useUser();
     const { id: eventId } = eventData;
 
-    // NOTE: Defaults to paused, use startPingEvent to start pinging once participant is validated
-    // since we only want participants on the live page to ping the server, thus avoiding unnecessary pings on pre/post event pages
-    // If this was defaulted to true, it would ping the server even if the user is redirected to a different page after validation
     const { pausePingEvent, resumePingEvent, startPingEvent } = usePingEvent(eventId);
 
     const pauseParentRefreshing = React.useCallback(() => {

--- a/app/client/src/features/events/EventLive.tsx
+++ b/app/client/src/features/events/EventLive.tsx
@@ -114,6 +114,7 @@ function EventLive({ node, validateInvite, tokenProvided }: EventLiveProps) {
     const { id: eventId } = eventData;
 
     const { pausePingEvent, resumePingEvent, startPingEvent } = usePingEvent(eventId);
+    const { leaveEvent } = useLeaveEvent(eventId);
 
     const pauseParentRefreshing = React.useCallback(() => {
         pauseEventDetailsRefresh();
@@ -124,6 +125,13 @@ function EventLive({ node, validateInvite, tokenProvided }: EventLiveProps) {
         resumeEventDetailsRefresh();
         resumePingEvent();
     }, [resumeEventDetailsRefresh, resumePingEvent]);
+
+    React.useEffect(() => {
+        window.addEventListener('beforeunload', leaveEvent);
+        return () => {
+            window.removeEventListener('beforeunload', leaveEvent);
+        };
+    }, [leaveEvent]);
 
     React.useEffect(() => {
         if (routeChecked && validationChecked) startPingEvent();

--- a/app/client/src/features/events/Participants/useLeaveEvent.ts
+++ b/app/client/src/features/events/Participants/useLeaveEvent.ts
@@ -1,0 +1,26 @@
+import React from 'react';
+import { useMutation, graphql } from 'react-relay';
+
+import type { useLeaveEventMutation } from '@local/__generated__/useLeaveEventMutation.graphql';
+
+export const PING_EVENT_MUTATION = graphql`
+    mutation useLeaveEventMutation($eventId: ID!) {
+        participantLeaveEvent(eventId: $eventId) {
+            isError
+            message
+        }
+    }
+`;
+
+// Pings the server every 20 seconds to keep the participant active in the event participants list
+export function useLeaveEvent(eventId: string) {
+    const [commit] = useMutation<useLeaveEventMutation>(PING_EVENT_MUTATION);
+
+    const leaveEvent = React.useCallback(() => {
+        commit({
+            variables: { eventId },
+        });
+    }, [eventId, commit]);
+
+    return { leaveEvent };
+}

--- a/app/client/src/features/events/Participants/usePingEvent.ts
+++ b/app/client/src/features/events/Participants/usePingEvent.ts
@@ -16,31 +16,35 @@ export const PING_EVENT_MUTATION = graphql`
 export function usePingEvent(eventId: string) {
     const [commit] = useMutation<usePingEventMutation>(PING_EVENT_MUTATION);
     const [pingPaused, setPingPaused] = React.useState(false);
-    const PING_INTERVAL = 20000; // 20 seconds
+    const PING_INTERVAL = 60000; // 60 seconds
+
+    const pingEvent = React.useCallback(() => {
+        commit({
+            variables: { eventId },
+        });
+    }, [eventId, commit]);
 
     const pausePingEvent = React.useCallback(() => {
         setPingPaused(true);
     }, [setPingPaused]);
+
     const resumePingEvent = React.useCallback(() => {
         setPingPaused(false);
     }, [setPingPaused]);
+
     const startPingEvent = React.useCallback(() => {
-        commit({
-            variables: { eventId },
-        });
+        pingEvent();
         setPingPaused(false);
-    }, [commit, eventId]);
+    }, [pingEvent, setPingPaused]);
 
     useEffect(() => {
         const pingInterval = setInterval(() => {
             if (pingPaused) return;
-            commit({
-                variables: { eventId },
-            });
+            pingEvent();
         }, PING_INTERVAL);
 
         return () => clearInterval(pingInterval);
-    }, [pingPaused, eventId, commit]);
+    }, [pingPaused, pingEvent]);
 
     return { pingEvent: commit, pausePingEvent, resumePingEvent, startPingEvent };
 }

--- a/app/client/src/graphql-types.ts
+++ b/app/client/src/graphql-types.ts
@@ -704,6 +704,7 @@ export type Mutation = {
    * TODO: make this an EventMutationResponse
    */
   nextQuestion: Event;
+  participantLeaveEvent: ParticipantPingEventMutationResponse;
   participantPingEvent: ParticipantPingEventMutationResponse;
   /**
    * Go to the previous question
@@ -884,6 +885,11 @@ export type MutationMuteParticipantArgs = {
 
 
 export type MutationNextQuestionArgs = {
+  eventId: Scalars['ID'];
+};
+
+
+export type MutationParticipantLeaveEventArgs = {
   eventId: Scalars['ID'];
 };
 

--- a/app/server/src/features/events/methods.ts
+++ b/app/server/src/features/events/methods.ts
@@ -327,9 +327,9 @@ export async function findAllEvents(viewerId: string, filter: EventsSearchFilter
 }
 
 export async function findParticipantsByEventId(eventId: string, prisma: PrismaClient) {
-    const SIXTY_SECONDS = 1000 * 60;
+    const FIVE_MINUTES = 1000 * 60 * 5; // 5 minutes in milliseconds
     const result = await prisma.eventParticipant.findMany({
-        where: { eventId, lastPingTime: { gte: new Date(Date.now() - SIXTY_SECONDS) } },
+        where: { eventId, lastPingTime: { gte: new Date(Date.now() - FIVE_MINUTES) } },
         select: { user: true, isMuted: true },
         orderBy: { user: { firstName: 'asc' } },
     });

--- a/app/server/src/features/events/participants/methods.ts
+++ b/app/server/src/features/events/participants/methods.ts
@@ -51,6 +51,23 @@ export async function joinOrPingEvent(prisma: PrismaClient, eventId: string, use
     }
 }
 
+export async function leaveEvent(prisma: PrismaClient, eventId: string, userId: string): Promise<void> {
+    try {
+        await prisma.eventParticipant.delete({
+            where: {
+                eventId_userId: {
+                    eventId,
+                    userId,
+                },
+            },
+        });
+    } catch (e) {
+        console.error(e);
+        // no need to throw a protected error here, as when a user is leaving an event they are likely closing the page and won't see/need the error message
+        // Worst case the participant will be removed from the participants list after the expiration time
+    }
+}
+
 // TODO: Add purge messages option
 export async function muteParticipant(
     prisma: PrismaClient,

--- a/app/server/src/features/events/participants/resolvers.ts
+++ b/app/server/src/features/events/participants/resolvers.ts
@@ -26,6 +26,14 @@ export const resolvers: Resolvers = {
                 await Participants.joinOrPingEvent(ctx.prisma, eventId, viewerId);
             });
         },
+        async participantLeaveEvent(parent, args, ctx) {
+            return runMutation(async () => {
+                const { id: viewerId } = ctx.viewer;
+                const { id: eventId } = fromGlobalId(args.eventId);
+                if (!viewerId) throw new ProtectedError({ userMessage: errors.noLogin });
+                await Participants.leaveEvent(ctx.prisma, eventId, viewerId);
+            });
+        },
         async muteParticipant(parent, args, ctx) {
             return runMutation(async () => {
                 const { id: viewerId } = ctx.viewer;

--- a/app/server/src/features/events/participants/schema.graphql
+++ b/app/server/src/features/events/participants/schema.graphql
@@ -29,6 +29,7 @@ type Query {
 
 type Mutation {
     participantPingEvent(eventId: ID!): ParticipantPingEventMutationResponse!
+    participantLeaveEvent(eventId: ID!): ParticipantPingEventMutationResponse!
     muteParticipant(eventId: ID!, userId: ID!): MuteParticipantMutationResponse!
     unmuteParticipant(eventId: ID!, userId: ID!): MuteParticipantMutationResponse!
 }

--- a/app/server/src/graphql-types.ts
+++ b/app/server/src/graphql-types.ts
@@ -366,6 +366,7 @@ export type Mutation = {
      */
     prevQuestion: Event;
     participantPingEvent: ParticipantPingEventMutationResponse;
+    participantLeaveEvent: ParticipantPingEventMutationResponse;
     muteParticipant: MuteParticipantMutationResponse;
     unmuteParticipant: MuteParticipantMutationResponse;
     createQuestion: EventQuestionMutationResponse;
@@ -539,6 +540,10 @@ export type MutationprevQuestionArgs = {
 };
 
 export type MutationparticipantPingEventArgs = {
+    eventId: Scalars['ID'];
+};
+
+export type MutationparticipantLeaveEventArgs = {
     eventId: Scalars['ID'];
 };
 
@@ -2351,6 +2356,12 @@ export type MutationResolvers<
         ParentType,
         ContextType,
         RequireFields<MutationparticipantPingEventArgs, 'eventId'>
+    >;
+    participantLeaveEvent?: Resolver<
+        ResolversTypes['ParticipantPingEventMutationResponse'],
+        ParentType,
+        ContextType,
+        RequireFields<MutationparticipantLeaveEventArgs, 'eventId'>
     >;
     muteParticipant?: Resolver<
         ResolversTypes['MuteParticipantMutationResponse'],


### PR DESCRIPTION
- Reworked pinging slightly to improve it
- Added a leave event mutation that triggers when the tab/window is closed, removing the user from the event participant list.
- Because we more reliably know when users are leaving the event, the times for both pinging and last ping time checked have been increased. This will reduce the amount of requests sent during the event, helping to free up bandwidth for more important things. 