### PR TITLE
Ask question translation optimistic response fix

### DIFF
--- a/app/client/src/features/events/Questions/AskQuestion/AskQuestion.tsx
+++ b/app/client/src/features/events/Questions/AskQuestion/AskQuestion.tsx
@@ -155,7 +155,7 @@ function AskQuestion({ className, eventId, viewerOnly = false }: AskQuestionProp
                     // Set the values for the new question (doesn't display values otherwise even though they are in the optimistic response for some reason)
                     newQuestionRecord.setValue(form.question, 'question');
                     newQuestionRecord.setValue(user?.preferredLang || 'EN', 'lang');
-                    newQuestionRecord.setValue('', 'questionTranslated');
+                    newQuestionRecord.setValue(form.question, 'questionTranslated');
                     newQuestionRecord.setValue(new Date().toISOString(), 'createdAt');
                     newQuestionRecord.setLinkedRecord(userRecord, 'createdBy');
 
@@ -183,7 +183,7 @@ function AskQuestion({ className, eventId, viewerOnly = false }: AskQuestionProp
                                 createdAt: null,
                                 question: form.question,
                                 lang: user?.preferredLang || 'EN',
-                                questionTranslated: '',
+                                questionTranslated: form.question,
                                 createdBy: {
                                     id: user?.id || '',
                                     firstName: user?.firstName || '',

--- a/app/client/src/features/events/Questions/QuestionContent.tsx
+++ b/app/client/src/features/events/Questions/QuestionContent.tsx
@@ -5,6 +5,7 @@ import {
     CardContentProps,
     IconButton,
     Paper,
+    Skeleton,
     Stack,
     Tooltip,
     Typography,
@@ -70,7 +71,7 @@ export function QuestionContent({ fragmentRef, typographyProps = {}, measure, ..
     return (
         <CardContent {...props} sx={{ margin: (theme) => theme.spacing(-2, 0, -1, 0) }}>
             <Typography variant='inherit' style={{ wordBreak: 'break-word' }} {...typographyProps}>
-                {questionContentData.questionTranslated}
+                {questionContentData.questionTranslated || questionContentData.question || <Skeleton />}
             </Typography>
             {translationButton()}
             {showOriginalLanguage ? (


### PR DESCRIPTION
- question was blank since it was displaying the translation first. Added a fallback so it should display the untranslated question or a skeleton if neither are available. 