### PR TITLE
E2E Workflow Triggers Update

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -2,13 +2,19 @@
 name: Prytaneum Test end-to-end
 
 on:
-    pull_request:
+    push:
         branches:
             - staging
         paths:
             - 'app/client/**'
             - 'app/server/**'
             - 'app/e2e/**'
+    pull_request:
+        branches:
+            - staging
+        paths:
+            - 'app/e2e/**'
+    workflow_dispatch:
 
 jobs:
     e2e:


### PR DESCRIPTION
Should now only run when:
- a pull request is merged
- a pull request is opened with changes to e2e tests workspace
- manually ran via a dispatch