### PR TITLE
Registration Fixes

### DIFF
--- a/app/client/src/pages/register.tsx
+++ b/app/client/src/pages/register.tsx
@@ -50,7 +50,7 @@ export default function RegisterPage() {
                     }}
                 >
                     <RegisterForm
-                        onSuccess={() => router.push('/dashboard')}
+                        onSuccess={() => router.reload()}
                         secondaryActions={
                             <Link
                                 href='/login'

--- a/app/e2e/common/pages/playwright-register-page.ts
+++ b/app/e2e/common/pages/playwright-register-page.ts
@@ -34,7 +34,7 @@ export class PlaywrightRegisterPage {
         this.confirmPasswordInput = page.getByLabel('Confirm Password *');
         this.loginLink = page.getByRole('link', { name: 'Already have an account?' });
         // Snacks
-        this.failedSnackMismatcedPasswords = page.getByText('Passwords must match.');
+        this.failedSnackMismatcedPasswords = page.getByText('Passwords must match');
         this.failedSnackPasswordSpecialCharacter = page.getByText('Must contain at least one special character');
         this.failedSnackPasswordMissingNumber = page.getByText('Must contain at least one number');
         this.failedSnackPasswordUpperCase = page.getByText('Must contain at least one uppercase character');

--- a/app/e2e/common/pages/playwright-register-page.ts
+++ b/app/e2e/common/pages/playwright-register-page.ts
@@ -35,19 +35,11 @@ export class PlaywrightRegisterPage {
         this.loginLink = page.getByRole('link', { name: 'Already have an account?' });
         // Snacks
         this.failedSnackMismatcedPasswords = page.getByText('Passwords must match.');
-        this.failedSnackPasswordSpecialCharacter = page.getByText(
-            'Password missing required complexity: special character.'
-        );
-        this.failedSnackPasswordMissingNumber = page.getByText(
-            'Password missing required complexity: number character.'
-        );
-        this.failedSnackPasswordUpperCase = page.getByText(
-            'Password missing required complexity: upper case character.'
-        );
-        this.failedSnackPasswordLowerCase = page.getByText(
-            'Password missing required complexity: lower case character.'
-        );
-        this.failedSnackPasswordLength = page.getByText('New passwords must be at least 8 characters.');
+        this.failedSnackPasswordSpecialCharacter = page.getByText('Must contain at least one special character');
+        this.failedSnackPasswordMissingNumber = page.getByText('Must contain at least one number');
+        this.failedSnackPasswordUpperCase = page.getByText('Must contain at least one uppercase character');
+        this.failedSnackPasswordLowerCase = page.getByText('Must contain at least one lowercase character');
+        this.failedSnackPasswordLength = page.getByText('Password too short');
         this.failedSnackInternalError = page.getByText(
             'A link to activate your account has been emailed to the address provided.'
         );

--- a/app/e2e/tests/account/register.spec.ts
+++ b/app/e2e/tests/account/register.spec.ts
@@ -28,7 +28,6 @@ test.describe('register page', () => {
         await register.fillInEmail('johnDoe@test.com');
         await register.fillInPassword('Password1!');
         await register.fillInConfirmPassword('Password2!');
-        await register.submitRegisterForm();
         // assert
         await register.see(register.failedSnackMismatcedPasswords);
     });
@@ -42,7 +41,6 @@ test.describe('register page', () => {
         await register.fillInEmail('johnDoe@test.com');
         await register.fillInPassword('Password1');
         await register.fillInConfirmPassword('Password1');
-        await register.submitRegisterForm();
         // assert
         await register.see(register.failedSnackPasswordSpecialCharacter);
     });
@@ -56,7 +54,6 @@ test.describe('register page', () => {
         await register.fillInEmail('johnDoe@test.com');
         await register.fillInPassword('Password!');
         await register.fillInConfirmPassword('Password!');
-        await register.submitRegisterForm();
         // assert
         await register.see(register.failedSnackPasswordMissingNumber);
     });
@@ -70,7 +67,6 @@ test.describe('register page', () => {
         await register.fillInEmail('johnDoe@test.com');
         await register.fillInPassword('password1!');
         await register.fillInConfirmPassword('password1!');
-        await register.submitRegisterForm();
         // assert
         await register.see(register.failedSnackPasswordUpperCase);
     });
@@ -84,7 +80,6 @@ test.describe('register page', () => {
         await register.fillInEmail('johnDoe@test.com');
         await register.fillInPassword('PASSWORD1!');
         await register.fillInConfirmPassword('PASSWORD1!');
-        await register.submitRegisterForm();
         // assert
         await register.see(register.failedSnackPasswordLowerCase);
     });
@@ -98,7 +93,6 @@ test.describe('register page', () => {
         await register.fillInEmail('johnDoe@test.com');
         await register.fillInPassword('Pass1!');
         await register.fillInConfirmPassword('Pass1!');
-        await register.submitRegisterForm();
         // assert
         await register.see(register.failedSnackPasswordLength);
     });

--- a/app/server/src/features/accounts/methods.ts
+++ b/app/server/src/features/accounts/methods.ts
@@ -131,12 +131,18 @@ export async function register(prisma: PrismaClient, userData: MinimalUser, text
     // This could technically be an attack vector. Say a user creates an account and is trying to see
     // if a particular email is already registered. We should throw the same type of protected error
     // that is used on the account creation page.
-    if (!!user)
+    if (!!user) {
+        sendEmail({
+            to: user.email,
+            subject: 'Email Registration Attempt',
+            template: 'register-attempt',
+        });
         throw new ProtectedError({
             userMessage: ProtectedError.accountCreationErrorMessage,
             // This is probably only useful for debugging purposes, but it's still fine to log this anyways.
             internalMessage: `A user with the email ${email} already exists.`,
         });
+    }
 
     // TODO remove once shadow user account setup prompt is implemented
     if (!textPassword)
@@ -300,12 +306,18 @@ export async function updateEmail(prisma: PrismaClient, input: UpdateEmailForm) 
     // This could technically be an attack vector. Say a user creates an account and is trying to see
     // if a particular email is already registered. We should throw the same type of protected error
     // that is used on the account creation page.
-    if (!!user)
+    if (!!user) {
+        sendEmail({
+            to: user.email,
+            subject: 'Email Change Attempt',
+            template: 'register-attempt',
+        });
         throw new ProtectedError({
             userMessage: ProtectedError.accountCreationErrorMessage,
             // This is probably only useful for debugging purposes, but it's still fine to log this anyways.
             internalMessage: `A user with the email ${newEmail} already exists.`,
         });
+    }
 
     // update user email
     const updatedUser = await prisma.user.update({

--- a/app/server/src/lib/email/email.ts
+++ b/app/server/src/lib/email/email.ts
@@ -1,6 +1,6 @@
 import mg from './client';
 
-export type EmailTemplates = 'prytaneum-invite' | 'password-reset' | 'prytaneum-invites';
+export type EmailTemplates = 'prytaneum-invite' | 'password-reset' | 'prytaneum-invites' | 'register-attempt';
 
 export interface EmailConfig {
     to: string | Array<string>;
@@ -21,6 +21,7 @@ export interface EmailConfig {
  * @returns {Promise<string>}
  */
 export async function sendEmail(config: EmailConfig) {
+    // TODO: Generate unsubscribe url and attach to all emails
     if (!process.env.MAILGUN_DOMAIN) throw new Error('MAILGUN_DOMAIN not configured');
 
     if (process.env.NODE_ENV === 'test') {


### PR DESCRIPTION
- Better validation and error messages using yup on the registration form.
- Now an email should be sent out letting users know there was a registration attempt (same with trying to update the email to an existing one.) This makes the generic error message that is received be true and not confusing.