### PR TITLE
Prytaneum event settings fixes

### DIFF
--- a/app/client/src/features/events/Invites/InvitedUsersList.tsx
+++ b/app/client/src/features/events/Invites/InvitedUsersList.tsx
@@ -55,17 +55,40 @@ export function InvitedUsersList({ isVisible, fragmentRef }: InvitedUsersListPro
     return (
         <React.Fragment>
             <Typography variant='h6'>Invited Users List</Typography>
-            <Grid container display='grid' maxHeight={'300px'} style={{ overflowY: 'scroll' }}>
+            <Grid
+                container
+                display='grid'
+                maxHeight={'300px'}
+                sx={{
+                    overflowY: 'scroll',
+                    '::-webkit-scrollbar': {
+                        backgroundColor: 'transparent',
+                    },
+                    '::-webkit-scrollbar-thumb': {
+                        backgroundColor: '#D9D9D9',
+                        backgroundOpacity: '0.3',
+                        borderRadius: '20px',
+                        border: '5px solid transparent',
+                        backgroundClip: 'content-box',
+                    },
+                }}
+            >
                 <Grid item paddingTop='1rem'>
-                    {invitedUsers.length === 0 && <p>No invitedUsers yet</p>}
-                    <Grid item container alignItems='center' justifyContent='center'>
-                        <ListFilter
-                            style={{ width: '80%' }}
-                            onFilterChange={handleFilterChange}
-                            onSearch={handleSearch}
-                            length={filteredList.length}
-                        />
-                    </Grid>
+                    {invitedUsers.length === 0 && (
+                        <Grid item container alignItems='center' justifyContent='center'>
+                            <p>No invited Users yet</p>
+                        </Grid>
+                    )}
+                    {invitedUsers.length > 0 && (
+                        <Grid item container alignItems='center' justifyContent='center'>
+                            <ListFilter
+                                style={{ width: '80%' }}
+                                onFilterChange={handleFilterChange}
+                                onSearch={handleSearch}
+                                length={filteredList.length}
+                            />
+                        </Grid>
+                    )}
                     <Grid item container alignItems='center' justifyContent='center'>
                         <List disablePadding style={{ width: '80%' }}>
                             {filteredList.map((invitee) => (

--- a/app/client/src/features/events/Moderation/CreateModerator.tsx
+++ b/app/client/src/features/events/Moderation/CreateModerator.tsx
@@ -28,6 +28,7 @@ export const CREATE_MODERATOR_MUTATION = graphql`
 export function CreateModerator({ eventId, onSubmit, connections }: CreateModeratorProps) {
     const { displaySnack } = useSnack();
     const [commit] = useMutation<CreateModeratorMutation>(CREATE_MODERATOR_MUTATION);
+
     const handleSubmit: ModeratorProps['onSubmit'] = (submittedForm) => {
         commit({
             variables: {
@@ -40,9 +41,12 @@ export function CreateModerator({ eventId, onSubmit, connections }: CreateModera
             onCompleted({ createModerator }) {
                 if (createModerator.isError) {
                     displaySnack(createModerator.message, { variant: 'error' });
-                } else if (!createModerator.isError && onSubmit) {
+                } else if (onSubmit) {
                     onSubmit();
                 }
+            },
+            onError(err) {
+                displaySnack(err.message, { variant: 'error' });
             },
         });
     };

--- a/app/client/src/features/events/Moderation/DeleteModerator.tsx
+++ b/app/client/src/features/events/Moderation/DeleteModerator.tsx
@@ -38,6 +38,9 @@ export function DeleteModerator(props: DeleteModeratorProps) {
                     onConfirm();
                 }
             },
+            onError: (err) => {
+                displaySnack(err.message, { variant: 'error' });
+            },
         });
     };
     return (

--- a/app/client/src/features/events/Moderation/UpdateModerator.tsx
+++ b/app/client/src/features/events/Moderation/UpdateModerator.tsx
@@ -3,6 +3,7 @@ import { graphql, useMutation } from 'react-relay';
 
 import type { UpdateModeratorMutation } from '@local/__generated__/UpdateModeratorMutation.graphql';
 import { ModeratorForm, ModeratorProps, TModeratorForm } from './ModeratorForm';
+import { useSnack } from '@local/core';
 
 export interface CreateModeratorProps {
     eventId: string;
@@ -27,6 +28,8 @@ export const UPDATE_MODERATOR_MUTATION = graphql`
 
 export function UpdateModerator({ eventId, onSubmit, form }: CreateModeratorProps) {
     const [commit] = useMutation<UpdateModeratorMutation>(UPDATE_MODERATOR_MUTATION);
+    const { displaySnack } = useSnack();
+
     const handleSubmit: ModeratorProps['onSubmit'] = (submittedForm: TModeratorForm) => {
         commit({
             variables: {
@@ -35,8 +38,13 @@ export function UpdateModerator({ eventId, onSubmit, form }: CreateModeratorProp
                     eventId,
                 },
             },
-            onCompleted() {
-                if (onSubmit) onSubmit();
+            onCompleted(results) {
+                if (results.updateModerator.isError)
+                    displaySnack(results.updateModerator.message, { variant: 'error' });
+                else if (onSubmit) onSubmit();
+            },
+            onError(err) {
+                displaySnack(err.message, { variant: 'error' });
             },
         });
     };

--- a/app/client/src/features/events/Speakers/CreateSpeaker.tsx
+++ b/app/client/src/features/events/Speakers/CreateSpeaker.tsx
@@ -5,6 +5,7 @@ import type {
     CreateSpeakerMutation$data,
 } from '@local/__generated__/CreateSpeakerMutation.graphql';
 import { SpeakerForm, TSpeakerForm } from './SpeakerForm';
+import { useSnack } from '@local/core';
 
 const CREATE_SPEAKER_MUTATION = graphql`
     mutation CreateSpeakerMutation($input: CreateSpeaker!, $connections: [ID!]!) {
@@ -33,6 +34,7 @@ export interface CreateSpeakerProps {
 
 export function CreateSpeaker({ eventId, onSubmit, connections }: CreateSpeakerProps) {
     const [commit] = useMutation<CreateSpeakerMutation>(CREATE_SPEAKER_MUTATION);
+    const { displaySnack } = useSnack();
 
     function handleSubmit(form: TSpeakerForm) {
         commit({
@@ -44,7 +46,11 @@ export function CreateSpeaker({ eventId, onSubmit, connections }: CreateSpeakerP
                 connections: connections ?? [],
             },
             onCompleted(results) {
-                if (results.createSpeaker) onSubmit(results.createSpeaker);
+                if (results.createSpeaker.isError) displaySnack(results.createSpeaker.message, { variant: 'error' });
+                else if (results.createSpeaker) onSubmit(results.createSpeaker);
+            },
+            onError(err) {
+                displaySnack(err.message, { variant: 'error' });
             },
         });
     }

--- a/app/client/src/features/events/Speakers/UpdateSpeaker.tsx
+++ b/app/client/src/features/events/Speakers/UpdateSpeaker.tsx
@@ -6,6 +6,7 @@ import type {
 } from '@local/__generated__/UpdateSpeakerMutation.graphql';
 import { NullableFields } from '@local/utils/ts-utils';
 import { SpeakerForm, TSpeakerForm } from './SpeakerForm';
+import { useSnack } from '@local/core';
 
 const UPDATE_SPEAKER_MUTATION = graphql`
     mutation UpdateSpeakerMutation($input: UpdateSpeaker!) {
@@ -35,6 +36,7 @@ export interface UpdateSpeakerProps {
 
 export function UpdateSpeaker({ form, speakerId, eventId, onSubmit }: UpdateSpeakerProps) {
     const [commit] = useMutation<UpdateSpeakerMutation>(UPDATE_SPEAKER_MUTATION);
+    const { displaySnack } = useSnack();
 
     function handleSubmit(submittedForm: TSpeakerForm) {
         if (!eventId) return;
@@ -47,7 +49,11 @@ export function UpdateSpeaker({ form, speakerId, eventId, onSubmit }: UpdateSpea
                 },
             },
             onCompleted(results) {
-                if (results.updateSpeaker) onSubmit(results.updateSpeaker);
+                if (results.updateSpeaker.isError) displaySnack(results.updateSpeaker.message, { variant: 'error' });
+                else if (results.updateSpeaker) onSubmit(results.updateSpeaker);
+            },
+            onError(err) {
+                displaySnack(err.message, { variant: 'error' });
             },
         });
     }

--- a/app/client/src/features/events/UpdateEvent.tsx
+++ b/app/client/src/features/events/UpdateEvent.tsx
@@ -2,6 +2,7 @@ import { graphql, useMutation } from 'react-relay';
 
 import type { UpdateEventMutation, UpdateEventMutation$data } from '@local/__generated__/UpdateEventMutation.graphql';
 import { EventForm, TEventForm, EventFormProps } from './EventForm';
+import { useSnack } from '@local/core';
 
 export const UPDATE_EVENT_MUTATION = graphql`
     mutation UpdateEventMutation($input: UpdateEvent!) {
@@ -23,12 +24,13 @@ export const UPDATE_EVENT_MUTATION = graphql`
 export type TUpdatedEvent = NonNullable<UpdateEventMutation$data['updateEvent']>;
 export type UpdateEventProps = {
     eventId: string;
-    onSubmit: (event: TUpdatedEvent) => void;
+    onSubmit: () => void;
     form: TEventForm;
 } & Omit<EventFormProps, 'onSubmit' | 'form' | 'formType'>;
 
 export function UpdateEvent({ eventId, onSubmit, ...eventFormProps }: UpdateEventProps) {
     const [commit] = useMutation<UpdateEventMutation>(UPDATE_EVENT_MUTATION);
+    const { displaySnack } = useSnack();
 
     function handleSubmit(submittedForm: TEventForm) {
         commit({
@@ -39,7 +41,8 @@ export function UpdateEvent({ eventId, onSubmit, ...eventFormProps }: UpdateEven
                 },
             },
             onCompleted(results) {
-                if (results.updateEvent) onSubmit(results.updateEvent);
+                if (results.updateEvent.isError) displaySnack(results.updateEvent.message, { variant: 'error' });
+                else onSubmit();
             },
         });
     }

--- a/app/client/src/features/events/UpdateEvent.tsx
+++ b/app/client/src/features/events/UpdateEvent.tsx
@@ -44,6 +44,9 @@ export function UpdateEvent({ eventId, onSubmit, ...eventFormProps }: UpdateEven
                 if (results.updateEvent.isError) displaySnack(results.updateEvent.message, { variant: 'error' });
                 else onSubmit();
             },
+            onError(err) {
+                displaySnack(err.message, { variant: 'error' });
+            },
         });
     }
 

--- a/app/client/src/features/events/Videos/CreateVideo.tsx
+++ b/app/client/src/features/events/Videos/CreateVideo.tsx
@@ -3,6 +3,7 @@ import { graphql, useMutation } from 'react-relay';
 
 import type { CreateVideoMutation, CreateVideoMutation$data } from '@local/__generated__/CreateVideoMutation.graphql';
 import { VideoForm, TVideoForm } from './VideoForm';
+import { useSnack } from '@local/core';
 
 interface CreateVideoProps {
     onSubmit: (res: CreateVideoMutation$data['createVideo']['body']) => void;
@@ -26,12 +27,17 @@ export const CREATE_VIDEO_MUTATION = graphql`
 
 export const CreateVideo = ({ onSubmit, eventId, connections }: CreateVideoProps) => {
     const [commit] = useMutation<CreateVideoMutation>(CREATE_VIDEO_MUTATION);
+    const { displaySnack } = useSnack();
 
     function handleSubmit(form: TVideoForm) {
         commit({
             variables: { input: { ...form, eventId }, connections },
             onCompleted(data) {
-                if (data.createVideo.body) onSubmit(data.createVideo.body);
+                if (data.createVideo.isError) displaySnack(data.createVideo.message, { variant: 'error' });
+                else if (data.createVideo.body) onSubmit(data.createVideo.body);
+            },
+            onError(err) {
+                displaySnack(err.message, { variant: 'error' });
             },
         });
     }

--- a/app/client/src/features/events/Videos/DeleteVideo.tsx
+++ b/app/client/src/features/events/Videos/DeleteVideo.tsx
@@ -4,6 +4,7 @@ import { graphql, useMutation } from 'react-relay';
 import type { DeleteVideoMutation } from '@local/__generated__/DeleteVideoMutation.graphql';
 import { ConfirmationDialog, ConfirmationDialogProps } from '@local/components/ConfirmationDialog';
 import type { EventVideo } from '@local/graphql-types';
+import { useSnack } from '@local/core';
 
 export const DELETE_VIDEO_MUTATION = graphql`
     mutation DeleteVideoMutation($input: DeleteVideo!, $connections: [ID!]!) {
@@ -22,11 +23,19 @@ type DeleteVideoProps = ConfirmationDialogProps & { video: EventVideo | null; ev
 export function DeleteVideo(props: DeleteVideoProps) {
     const { children, connections, onConfirm, video, eventId, ...propsSubset } = props;
     const [commit] = useMutation<DeleteVideoMutation>(DELETE_VIDEO_MUTATION);
+    const { displaySnack } = useSnack();
+
     const curryOnConfirm = () => {
         if (!video) return;
         commit({
             variables: { input: { id: video.id, eventId }, connections },
-            onCompleted: onConfirm,
+            onCompleted(data) {
+                if (data.deleteVideo.isError) displaySnack(data.deleteVideo.message, { variant: 'error' });
+                else onConfirm();
+            },
+            onError(err) {
+                displaySnack(err.message, { variant: 'error' });
+            },
         });
     };
     return (

--- a/app/client/src/features/events/Videos/UpdateVideo.tsx
+++ b/app/client/src/features/events/Videos/UpdateVideo.tsx
@@ -3,6 +3,7 @@ import { graphql, useMutation } from 'react-relay';
 
 import type { UpdateVideoMutation, UpdateVideoMutation$data } from '@local/__generated__/UpdateVideoMutation.graphql';
 import { VideoForm, TVideoForm } from './VideoForm';
+import { useSnack } from '@local/core';
 
 interface CreateVideoProps {
     onSubmit: (res: UpdateVideoMutation$data['updateVideo']) => void;
@@ -26,12 +27,17 @@ export const UPDATE_VIDEO_MUTATION = graphql`
 
 export const UpdateVideo = ({ onSubmit, eventId, video }: CreateVideoProps) => {
     const [commit] = useMutation<UpdateVideoMutation>(UPDATE_VIDEO_MUTATION);
+    const { displaySnack } = useSnack();
 
     function handleSubmit(form: TVideoForm) {
         commit({
             variables: { input: { ...form, eventId, videoId: video.id } },
             onCompleted(data) {
-                if (data.updateVideo) onSubmit(data.updateVideo);
+                if (data.updateVideo.isError) displaySnack(data.updateVideo.message, { variant: 'error' });
+                else onSubmit(data.updateVideo);
+            },
+            onError(err) {
+                displaySnack(err.message, { variant: 'error' });
             },
         });
     }


### PR DESCRIPTION
- Some users were having issues editing the event settings in production.
- Implemented the error snacks for updating event details, this was not properly set up before so any server errors were not being displayed to the user, causing confusion if the change did not go through without any visible reason why.
- The search bar for invited users looked out of place with an empty list, so now it only displays if there are invited users in the list. Also fixed minor typo in no invited users yet text