### PR TITLE
Prytaneum Dashboard Hotfix 1

### DIFF
--- a/app/client/src/features/dashboard/DashboardEvents.tsx
+++ b/app/client/src/features/dashboard/DashboardEvents.tsx
@@ -80,6 +80,11 @@ export function DashboardEvents({ dashboardEvents }: DashboardEventsProps) {
                             Current Events
                         </Typography>
                         <List>
+                            {ongoingEvents.length === 0 && (
+                                <Grid container justifyContent='center'>
+                                    <Typography variant='subtitle2'>No Ongoing Events To Display</Typography>
+                                </Grid>
+                            )}
                             {ongoingEvents.map((event, idx) => (
                                 <DashboardEventListItem
                                     key={event.id}
@@ -116,6 +121,11 @@ export function DashboardEvents({ dashboardEvents }: DashboardEventsProps) {
                             Upcoming Events
                         </Typography>
                         <List>
+                            {upcomingEvents.length === 0 && (
+                                <Grid container justifyContent='center'>
+                                    <Typography variant='subtitle2'>No Upcoming Events To Display</Typography>
+                                </Grid>
+                            )}
                             {upcomingEvents.map((event, idx) => (
                                 <DashboardEventListItem
                                     key={event.id}


### PR DESCRIPTION
- Added back text to display when an event list is empty in the dashboard.