### PR TITLE
Moderation algo deployment fix dockerfile

### DIFF
--- a/app/moderation-algo/Dockerfile
+++ b/app/moderation-algo/Dockerfile
@@ -23,4 +23,4 @@ USER appuser
 EXPOSE 5000
 
 # During debugging, this entry point will be overridden. For more information, please refer to https://aka.ms/vscode-docker-python-debug
-CMD ["python", "/app/main.py"]
+CMD ls -l && python /app/main.py

--- a/app/moderation-algo/Dockerfile
+++ b/app/moderation-algo/Dockerfile
@@ -20,8 +20,7 @@ COPY . /app
 RUN adduser -u 5678 --disabled-password --gecos "" appuser && chown -R appuser /app
 USER appuser
 
-# TODO: Change this to the right port
 EXPOSE 5000
 
 # During debugging, this entry point will be overridden. For more information, please refer to https://aka.ms/vscode-docker-python-debug
-CMD ["python", "main.py"]
+CMD ["python", "/app/main.py"]


### PR DESCRIPTION
- Dockerfile was working locally and in docker-compose, but it failed to find the path when deployed to gke. Trying this suggested [fix](https://stackoverflow.com/questions/57556865/cant-open-file-app-py-errno-2-no-such-file-or-directory)