### PR TITLE
Moderation algo fixes 2

### DIFF
--- a/app/server/src/features/events/topics/methods.ts
+++ b/app/server/src/features/events/topics/methods.ts
@@ -184,9 +184,16 @@ export async function finalizeTopics(
     topics: { topic: string; description: string }[],
     prisma: PrismaClient
 ) {
+    // Remove all existing topics
+    await prisma.eventTopic.deleteMany({ where: { eventId } });
+
     const result = await prisma.eventTopic.createMany({
         data: topics.map((topic) => ({ eventId, topic: topic.topic, description: topic.description })),
         skipDuplicates: true,
     });
     console.log('Result: ', result);
+}
+
+export async function deleteAllTopics(eventId: string, prisma: PrismaClient) {
+    await prisma.eventTopic.deleteMany({ where: { eventId } });
 }

--- a/app/server/src/features/events/topics/resolvers.ts
+++ b/app/server/src/features/events/topics/resolvers.ts
@@ -38,7 +38,7 @@ export const resolvers: Resolvers = {
             return runMutation(async () => {
                 const { eventId, oldTopic, newTopic, description } = args;
                 const { id: globalEventId } = fromGlobalId(eventId);
-                await Topics.updateTopic({ eventId, oldTopic, newTopic, description });
+                await Topics.updateTopic({ eventId: globalEventId, oldTopic, newTopic, description });
                 return { topic: newTopic, description };
             });
         },


### PR DESCRIPTION
- updates might have not been working since the global Id wasn't being passed. (Still not sure about the regeneration for now).
- Instead of adding more topics if generation is run, removing all previous ones before adding the new ones.