### PR TITLE
Feedback Prompt Form Fix

### DIFF
--- a/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackPrompt/LiveFeedbackPromptForm.tsx
+++ b/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackPrompt/LiveFeedbackPromptForm.tsx
@@ -68,6 +68,16 @@ export function LiveFeedbackPromptForm({ onSubmit, onCancel }: LiveFeedbackPromp
         form.choices = newChoices;
     };
 
+    const isPromptValidForSubmission = () => {
+        if (!isFeedbackPromptValid) {
+            return false;
+        }
+        if (form.feedbackType === 'multiple-choice' && !isMultipleChoiceOptionsValid) {
+            return false;
+        }
+        return true;
+    };
+
     return (
         <Form onSubmit={handleSubmit(onSubmit)}>
             <FormTitle title='Feedback Prompt' />
@@ -158,12 +168,7 @@ export function LiveFeedbackPromptForm({ onSubmit, onCancel }: LiveFeedbackPromp
                         Cancel
                     </Button>
                 )}
-                <Button
-                    disabled={!isFeedbackPromptValid || !isMultipleChoiceOptionsValid}
-                    type='submit'
-                    variant='contained'
-                    color='primary'
-                >
+                <Button disabled={!isPromptValidForSubmission()} type='submit' variant='contained' color='primary'>
                     Create
                 </Button>
             </FormActions>


### PR DESCRIPTION
- The disabled check on the submission button was not correct for non-multiple choice prompts, preventing creating them without filling out the multiple choice fields.
- Fixed with more proper check for prompt validity