### PR TITLE
Prytaneum events dashboard fix

### DIFF
--- a/app/client/schema.graphql
+++ b/app/client/schema.graphql
@@ -755,6 +755,8 @@ type PostEventFeedbackMutationResponse implements MutationResponse {
 }
 
 type Query {
+  dashboardEvents: [Event!]
+
   """Fetch a single event"""
   event(eventId: ID!): Event
   eventBroadcastMessages(eventId: ID!): [EventBroadcastMessage!]

--- a/app/client/src/__generated__/DashboardQuery.graphql.ts
+++ b/app/client/src/__generated__/DashboardQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<89a18e5ed98ac85ea80bcc8f175a23b0>>
+ * @generated SignedSource<<041fa4d2e2122066c8dca38a5f23c24e>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,12 +9,21 @@
 // @ts-nocheck
 
 import { ConcreteRequest, Query } from 'relay-runtime';
-import { FragmentRefs } from "relay-runtime";
 export type DashboardQuery$variables = {};
 export type DashboardQuery$data = {
-  readonly me: {
-    readonly " $fragmentSpreads": FragmentRefs<"useDashboardEventsFragment">;
-  } | null;
+  readonly dashboardEvents: ReadonlyArray<{
+    readonly description: string | null;
+    readonly endDateTime: Date | null;
+    readonly id: string;
+    readonly isActive: boolean | null;
+    readonly isViewerModerator: boolean | null;
+    readonly organization: {
+      readonly name: string;
+    } | null;
+    readonly startDateTime: Date | null;
+    readonly title: string | null;
+    readonly topic: string | null;
+  }> | null;
 };
 export type DashboardQuery = {
   response: DashboardQuery$data;
@@ -29,18 +38,62 @@ var v0 = {
   "name": "id",
   "storageKey": null
 },
-v1 = [
-  {
-    "kind": "Literal",
-    "name": "after",
-    "value": ""
-  },
-  {
-    "kind": "Literal",
-    "name": "first",
-    "value": 50
-  }
-];
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "startDateTime",
+  "storageKey": null
+},
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "endDateTime",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "title",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "topic",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "description",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "isActive",
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "isViewerModerator",
+  "storageKey": null
+},
+v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+};
 return {
   "fragment": {
     "argumentDefinitions": [],
@@ -51,15 +104,30 @@ return {
       {
         "alias": null,
         "args": null,
-        "concreteType": "User",
+        "concreteType": "Event",
         "kind": "LinkedField",
-        "name": "me",
-        "plural": false,
+        "name": "dashboardEvents",
+        "plural": true,
         "selections": [
+          (v0/*: any*/),
+          (v1/*: any*/),
+          (v2/*: any*/),
+          (v3/*: any*/),
+          (v4/*: any*/),
+          (v5/*: any*/),
+          (v6/*: any*/),
+          (v7/*: any*/),
           {
+            "alias": null,
             "args": null,
-            "kind": "FragmentSpread",
-            "name": "useDashboardEventsFragment"
+            "concreteType": "Organization",
+            "kind": "LinkedField",
+            "name": "organization",
+            "plural": false,
+            "selections": [
+              (v8/*: any*/)
+            ],
+            "storageKey": null
           }
         ],
         "storageKey": null
@@ -77,173 +145,31 @@ return {
       {
         "alias": null,
         "args": null,
-        "concreteType": "User",
+        "concreteType": "Event",
         "kind": "LinkedField",
-        "name": "me",
-        "plural": false,
+        "name": "dashboardEvents",
+        "plural": true,
         "selections": [
           (v0/*: any*/),
+          (v1/*: any*/),
+          (v2/*: any*/),
+          (v3/*: any*/),
+          (v4/*: any*/),
+          (v5/*: any*/),
+          (v6/*: any*/),
+          (v7/*: any*/),
           {
             "alias": null,
-            "args": (v1/*: any*/),
-            "concreteType": "EventConnection",
+            "args": null,
+            "concreteType": "Organization",
             "kind": "LinkedField",
-            "name": "events",
+            "name": "organization",
             "plural": false,
             "selections": [
-              {
-                "alias": null,
-                "args": null,
-                "concreteType": "EventEdge",
-                "kind": "LinkedField",
-                "name": "edges",
-                "plural": true,
-                "selections": [
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "Event",
-                    "kind": "LinkedField",
-                    "name": "node",
-                    "plural": false,
-                    "selections": [
-                      (v0/*: any*/),
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "title",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "description",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "startDateTime",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "endDateTime",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "isViewerModerator",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "isActive",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "Organization",
-                        "kind": "LinkedField",
-                        "name": "organization",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "name",
-                            "storageKey": null
-                          },
-                          (v0/*: any*/)
-                        ],
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "__typename",
-                        "storageKey": null
-                      }
-                    ],
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "cursor",
-                    "storageKey": null
-                  }
-                ],
-                "storageKey": null
-              },
-              {
-                "alias": null,
-                "args": null,
-                "concreteType": "PageInfo",
-                "kind": "LinkedField",
-                "name": "pageInfo",
-                "plural": false,
-                "selections": [
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "startCursor",
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "endCursor",
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "hasNextPage",
-                    "storageKey": null
-                  }
-                ],
-                "storageKey": null
-              },
-              {
-                "kind": "ClientExtension",
-                "selections": [
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "__id",
-                    "storageKey": null
-                  }
-                ]
-              }
+              (v8/*: any*/),
+              (v0/*: any*/)
             ],
-            "storageKey": "events(after:\"\",first:50)"
-          },
-          {
-            "alias": null,
-            "args": (v1/*: any*/),
-            "filters": null,
-            "handle": "connection",
-            "key": "useDashboardEventsFragment_events",
-            "kind": "LinkedHandle",
-            "name": "events"
+            "storageKey": null
           }
         ],
         "storageKey": null
@@ -251,16 +177,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "8468a9cff02e9250079fe7a1ce56cd16",
+    "cacheID": "600cd77117edbb1828300d9dab38c11e",
     "id": null,
     "metadata": {},
     "name": "DashboardQuery",
     "operationKind": "query",
-    "text": "query DashboardQuery {\n  me {\n    ...useDashboardEventsFragment\n    id\n  }\n}\n\nfragment useDashboardEventsFragment on User {\n  id\n  events(first: 50, after: \"\") {\n    edges {\n      node {\n        id\n        title\n        description\n        startDateTime\n        endDateTime\n        isViewerModerator\n        isActive\n        organization {\n          name\n          id\n        }\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      startCursor\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query DashboardQuery {\n  dashboardEvents {\n    id\n    startDateTime\n    endDateTime\n    title\n    topic\n    description\n    isActive\n    isViewerModerator\n    organization {\n      name\n      id\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "48e573911902d176c175a57b8b074e14";
+(node as any).hash = "36938619379a73874f30e88888d5cb94";
 
 export default node;

--- a/app/client/src/features/admin/EventsDashboard.tsx
+++ b/app/client/src/features/admin/EventsDashboard.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { graphql, useQueryLoader, PreloadedQuery, usePreloadedQuery } from 'react-relay';
-import { Grid, Paper, Typography } from '@mui/material';
+import { Grid, Paper, Typography, useMediaQuery } from '@mui/material';
+import { useTheme } from '@mui/styles';
 
 import { ConditionalRender, Loader } from '@local/components';
 import type { EventsDashboardQuery } from '@local/__generated__/EventsDashboardQuery.graphql';
@@ -22,11 +23,7 @@ function EventsList({ queryRef }: UsersListProps) {
     const { me } = usePreloadedQuery(EVENTS_DASHBOARD_QUERY, queryRef);
 
     if (!me) return <Loader />;
-    return (
-        <Grid container>
-            <EventsTable fragmentRef={me} />
-        </Grid>
-    );
+    return <EventsTable fragmentRef={me} />;
 }
 
 function PreloadedEventsList() {
@@ -46,16 +43,21 @@ function PreloadedEventsList() {
 }
 
 export function EventsDashboard() {
+    const theme = useTheme();
+    const lgUpBreakpoint = useMediaQuery(theme.breakpoints.up('lg'));
+
     return (
-        <Paper>
-            <Grid paddingLeft='1rem'>
-                <Typography variant='h4'>Admin Dashboard: Events</Typography>
-            </Grid>
-            <ConditionalRender client>
-                <React.Suspense fallback={<Loader />}>
-                    <PreloadedEventsList />
-                </React.Suspense>
-            </ConditionalRender>
-        </Paper>
+        <Grid container width={lgUpBreakpoint ? '80%' : '100%'} marginLeft={lgUpBreakpoint ? '250px' : '0px'}>
+            <Paper>
+                <Grid paddingLeft='1rem'>
+                    <Typography variant='h4'>Admin Dashboard: Events</Typography>
+                </Grid>
+                <ConditionalRender client>
+                    <React.Suspense fallback={<Loader />}>
+                        <PreloadedEventsList />
+                    </React.Suspense>
+                </ConditionalRender>
+            </Paper>
+        </Grid>
     );
 }

--- a/app/client/src/features/admin/EventsTable.tsx
+++ b/app/client/src/features/admin/EventsTable.tsx
@@ -132,7 +132,7 @@ export function EventsTable({ fragmentRef }: EventsTableProps) {
     }, [handleLoadNext, nextPageIsLastPage]);
 
     return (
-        <React.Fragment>
+        <Grid container>
             <Grid container justifyContent='center'>
                 <SearchBar handleSearchFilter={handleSearchFilter} />
             </Grid>
@@ -235,6 +235,6 @@ export function EventsTable({ fragmentRef }: EventsTableProps) {
                     </TableFooter>
                 </Table>
             </TableContainer>
-        </React.Fragment>
+        </Grid>
     );
 }

--- a/app/client/src/features/admin/UsersDashboard.tsx
+++ b/app/client/src/features/admin/UsersDashboard.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { graphql, useQueryLoader, PreloadedQuery, usePreloadedQuery } from 'react-relay';
-import { Grid, Paper, Typography } from '@mui/material';
+import { Grid, Paper, Typography, useMediaQuery } from '@mui/material';
+import { useTheme } from '@mui/styles';
 
 import { ConditionalRender, Loader } from '@local/components';
 import type { UsersDashboardQuery } from '@local/__generated__/UsersDashboardQuery.graphql';
@@ -22,11 +23,7 @@ function UsersList({ queryRef }: UsersListProps) {
     const { me } = usePreloadedQuery(USERS_DASHBOARD_QUERY, queryRef);
 
     if (!me) return <Loader />;
-    return (
-        <Grid container>
-            <UsersTable fragmentRef={me} />
-        </Grid>
-    );
+    return <UsersTable fragmentRef={me} />;
 }
 
 function PreloadedUsersList() {
@@ -46,16 +43,21 @@ function PreloadedUsersList() {
 }
 
 export function UsersDashboard() {
+    const theme = useTheme();
+    const lgUpBreakpoint = useMediaQuery(theme.breakpoints.up('lg'));
+
     return (
-        <Paper>
-            <Grid paddingLeft='1rem'>
-                <Typography variant='h4'>Admin Dashboard: Users</Typography>
-            </Grid>
-            <ConditionalRender client>
-                <React.Suspense fallback={<Loader />}>
-                    <PreloadedUsersList />
-                </React.Suspense>
-            </ConditionalRender>
-        </Paper>
+        <Grid container width={lgUpBreakpoint ? '80%' : '100%'} marginLeft={lgUpBreakpoint ? '250px' : '0px'}>
+            <Paper>
+                <Grid paddingLeft='1rem'>
+                    <Typography variant='h4'>Admin Dashboard: Users</Typography>
+                </Grid>
+                <ConditionalRender client>
+                    <React.Suspense fallback={<Loader />}>
+                        <PreloadedUsersList />
+                    </React.Suspense>
+                </ConditionalRender>
+            </Paper>
+        </Grid>
     );
 }

--- a/app/client/src/features/admin/UsersTable.tsx
+++ b/app/client/src/features/admin/UsersTable.tsx
@@ -134,7 +134,7 @@ export function UsersTable({ fragmentRef }: UsersTableProps) {
     }, [handleLoadNext, nextPageIsLastPage]);
 
     return (
-        <React.Fragment>
+        <Grid container>
             <Grid container justifyContent='center'>
                 <SearchBar handleSearchFilter={handleSearchFilter} />
             </Grid>
@@ -227,6 +227,6 @@ export function UsersTable({ fragmentRef }: UsersTableProps) {
                     </TableFooter>
                 </Table>
             </TableContainer>
-        </React.Fragment>
+        </Grid>
     );
 }

--- a/app/client/src/features/dashboard/Dashboard.tsx
+++ b/app/client/src/features/dashboard/Dashboard.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { graphql, PreloadedQuery, usePreloadedQuery, useQueryLoader } from 'react-relay';
+import { fetchQuery, graphql, PreloadedQuery, usePreloadedQuery, useQueryLoader, useRelayEnvironment } from 'react-relay';
 
 import type { DashboardQuery } from '@local/__generated__/DashboardQuery.graphql';
 import { ConditionalRender } from '@local/components/ConditionalRender';
@@ -8,8 +8,18 @@ import { DashboardEvents } from './DashboardEvents';
 
 export const DASHBOARD_QUERY = graphql`
     query DashboardQuery {
-        me {
-            ...useDashboardEventsFragment
+        dashboardEvents {
+            id
+            startDateTime
+            endDateTime
+            title
+            topic
+            description
+            isActive
+            isViewerModerator
+            organization {
+                name
+            }
         }
     }
 `;
@@ -19,23 +29,42 @@ interface DashboardContainerProps {
 }
 
 export function DashboardContainer({ queryRef }: DashboardContainerProps) {
-    const { me: queryResponse } = usePreloadedQuery(DASHBOARD_QUERY, queryRef);
+    const { dashboardEvents } = usePreloadedQuery(DASHBOARD_QUERY, queryRef);
 
-    if (!queryResponse) return <Loader />;
-    return (
-        <React.Suspense fallback={<Loader />}>
-            <DashboardEvents fragmentRef={queryResponse} />
-        </React.Suspense>
-    );
+    if (!dashboardEvents) return <Loader />;
+    return <DashboardEvents dashboardEvents={dashboardEvents} />;
 }
 
 export function PreloadedDashboard() {
     const [queryRef, loadQuery, dispose] = useQueryLoader<DashboardQuery>(DASHBOARD_QUERY);
+    const [isRefreshing, setIsRefreshing] = React.useState(false)
+    const environment = useRelayEnvironment();
+    const REFRESH_INTERVAL = 20000; // 20 seconds
+
+    const refresh = React.useCallback(() => {
+        if (isRefreshing) return;
+        setIsRefreshing(true);
+        fetchQuery(environment, DASHBOARD_QUERY, {}).subscribe({
+            complete: () => {
+                setIsRefreshing(false);
+                loadQuery({}, { fetchPolicy: 'store-or-network' });
+            },
+            error: (error: any) => {
+                console.error(error);
+                setIsRefreshing(false);
+            }
+        });
+    }, [environment, isRefreshing, loadQuery]);
 
     React.useEffect(() => {
         // Load the query on initial render
         if (!queryRef) loadQuery({}, { fetchPolicy: 'network-only' });
-        return () => dispose();
+        // Refresh the query every 20 seconds
+        const interval = setInterval(refresh, REFRESH_INTERVAL);
+        return () => {
+            clearInterval(interval);
+            dispose();
+        };
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 

--- a/app/client/src/features/dashboard/Dashboard.tsx
+++ b/app/client/src/features/dashboard/Dashboard.tsx
@@ -1,5 +1,12 @@
 import * as React from 'react';
-import { fetchQuery, graphql, PreloadedQuery, usePreloadedQuery, useQueryLoader, useRelayEnvironment } from 'react-relay';
+import {
+    fetchQuery,
+    graphql,
+    PreloadedQuery,
+    usePreloadedQuery,
+    useQueryLoader,
+    useRelayEnvironment,
+} from 'react-relay';
 
 import type { DashboardQuery } from '@local/__generated__/DashboardQuery.graphql';
 import { ConditionalRender } from '@local/components/ConditionalRender';
@@ -37,9 +44,9 @@ export function DashboardContainer({ queryRef }: DashboardContainerProps) {
 
 export function PreloadedDashboard() {
     const [queryRef, loadQuery, dispose] = useQueryLoader<DashboardQuery>(DASHBOARD_QUERY);
-    const [isRefreshing, setIsRefreshing] = React.useState(false)
+    const [isRefreshing, setIsRefreshing] = React.useState(false);
     const environment = useRelayEnvironment();
-    const REFRESH_INTERVAL = 20000; // 20 seconds
+    const REFRESH_INTERVAL = 60000; // 60 seconds
 
     const refresh = React.useCallback(() => {
         if (isRefreshing) return;
@@ -52,7 +59,7 @@ export function PreloadedDashboard() {
             error: (error: any) => {
                 console.error(error);
                 setIsRefreshing(false);
-            }
+            },
         });
     }, [environment, isRefreshing, loadQuery]);
 

--- a/app/client/src/features/dashboard/DashboardEventListItem.tsx
+++ b/app/client/src/features/dashboard/DashboardEventListItem.tsx
@@ -3,19 +3,10 @@ import { useRouter } from 'next/router';
 import { ListItem, ListItemAvatar } from '@mui/material';
 import { Shield } from '@mui/icons-material';
 import { DashboardEvent } from '@local/features/dashboard/DashboardEvent';
+import type { TDashboardEvent } from '@local/features/dashboard/DashboardEvents';
 
 interface DashboardEventListItemProps {
-    event: {
-        id: string;
-        title: string | null;
-        description: string | null;
-        startDateTime: Date | null;
-        endDateTime: Date | null;
-        isViewerModerator: boolean | null;
-        organization: {
-            name: string;
-        } | null;
-    };
+    event: TDashboardEvent;
     divider: boolean;
     children: React.ReactNode;
 }

--- a/app/client/src/features/dashboard/DashboardEventListItem.tsx
+++ b/app/client/src/features/dashboard/DashboardEventListItem.tsx
@@ -37,6 +37,7 @@ export function DashboardEventListItem({ event, divider, children }: DashboardEv
             onClick={handleClick}
             disableRipple={!event.isViewerModerator}
             disableTouchRipple={!event.isViewerModerator}
+            data-test-id={`dashboard-event-list-item-${event.title}`}
         >
             <ModeratorIcon isModerator={!!event.isViewerModerator} />
             <DashboardEvent

--- a/app/client/src/features/dashboard/DashboardEvents.tsx
+++ b/app/client/src/features/dashboard/DashboardEvents.tsx
@@ -1,24 +1,116 @@
 import * as React from 'react';
-import { FragmentRefs } from 'relay-runtime';
-import { Grid, useMediaQuery } from '@mui/material';
+import { Button, Card, CardContent, Grid, List, ListItemSecondaryAction, Typography, useMediaQuery } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
+import { isAfter, isBefore } from 'date-fns';
 
-import { DashboardEventListDisplay } from './DashboardEventListDisplay';
+import { useRouter } from 'next/router';
+import { DashboardEventListItem } from './DashboardEventListItem';
+import { useRefresh } from '../core';
+
+export type TDashboardEvent = {
+    readonly id: string;
+    readonly title: string | null;
+    readonly description: string | null;
+    readonly isActive: boolean | null;
+    readonly isViewerModerator: boolean | null;
+    readonly startDateTime: Date | null;
+    readonly endDateTime: Date | null;
+    readonly organization: {
+        readonly name: string;
+    } | null;
+};
 
 interface DashboardEventsProps {
-    fragmentRef: {
-        readonly ' $fragmentSpreads': FragmentRefs<any>;
-    };
+    dashboardEvents: readonly TDashboardEvent[];
 }
 
-export function DashboardEvents({ fragmentRef }: DashboardEventsProps) {
+export function DashboardEvents({ dashboardEvents }: DashboardEventsProps) {
     const theme = useTheme();
     const lgUpBreakpoint = useMediaQuery(theme.breakpoints.up('lg'));
+    const router = useRouter();
+    const [now, setNow] = React.useState(new Date());
+    useRefresh({ refreshInterval: 5000 /* 5 seconds */, callback: () => setNow(new Date()) });
+
+    const handleNav = (event: TDashboardEvent) => () => {
+        if (event.isViewerModerator) router.push(`/events/${event.id}/mod`)
+        else if (event.isActive) router.push(`/events/${event.id}/live`);
+        else router.push(`/events/${event.id}/pre`);
+    };
+
+    const upcomingEvents = React.useMemo(() => {
+        return dashboardEvents.filter((event) => {
+            if (!event.startDateTime || event.isActive) return false;
+            return isAfter(new Date(event.startDateTime), now);
+        });
+    }, [dashboardEvents, now]);
+
+    const ongoingEvents = React.useMemo(() => {
+        return dashboardEvents.filter((event) => {
+            if (!event.startDateTime || !event.endDateTime) return Boolean(event.isActive);
+            return (
+                Boolean(event.isActive) ||
+                (isBefore(new Date(event.startDateTime), now) && isAfter(new Date(event.endDateTime), now))
+            );
+        });
+    }, [dashboardEvents, now])
+
+    const eventButtonText = (event: TDashboardEvent) => {
+        const { isViewerModerator, isActive } = event;
+        if (isViewerModerator) return 'Moderate Event'
+        else if (isActive) return 'Join Event';
+        else return 'Join Pre Event'
+    }
 
     return (
         <Grid container width={lgUpBreakpoint ? '80%' : '100%'} marginLeft={lgUpBreakpoint ? '250px' : '0px'}>
-            <DashboardEventListDisplay fragmentRef={fragmentRef} ongoing={true} />
-            <DashboardEventListDisplay fragmentRef={fragmentRef} ongoing={false} />
+            <Grid item xs={12} marginBottom={theme.spacing(4)}>
+            <Card style={{ padding: theme.spacing(1) }}>
+                <CardContent>
+                        <React.Fragment>
+                            <Typography variant='h6' marginBottom={theme.spacing(1)}>
+                                Current Events
+                            </Typography>
+                            <List>
+                                {ongoingEvents.map((event, idx) => (
+                                    <DashboardEventListItem key={event.id} event={event} divider={idx !== dashboardEvents.length - 1}>
+                                        <ListItemSecondaryAction>
+                                                <Button
+                                                    aria-label='view live feed of current event'
+                                                    variant='contained'
+                                                    color='primary'
+                                                    onClick={handleNav(event)}
+                                                >
+                                                    {eventButtonText(event)}
+                                                </Button>
+                                        </ListItemSecondaryAction>
+                                    </DashboardEventListItem>
+                                ))}
+                            </List>
+                        </React.Fragment>
+                        <React.Fragment>
+                            <Typography variant='h6' marginBottom={theme.spacing(1)}>
+                                Upcoming Events
+                            </Typography>
+                            <List>
+                                {upcomingEvents.map((event, idx) => (
+                                    <DashboardEventListItem key={event.id} event={event} divider={idx !== dashboardEvents.length - 1}>
+                                        <ListItemSecondaryAction>
+                                                <Button
+                                                    aria-label='view live feed of current event'
+                                                    variant='contained'
+                                                    color='primary'
+                                                    onClick={handleNav(event)}
+                                                >
+                                                    {eventButtonText(event)}
+                                                </Button>
+                                        </ListItemSecondaryAction>
+                                    </DashboardEventListItem>
+                                ))}
+                            </List>
+                        </React.Fragment>
+                </CardContent>
+            </Card>
+            </Grid>
         </Grid>
     );
 }

--- a/app/client/src/features/dashboard/DashboardEvents.tsx
+++ b/app/client/src/features/dashboard/DashboardEvents.tsx
@@ -1,5 +1,14 @@
 import * as React from 'react';
-import { Button, Card, CardContent, Grid, List, ListItemSecondaryAction, Typography, useMediaQuery } from '@mui/material';
+import {
+    Button,
+    Card,
+    CardContent,
+    Grid,
+    List,
+    ListItemSecondaryAction,
+    Typography,
+    useMediaQuery,
+} from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 import { isAfter, isBefore } from 'date-fns';
 
@@ -27,12 +36,13 @@ interface DashboardEventsProps {
 export function DashboardEvents({ dashboardEvents }: DashboardEventsProps) {
     const theme = useTheme();
     const lgUpBreakpoint = useMediaQuery(theme.breakpoints.up('lg'));
+    const smDownBreakpoint = useMediaQuery(theme.breakpoints.down('sm'));
     const router = useRouter();
     const [now, setNow] = React.useState(new Date());
     useRefresh({ refreshInterval: 5000 /* 5 seconds */, callback: () => setNow(new Date()) });
 
     const handleNav = (event: TDashboardEvent) => () => {
-        if (event.isViewerModerator) router.push(`/events/${event.id}/mod`)
+        if (event.isViewerModerator) router.push(`/events/${event.id}/mod`);
         else if (event.isActive) router.push(`/events/${event.id}/live`);
         else router.push(`/events/${event.id}/pre`);
     };
@@ -52,64 +62,94 @@ export function DashboardEvents({ dashboardEvents }: DashboardEventsProps) {
                 (isBefore(new Date(event.startDateTime), now) && isAfter(new Date(event.endDateTime), now))
             );
         });
-    }, [dashboardEvents, now])
+    }, [dashboardEvents, now]);
 
     const eventButtonText = (event: TDashboardEvent) => {
         const { isViewerModerator, isActive } = event;
-        if (isViewerModerator) return 'Moderate Event'
-        else if (isActive) return 'Join Event';
-        else return 'Join Pre Event'
-    }
+        if (isViewerModerator) return 'Moderate';
+        else if (isActive) return 'Join';
+        else return 'Pre Event';
+    };
 
     return (
         <Grid container width={lgUpBreakpoint ? '80%' : '100%'} marginLeft={lgUpBreakpoint ? '250px' : '0px'}>
             <Grid item xs={12} marginBottom={theme.spacing(4)}>
-            <Card style={{ padding: theme.spacing(1) }}>
-                <CardContent>
-                        <React.Fragment>
-                            <Typography variant='h6' marginBottom={theme.spacing(1)}>
-                                Current Events
-                            </Typography>
-                            <List>
-                                {ongoingEvents.map((event, idx) => (
-                                    <DashboardEventListItem key={event.id} event={event} divider={idx !== dashboardEvents.length - 1}>
+                <Card style={{ padding: theme.spacing(1) }}>
+                    <CardContent>
+                        <Typography variant='h6' marginBottom={theme.spacing(1)}>
+                            Current Events
+                        </Typography>
+                        <List>
+                            {ongoingEvents.map((event, idx) => (
+                                <DashboardEventListItem
+                                    key={event.id}
+                                    event={event}
+                                    divider={idx !== dashboardEvents.length - 1}
+                                >
+                                    {smDownBreakpoint ? (
+                                        <Button
+                                            aria-label='view live feed of current event'
+                                            variant='contained'
+                                            color='primary'
+                                            onClick={handleNav(event)}
+                                            data-test-id='dashboard-ongoing-event-join-button'
+                                        >
+                                            {eventButtonText(event)}
+                                        </Button>
+                                    ) : (
                                         <ListItemSecondaryAction>
-                                                <Button
-                                                    aria-label='view live feed of current event'
-                                                    variant='contained'
-                                                    color='primary'
-                                                    onClick={handleNav(event)}
-                                                >
-                                                    {eventButtonText(event)}
-                                                </Button>
+                                            <Button
+                                                aria-label='view live feed of current event'
+                                                variant='contained'
+                                                color='primary'
+                                                onClick={handleNav(event)}
+                                                data-test-id='dashboard-ongoing-event-join-button'
+                                            >
+                                                {eventButtonText(event)}
+                                            </Button>
                                         </ListItemSecondaryAction>
-                                    </DashboardEventListItem>
-                                ))}
-                            </List>
-                        </React.Fragment>
-                        <React.Fragment>
-                            <Typography variant='h6' marginBottom={theme.spacing(1)}>
-                                Upcoming Events
-                            </Typography>
-                            <List>
-                                {upcomingEvents.map((event, idx) => (
-                                    <DashboardEventListItem key={event.id} event={event} divider={idx !== dashboardEvents.length - 1}>
+                                    )}
+                                </DashboardEventListItem>
+                            ))}
+                        </List>
+                        <Typography variant='h6' marginBottom={theme.spacing(1)}>
+                            Upcoming Events
+                        </Typography>
+                        <List>
+                            {upcomingEvents.map((event, idx) => (
+                                <DashboardEventListItem
+                                    key={event.id}
+                                    event={event}
+                                    divider={idx !== dashboardEvents.length - 1}
+                                >
+                                    {smDownBreakpoint ? (
+                                        <Button
+                                            aria-label='view live feed of current event'
+                                            variant='contained'
+                                            color='primary'
+                                            onClick={handleNav(event)}
+                                            data-test-id='dashboard-upcoming-event-join-button'
+                                        >
+                                            {eventButtonText(event)}
+                                        </Button>
+                                    ) : (
                                         <ListItemSecondaryAction>
-                                                <Button
-                                                    aria-label='view live feed of current event'
-                                                    variant='contained'
-                                                    color='primary'
-                                                    onClick={handleNav(event)}
-                                                >
-                                                    {eventButtonText(event)}
-                                                </Button>
+                                            <Button
+                                                aria-label='view live feed of current event'
+                                                variant='contained'
+                                                color='primary'
+                                                onClick={handleNav(event)}
+                                                data-test-id='dashboard-upcoming-event-join-button'
+                                            >
+                                                {eventButtonText(event)}
+                                            </Button>
                                         </ListItemSecondaryAction>
-                                    </DashboardEventListItem>
-                                ))}
-                            </List>
-                        </React.Fragment>
-                </CardContent>
-            </Card>
+                                    )}
+                                </DashboardEventListItem>
+                            ))}
+                        </List>
+                    </CardContent>
+                </Card>
             </Grid>
         </Grid>
     );

--- a/app/client/src/graphql-types.ts
+++ b/app/client/src/graphql-types.ts
@@ -1097,6 +1097,7 @@ export type PostEventFeedbackMutationResponse = MutationResponse & {
 
 export type Query = {
   __typename?: 'Query';
+  dashboardEvents?: Maybe<Array<Event>>;
   /** Fetch a single event */
   event?: Maybe<Event>;
   eventBroadcastMessages?: Maybe<Array<EventBroadcastMessage>>;

--- a/app/e2e/common/pages/playwright-dashboard-page.ts
+++ b/app/e2e/common/pages/playwright-dashboard-page.ts
@@ -55,18 +55,12 @@ export class PlaywrightDashboardPage {
     }
 
     async clickOnEvent(eventName: string, orgName: string, ongoing: boolean) {
-        const formattedDate = this.today.toLocaleDateString('en-US', {
-            month: '2-digit',
-            day: '2-digit',
-            year: 'numeric',
-        });
-        const buttonName = `${eventName} ${formattedDate} ${ongoing ? '12:00 AM' : '11:59 PM'} ${orgName}`;
-        await this.page.getByRole('button', { name: buttonName }).click();
+        await this.page.locator(`[data-test-id="dashboard-event-list-item-${eventName}"]`).click({ force: true});
         await this.page.waitForTimeout(5000); // Using this over waitForNavigation because it was not working with firefox.
     }
 
-    async clickOnLiveFeed() {
-        await this.page.getByRole('button', { name: 'view live feed of current event' }).first().click();
+    async clickOnJoinOngoingEventButton() {
+        await this.page.locator('[data-test-id="dashboard-ongoing-event-join-button"]').first().click();
         await this.page.waitForTimeout(5000); // Using this over waitForNavigation because it was not working with firefox.
     }
 }

--- a/app/e2e/tests/dashboard/organizer-dashboard.spec.ts
+++ b/app/e2e/tests/dashboard/organizer-dashboard.spec.ts
@@ -32,9 +32,9 @@ export default function organizerTests() {
             // Go to Dashboard
             await dashboardPageOrganizer.goto();
 
-            // Select Live Feed
-            await dashboardPageOrganizer.clickOnLiveFeed();
-            await expect(dashboardPageOrganizer.page).toHaveURL(/.*live/);
+            // Join ongoing event
+            await dashboardPageOrganizer.clickOnJoinOngoingEventButton();
+            await expect(dashboardPageOrganizer.page).toHaveURL(/.*mod/);
         });
 
         test('I am directed back to dashboard upon refresh.', async ({ dashboardPageOrganizer }) => {

--- a/app/server/src/features/events/resolvers.ts
+++ b/app/server/src/features/events/resolvers.ts
@@ -32,11 +32,11 @@ export const resolvers: Resolvers = {
             const foundEvent = await Event.findEventById(eventId, ctx.prisma);
             return foundEvent ? toEventId(foundEvent) : null;
         },
-        // async isEventPrivate(parent, args, ctx, info) {
-        //     const isPrivateEvent = await Event.isEventPrivate(ctx.prisma,{ ...args.event, eventId }, status);
-        //     if
-        //     return isPrivateEvent.map(toEventId);
-        // },
+        async dashboardEvents(parent, args, ctx, info) {
+            if (!ctx.viewer.id) throw new ProtectedError({ userMessage: errors.noLogin });
+            const foundEvents = await Event.findDashboardEvents(ctx.viewer.id, ctx.prisma);
+            return foundEvents.map(toEventId);
+        }
     },
     Mutation: {
         async createEvent(parent, args, ctx, info) {

--- a/app/server/src/features/events/schema.graphql
+++ b/app/server/src/features/events/schema.graphql
@@ -270,6 +270,7 @@ type Query {
     """
     event(eventId: ID!): Event
     eventBroadcastMessages(eventId: ID!): [EventBroadcastMessage!]
+    dashboardEvents: [Event!]
 }
 
 """

--- a/app/server/src/graphql-types.ts
+++ b/app/server/src/graphql-types.ts
@@ -47,6 +47,7 @@ export type Query = {
     /** Fetch a single event */
     event?: Maybe<Event>;
     eventBroadcastMessages?: Maybe<Array<EventBroadcastMessage>>;
+    dashboardEvents?: Maybe<Array<Event>>;
     isOrganizer: Scalars['Boolean'];
     myFeedback?: Maybe<Array<Maybe<EventLiveFeedback>>>;
     promptResponses?: Maybe<Array<EventLiveFeedbackPromptResponse>>;
@@ -1911,6 +1912,7 @@ export type QueryResolvers<
         ContextType,
         RequireFields<QueryeventBroadcastMessagesArgs, 'eventId'>
     >;
+    dashboardEvents?: Resolver<Maybe<Array<ResolversTypes['Event']>>, ParentType, ContextType>;
     isOrganizer?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
     myFeedback?: Resolver<
         Maybe<Array<Maybe<ResolversTypes['EventLiveFeedback']>>>,


### PR DESCRIPTION
- Dashboard was not always loading properly at first and was having odd behavior with some events not showing up until first refresh.
- Updated from using refetchable fragment to a query that refreshes on an interval. Because this is now a separate query, we can do the majority of sorting for active/upcoming events via SQL rather than fetching all events tied to someone's account and sorting on the client. This should make it more efficient and fix the behavior issue that was likely caused by the initial fetch of events being limited to 50, so if someone had more than that tied to their account not all would display initially. This is also better since the total number of events will grow over time but the number of events that meet the ongoing/upcoming conditions will be much more limited.
- Fixed a bug with the admin dashboards where on 1080p screens and below some of the table was being cut off.