### PR TITLE
Moderation algo deployment fix docker build context

### DIFF
--- a/.github/workflows/moderation-algo-build.yml
+++ b/.github/workflows/moderation-algo-build.yml
@@ -24,7 +24,6 @@ jobs:
               run: |-
                   docker build \
                     -f ./app/moderation-algo/Dockerfile \
-                    --build-arg REQUIREMENTS_FILE="./app/moderation-algo/requirements.txt" \
                     --build-arg GITHUB_SHA="$GITHUB_SHA" \
                     --build-arg GITHUB_REF="$GITHUB_REF" \
                     ./app/moderation-algo

--- a/.github/workflows/moderation-algo-build.yml
+++ b/.github/workflows/moderation-algo-build.yml
@@ -1,4 +1,4 @@
-name: Moderation Algorithm build, lint, and test
+name: Moderation Algorithm build
 on:
     pull_request:
         branches:
@@ -27,4 +27,4 @@ jobs:
                     --build-arg REQUIREMENTS_FILE="./app/moderation-algo/requirements.txt" \
                     --build-arg GITHUB_SHA="$GITHUB_SHA" \
                     --build-arg GITHUB_REF="$GITHUB_REF" \
-                    .
+                    ./app/moderation-algo

--- a/.github/workflows/moderation-algo-deploy.yml
+++ b/.github/workflows/moderation-algo-deploy.yml
@@ -73,7 +73,6 @@ jobs:
                   docker build \
                     -f ./app/moderation-algo/Dockerfile \
                     --tag "gcr.io/$PROJECT_ID/$MODERATION_ALGO_IMAGE:$GITHUB_SHA" \
-                    --build-arg REQUIREMENTS_FILE="./app/moderation-algo/requirements.txt" \
                     --build-arg GITHUB_SHA="$GITHUB_SHA" \
                     --build-arg GITHUB_REF="$GITHUB_REF" \
                     ./app/moderation-algo

--- a/.github/workflows/moderation-algo-deploy.yml
+++ b/.github/workflows/moderation-algo-deploy.yml
@@ -76,7 +76,7 @@ jobs:
                     --build-arg REQUIREMENTS_FILE="./app/moderation-algo/requirements.txt" \
                     --build-arg GITHUB_SHA="$GITHUB_SHA" \
                     --build-arg GITHUB_REF="$GITHUB_REF" \
-                    .
+                    ./app/moderation-algo
 
             # Push the Moderation algo image to Google Container Registry
             - name: Publish Moderation Algorithm

--- a/app/moderation-algo/Dockerfile
+++ b/app/moderation-algo/Dockerfile
@@ -8,8 +8,6 @@ ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
 
 # Install pip requirements
-ARG REQUIREMENTS_FILE=requirements.txt
-COPY ${REQUIREMENTS_FILE} .
 RUN python -m pip install -r requirements.txt
 
 WORKDIR /app

--- a/app/moderation-algo/Dockerfile
+++ b/app/moderation-algo/Dockerfile
@@ -8,6 +8,7 @@ ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
 
 # Install pip requirements
+COPY requirements.txt .
 RUN python -m pip install -r requirements.txt
 
 WORKDIR /app

--- a/app/moderation-algo/Dockerfile
+++ b/app/moderation-algo/Dockerfile
@@ -23,4 +23,4 @@ USER appuser
 EXPOSE 5000
 
 # During debugging, this entry point will be overridden. For more information, please refer to https://aka.ms/vscode-docker-python-debug
-CMD ls -l && python /app/main.py
+CMD ls -l && python main.py


### PR DESCRIPTION
- The context was relative to the root when building causing the python file to not be found. Now the copy should be relative to the path, fixing the issue with execution in deployment.