### PR TITLE
Prytaneum increase topic varchar limit

### DIFF
--- a/app/client/src/features/events/CreateEvent.tsx
+++ b/app/client/src/features/events/CreateEvent.tsx
@@ -2,6 +2,7 @@ import { graphql, useMutation } from 'react-relay';
 
 import type { CreateEventMutation, CreateEventMutation$data } from '@local/__generated__/CreateEventMutation.graphql';
 import { EventForm, TEventForm, EventFormProps } from './EventForm';
+import { useSnack } from '@local/core';
 
 export const CREATE_EVENT_MUTATION = graphql`
     mutation CreateEventMutation($input: CreateEvent!, $connections: [ID!]!) {
@@ -27,6 +28,7 @@ export type CreateEventProps = {
 
 export function CreateEvent({ orgId, onSubmit, connections, ...eventFormProps }: CreateEventProps) {
     const [commit] = useMutation<CreateEventMutation>(CREATE_EVENT_MUTATION);
+    const { displaySnack } = useSnack();
 
     function handleSubmit(submittedForm: TEventForm) {
         commit({
@@ -38,7 +40,11 @@ export function CreateEvent({ orgId, onSubmit, connections, ...eventFormProps }:
                 connections: connections || [],
             },
             onCompleted(results) {
+                if (results.createEvent.isError) displaySnack(results.createEvent.message, { variant: 'error' });
                 if (results.createEvent && onSubmit) onSubmit(results.createEvent);
+            },
+            onError(err) {
+                displaySnack(err.message, { variant: 'error' });
             },
         });
     }

--- a/app/client/src/features/events/EventForm.tsx
+++ b/app/client/src/features/events/EventForm.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Button, TextField } from '@mui/material';
+import { Button, TextField, Typography } from '@mui/material';
 import { MobileDateTimePicker } from '@mui/lab';
 import * as Yup from 'yup';
 
@@ -9,6 +9,7 @@ import type { CreateEvent as FormType } from '@local/graphql-types';
 import { FormActions } from '@local/components/FormActions';
 import { FormContent } from '@local/components/FormContent';
 import { FormTitle } from '@local/components/FormTitle';
+import { EVENT_TITLE_MAX_LENGTH, EVENT_TOPIC_MAX_LENGTH, EVENT_DESCRIPTION_MAX_LENGTH } from '@local/utils/rules';
 
 export interface EventFormProps {
     onSubmit: (event: TEventForm) => void;
@@ -26,15 +27,21 @@ type TSchema = {
     [key in keyof TEventForm]: Yup.AnySchema;
 };
 const validationSchema = Yup.object().shape<TSchema>({
-    title: Yup.string().max(100, 'Title must be less than 100 characters').required('Please enter a title'),
-    description: Yup.string().optional(),
+    title: Yup.string()
+        .max(EVENT_TITLE_MAX_LENGTH, `Title must be ${EVENT_TITLE_MAX_LENGTH} characters or less`)
+        .required('Please enter a title'),
+    description: Yup.string()
+        .max(EVENT_DESCRIPTION_MAX_LENGTH, `Description must be ${EVENT_DESCRIPTION_MAX_LENGTH} characters or less`)
+        .optional(),
     startDateTime: Yup.date()
         .max(Yup.ref('endDateTime'), 'Start date & time must be less than end date & time!')
         .required('Please enter a start date'),
     endDateTime: Yup.date()
         .min(Yup.ref('startDateTime'), 'End date & time must be greater than start date & time!')
         .required(),
-    topic: Yup.string().max(100, 'Topic must be less than 100 characters').required('Please enter a topic'),
+    topic: Yup.string()
+        .max(EVENT_TOPIC_MAX_LENGTH, `Topic must be ${EVENT_TOPIC_MAX_LENGTH} characters or less`)
+        .required('Please enter a topic'),
 });
 
 const initialState: TEventForm = {
@@ -65,6 +72,16 @@ export function EventForm({ onCancel, onSubmit, title, className, form, formType
                     value={state.title}
                     onChange={handleChange('title')}
                 />
+                <Typography
+                    variant='caption'
+                    color={state.title.length > EVENT_TITLE_MAX_LENGTH ? 'red' : 'black'}
+                    sx={{
+                        display: 'block',
+                        textAlign: 'right',
+                    }}
+                >
+                    {state.title.length}/{EVENT_TITLE_MAX_LENGTH}
+                </Typography>
                 <TextField
                     error={Boolean(errors.topic)}
                     helperText={errors.topic}
@@ -74,6 +91,16 @@ export function EventForm({ onCancel, onSubmit, title, className, form, formType
                     value={state.topic}
                     onChange={handleChange('topic')}
                 />
+                <Typography
+                    variant='caption'
+                    color={state.topic.length > EVENT_TOPIC_MAX_LENGTH ? 'red' : 'black'}
+                    sx={{
+                        display: 'block',
+                        textAlign: 'right',
+                    }}
+                >
+                    {state.topic.length}/{EVENT_TOPIC_MAX_LENGTH}
+                </Typography>
                 <TextField
                     error={Boolean(errors.description)}
                     helperText={errors.description}
@@ -82,6 +109,16 @@ export function EventForm({ onCancel, onSubmit, title, className, form, formType
                     value={state.description}
                     onChange={handleChange('description')}
                 />
+                <Typography
+                    variant='caption'
+                    color={state.description.length > EVENT_DESCRIPTION_MAX_LENGTH ? 'red' : 'black'}
+                    sx={{
+                        display: 'block',
+                        textAlign: 'right',
+                    }}
+                >
+                    {state.description.length}/{EVENT_DESCRIPTION_MAX_LENGTH}
+                </Typography>
                 <MobileDateTimePicker
                     value={state.startDateTime}
                     onChange={(value) =>

--- a/app/client/src/utils/rules.ts
+++ b/app/client/src/utils/rules.ts
@@ -6,3 +6,6 @@ export const BROADCAST_MESSAGE_MAX_LENGTH = 500;
 export const CHOICE_MAX_LENGTH = 250;
 export const CHOICES_MAX_AMOUNT = 20;
 export const STARTING_CHOICE_AMOUNT = 4;
+export const EVENT_TOPIC_MAX_LENGTH = 100;
+export const EVENT_TITLE_MAX_LENGTH = 100;
+export const EVENT_DESCRIPTION_MAX_LENGTH = 500;

--- a/app/server/prisma/migrations/20240430205342_event_topic_increased_char_limit/migration.sql
+++ b/app/server/prisma/migrations/20240430205342_event_topic_increased_char_limit/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Event" ALTER COLUMN "topic" SET DATA TYPE VARCHAR(100);

--- a/app/server/prisma/schema.prisma
+++ b/app/server/prisma/schema.prisma
@@ -84,7 +84,7 @@ model Event {
     startDateTime DateTime
     endDateTime DateTime
     description String @db.VarChar(500)
-    topic String @db.VarChar(50)
+    topic String @db.VarChar(100)
     currentQuestion String @db.VarChar(14) @default("-1")
     // settings defaults are built into the business logic layer rather than the db layer
     isActive Boolean


### PR DESCRIPTION
- The DB limit for even topics was set to 50 but the yup validation was accepting up to 100. Updated so now topics can be 100 chars as well as giving a better indication of the limits visually.