### PR TITLE
Ping Event Hotfix

### DIFF
--- a/app/client/src/features/events/EventLive.tsx
+++ b/app/client/src/features/events/EventLive.tsx
@@ -112,7 +112,8 @@ function EventLive({ node, validateInvite, tokenProvided }: EventLiveProps) {
     const { user } = useUser();
     const { id: eventId } = eventData;
 
-    const { pausePingEvent, resumePingEvent } = usePingEvent(eventId);
+    // NOTE: Defaults to paused, will resume after validation is checked
+    const { pausePingEvent, resumePingEvent, startPingEvent } = usePingEvent(eventId);
 
     const pauseParentRefreshing = React.useCallback(() => {
         pauseEventDetailsRefresh();
@@ -123,6 +124,10 @@ function EventLive({ node, validateInvite, tokenProvided }: EventLiveProps) {
         resumeEventDetailsRefresh();
         resumePingEvent();
     }, [resumeEventDetailsRefresh, resumePingEvent]);
+
+    React.useEffect(() => {
+        if (validationChecked) startPingEvent();
+    }, [startPingEvent, validationChecked]);
 
     // Handle private events and token validation
     React.useEffect(() => {
@@ -142,7 +147,7 @@ function EventLive({ node, validateInvite, tokenProvided }: EventLiveProps) {
         // Ensure user is logged in if invite is valid (Do not reload if user is already logged in)
         if (user === null && validateInvite?.valid && validateInvite?.user !== null) router.reload();
         else setValidationChecked(true);
-    }, [displaySnack, eventData, router, tokenProvided, user, validateInvite]);
+    }, [displaySnack, eventData, startPingEvent, router, tokenProvided, user, validateInvite]);
 
     React.useEffect(() => {
         if (!validationChecked) return;

--- a/app/client/src/features/events/Participants/usePingEvent.ts
+++ b/app/client/src/features/events/Participants/usePingEvent.ts
@@ -13,9 +13,12 @@ export const PING_EVENT_MUTATION = graphql`
 `;
 
 // Pings the server every 20 seconds to keep the participant active in the event participants list
+// NOTE: Defaults to paused, use startPingEvent to start pinging once participant is validated
+// since we only want participants on the live page to ping the server, thus avoiding unnecessary pings on pre/post event pages
+// If this was defaulted to true, it would ping the server even if the user is redirected to a different page after validation
 export function usePingEvent(eventId: string) {
     const [commit] = useMutation<usePingEventMutation>(PING_EVENT_MUTATION);
-    const [pingPaused, setPingPaused] = React.useState(false);
+    const [pingPaused, setPingPaused] = React.useState(true);
     const PING_INTERVAL = 20000; // 20 seconds
 
     const pausePingEvent = React.useCallback(() => {
@@ -41,5 +44,5 @@ export function usePingEvent(eventId: string) {
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [pingPaused, eventId, commit]);
 
-    return { pingEvent: commit, pausePingEvent, resumePingEvent };
+    return { pingEvent: commit, pausePingEvent, resumePingEvent, startPingEvent: resumePingEvent };
 }


### PR DESCRIPTION
- When participants clicked/went to the event `/live` route they were sending off a ping before the validation, causing them to show up in the list before the event was started.
- Simply added an additional check for validation being completed before beginning the pinging interval.