### PR TITLE
chore(mod-algo service): updated to a static cluster ip

### DIFF
--- a/k8s/moderation-algo/development/moderation-algo-service.yml
+++ b/k8s/moderation-algo/development/moderation-algo-service.yml
@@ -11,6 +11,7 @@ metadata:
     name: moderation-algo-service
     namespace: development
 spec:
+    ClusterIP: 10.112.10.193
     ports:
         - port: 5000
           protocol: TCP

--- a/k8s/moderation-algo/production/moderation-algo-service.yml
+++ b/k8s/moderation-algo/production/moderation-algo-service.yml
@@ -11,6 +11,7 @@ metadata:
     name: moderation-algo-service
     namespace: development
 spec:
+    ClusterIP: 10.112.10.190
     ports:
         - port: 5000
           protocol: TCP

--- a/k8s/server/development/prytaneum-server-configmap.yml
+++ b/k8s/server/development/prytaneum-server-configmap.yml
@@ -14,4 +14,4 @@ data:
     REDIS_HOST: staging-redis-cluster.development.svc.cluster.local
     REDIS_PORT: '6379'
     GCLOUD_ISSUE_GUIDES_STORAGE_BUCKET: prytaneum-issue-guides
-    MODERATION_URL: http://moderation-algo.svc.cluster.local:5000
+    MODERATION_URL: http://10.112.10.193:5000

--- a/k8s/server/production/prytaneum-server-configmap.yml
+++ b/k8s/server/production/prytaneum-server-configmap.yml
@@ -14,4 +14,4 @@ data:
     REDIS_HOST: prod-redis-cluster.production.svc.cluster.local
     REDIS_PORT: '6379'
     GCLOUD_ISSUE_GUIDES_STORAGE_BUCKET: prytaneum-issue-guides
-    MODERATION_URL: http://moderation-algo.svc.cluster.local:5000
+    MODERATION_URL: http://10.112.10.190:5000


### PR DESCRIPTION
- Giving the moderation-algo a static cluster IP to allow internal connections to that service without needing to expose it to LB. (checked already and there should be no overlap with any existing cluster IPs using these 2).
- Updated the moderation url on the server to use the clusterIp. 