### PR TITLE
fix(k8s): updated service type from cluster ip to headless

### DIFF
--- a/k8s/moderation-algo/development/moderation-algo-service.yml
+++ b/k8s/moderation-algo/development/moderation-algo-service.yml
@@ -11,11 +11,10 @@ metadata:
     name: moderation-algo-service
     namespace: development
 spec:
+    clusterIP: None
     ports:
         - port: 5000
           protocol: TCP
           targetPort: 5000
     selector:
         app: moderation-algo
-    sessionAffinity: 'ClientIP'
-    type: ClusterIP

--- a/k8s/moderation-algo/production/moderation-algo-service.yml
+++ b/k8s/moderation-algo/production/moderation-algo-service.yml
@@ -11,11 +11,10 @@ metadata:
     name: moderation-algo-service
     namespace: development
 spec:
+    clusterIP: None
     ports:
         - port: 5000
           protocol: TCP
           targetPort: 5000
     selector:
         app: moderation-algo
-    sessionAffinity: 'ClientIP'
-    type: ClusterIP


### PR DESCRIPTION
- Since we aren't doing an ingress with the mod-algorithm and just using it internally, should be able to run as headless service so the current url should work.