### PR TITLE
Feedback Prompt Hotfix 2

### DIFF
--- a/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackPrompt/LiveFeedbackPromptForm.tsx
+++ b/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackPrompt/LiveFeedbackPromptForm.tsx
@@ -96,6 +96,22 @@ export function LiveFeedbackPromptForm({ onSubmit, onCancel }: LiveFeedbackPromp
                         <FormControlLabel value='multiple-choice' control={<Radio />} label='Multiple Choice' />
                     </RadioGroup>
                 </Grid>
+                <Grid item container justifyContent='center'>
+                    {form.feedbackType === 'open-ended' && (
+                        <Typography>Ask participants to provide open ended feedback on a topic.</Typography>
+                    )}
+                    {form.feedbackType === 'vote' && (
+                        <Typography>
+                            Ask participants if they are <b>FOR</b>, <b>AGAINST</b>, or <b>CONFLICTED</b> about
+                            something and give their reasoning.
+                        </Typography>
+                    )}
+                    {form.feedbackType === 'multiple-choice' && (
+                        <Typography>
+                            Ask participants to choose from a list of options and give their reasoning.
+                        </Typography>
+                    )}
+                </Grid>
                 <TextField
                     id='feedback-prompt-field'
                     name='feedback-prompt'

--- a/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackPromptResponse/LiveFeedbackPromptResponseForm.tsx
+++ b/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackPromptResponse/LiveFeedbackPromptResponseForm.tsx
@@ -77,19 +77,21 @@ export function LiveFeedbackPromptResponseForm({ onSubmit, onCancel, promptRef }
                         </RadioGroup>
                     </Grid>
                 )}
-                <FormControl>
-                    <FormLabel component='legend'>Choose one:</FormLabel>
-                    <RadioGroup
-                        aria-label='feedback-prompt-multiple-choice'
-                        name='feedback-prompt-multiple-choice'
-                        value={form.multipleChoiceResponse}
-                        onChange={handleChange('multipleChoiceResponse')}
-                    >
-                        {promptRef.current.multipleChoiceOptions.map((option, index) => (
-                            <FormControlLabel key={index} value={option} control={<Radio />} label={option} />
-                        ))}
-                    </RadioGroup>
-                </FormControl>
+                {promptRef.current.isMultipleChoice && (
+                    <FormControl>
+                        <FormLabel component='legend'>Choose one:</FormLabel>
+                        <RadioGroup
+                            aria-label='feedback-prompt-multiple-choice'
+                            name='feedback-prompt-multiple-choice'
+                            value={form.multipleChoiceResponse}
+                            onChange={handleChange('multipleChoiceResponse')}
+                        >
+                            {promptRef.current.multipleChoiceOptions.map((option, index) => (
+                                <FormControlLabel key={index} value={option} control={<Radio />} label={option} />
+                            ))}
+                        </RadioGroup>
+                    </FormControl>
+                )}
                 <TextField
                     id='feedback-prompt-response-field'
                     name='feedback-prompt-response'


### PR DESCRIPTION
- The blank/filled out multiple choice options were being displayed on the response form even if it was not the multiple choice type. Fixed this so now prompt response form displays correctly.
- Made what each type of feedback prompt is more clear by adding descriptions to each.
- Might update to stepper at some point, but this should work well enough for now.