### PR TITLE
Question Card Min Height Fix

### DIFF
--- a/app/client/src/features/events/Questions/QuestionList/QuestionList.tsx
+++ b/app/client/src/features/events/Questions/QuestionList/QuestionList.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/indent */
 import * as React from 'react';
 import { Grid, Card, Typography, IconButton, Paper, Stack } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
@@ -76,7 +75,7 @@ export function QuestionList({
 
     const cache = new CellMeasurerCache({
         defaultHeight: 185,
-        minHeight: 185,
+        minHeight: 148,
         fixedWidth: true,
     });
 

--- a/app/client/src/features/events/Questions/ViewerOnlyQuestionList/ViewerOnlyQuestionList.tsx
+++ b/app/client/src/features/events/Questions/ViewerOnlyQuestionList/ViewerOnlyQuestionList.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/indent */
 import * as React from 'react';
 import { Grid, Card, Typography, Stack, Paper, IconButton } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
@@ -69,7 +68,7 @@ export function ViewerOnlyQuestionList({ fragmentRef, isVisible }: ViewerOnlyQue
 
     const cache = new CellMeasurerCache({
         defaultHeight: 185,
-        minHeight: 185,
+        minHeight: 148,
         fixedWidth: true,
     });
 


### PR DESCRIPTION
- For not logged in users the card min height was too big causing larger gaps. By lowering the height the list should look consistent for both authenticated and non authenticated users (on events that allow them to join).