### PR TITLE
Topic setup fixes

### DIFF
--- a/app/client/src/features/events/EventTopics/AddTopic.tsx
+++ b/app/client/src/features/events/EventTopics/AddTopic.tsx
@@ -9,19 +9,17 @@ import { useAddTopic } from './hooks/useAddTopic';
 import type { Topic } from './types';
 import { EVENT_TOPIC_DESCRIPTION_MAX_LENGTH, EVENT_TOPIC_TOPIC_MAX_LENGTH } from '@local/utils/rules';
 
-interface Props {
-    setTopics: React.Dispatch<React.SetStateAction<Topic[]>>;
-}
+interface Props {}
 
 /**
  * AddTopic
  * @returns JSX.Element
  * @description Add a new topic to the event.
  */
-export function AddTopic({ setTopics }: Props) {
-    const { isReadingMaterialsUploaded } = React.useContext(TopicContext);
+export function AddTopic({}: Props) {
+    const { isReadingMaterialsUploaded, setTopics } = React.useContext(TopicContext);
     const { displaySnack } = useSnack();
-    const [newTopic, setNewTopic] = React.useState<Topic>({ topic: '', description: '' });
+    const [newTopic, setNewTopic] = React.useState<Topic>({ topic: '', description: '', locked: true });
     const [isOpen, openDialog, closeDialog] = useResponsiveDialog();
     const { addTopic } = useAddTopic();
 
@@ -35,6 +33,8 @@ export function AddTopic({ setTopics }: Props) {
             return;
         }
         const onSuccess = () => {
+            // All created topics are locked by default
+            newTopic.locked = true;
             setTopics((prev) => [...prev, newTopic]);
             closeDialog();
         };
@@ -73,6 +73,7 @@ export function AddTopic({ setTopics }: Props) {
                                 setNewTopic((prev) => ({
                                     topic: e.target.value,
                                     description: prev.description,
+                                    locked: prev.locked,
                                 }));
                             }}
                         />

--- a/app/client/src/features/events/EventTopics/DeleteTopic.tsx
+++ b/app/client/src/features/events/EventTopics/DeleteTopic.tsx
@@ -35,13 +35,9 @@ export function DeleteTopic({ topic }: Props) {
         else onSuccess();
     };
 
-    const handleCloseDeleteDialog = () => {
-        closeDialog();
-    };
-
     return (
         <React.Fragment>
-            <Dialog open={isOpen} onClose={handleCloseDeleteDialog} maxWidth='sm' fullWidth>
+            <Dialog open={isOpen} onClose={closeDialog} maxWidth='sm' fullWidth>
                 <DialogTitle>Delete Topic</DialogTitle>
                 <DialogContent>
                     <Typography variant='body1'>
@@ -51,7 +47,7 @@ export function DeleteTopic({ topic }: Props) {
                 <DialogActions>
                     <Stack direction='row' spacing={2}>
                         <Stack direction='row' spacing={2}>
-                            <Button onClick={handleCloseDeleteDialog} color='inherit'>
+                            <Button onClick={closeDialog} color='inherit'>
                                 Cancel
                             </Button>
                             <Button onClick={handleDeleteTopic} variant='contained' color='error'>

--- a/app/client/src/features/events/EventTopics/EditTopic.tsx
+++ b/app/client/src/features/events/EventTopics/EditTopic.tsx
@@ -29,6 +29,11 @@ export function EditTopic({ topic: oldTopic }: Props) {
     const [topic, setTopic] = React.useState<Topic>(oldTopic);
     const { updateTopic } = useUpdateTopic();
 
+    const handleOpenEditDialog = () => {
+        setTopic(oldTopic);
+        openEditDialog();
+    };
+
     const handleCloseEditDialog = () => {
         closeEditDialog();
     };
@@ -42,6 +47,7 @@ export function EditTopic({ topic: oldTopic }: Props) {
                 if (index === -1) return prev;
                 const newTopics = [...prev];
                 newTopics[index] = newTopic;
+                newTopics[index].locked = oldTopic.locked;
                 return newTopics;
             });
             closeEditDialog();
@@ -129,7 +135,7 @@ export function EditTopic({ topic: oldTopic }: Props) {
                 </DialogActions>
             </Dialog>
             <Tooltip title='Edit Topic'>
-                <IconButton onClick={openEditDialog}>
+                <IconButton onClick={handleOpenEditDialog}>
                     <EditIcon />
                 </IconButton>
             </Tooltip>

--- a/app/client/src/features/events/EventTopics/EditTopics.tsx
+++ b/app/client/src/features/events/EventTopics/EditTopics.tsx
@@ -1,19 +1,26 @@
 import React from 'react';
 import { Stack, Typography } from '@mui/material';
 
-import { Topic } from './types';
 import { AddTopic } from './AddTopic';
 import { RegenerateTopics } from './RegenerateTopics';
 import { TopicCard } from './TopicCard';
 import { TopicContext } from './EventTopicSettings';
 
-interface Props {
-    topics: Topic[];
-    setTopics: React.Dispatch<React.SetStateAction<Topic[]>>;
-}
+interface Props {}
 
-export function EditTopics({ topics, setTopics }: Props) {
-    const { isReadingMaterialsUploaded } = React.useContext(TopicContext);
+export function EditTopics({}: Props) {
+    const { isReadingMaterialsUploaded, topics } = React.useContext(TopicContext);
+
+    const topicList = React.useMemo(() => topics, [topics]);
+
+    const memoizedTopicCards = React.useMemo(() => {
+        return topicList.map((topic, index) => (
+            <React.Fragment key={index}>
+                <TopicCard topic={topic} />
+            </React.Fragment>
+        ));
+    }, [topicList]);
+
     return (
         <React.Fragment>
             <Stack direction='column' width='100%' alignItems='center'>
@@ -21,13 +28,9 @@ export function EditTopics({ topics, setTopics }: Props) {
                 <Typography variant='caption' marginBottom={topics.length === 0 ? '1rem' : 0}>
                     {'(locking ensures the topic remains after re-generating)'}
                 </Typography>
-                {topics.map((topic, index) => (
-                    <React.Fragment key={index}>
-                        <TopicCard topic={topic} />
-                    </React.Fragment>
-                ))}
+                {memoizedTopicCards}
                 <Stack direction='row' spacing={2} justifyContent='center'>
-                    <AddTopic setTopics={setTopics} />
+                    <AddTopic />
                     {isReadingMaterialsUploaded && <RegenerateTopics />}
                 </Stack>
             </Stack>

--- a/app/client/src/features/events/EventTopics/EventTopicSettings.tsx
+++ b/app/client/src/features/events/EventTopics/EventTopicSettings.tsx
@@ -16,6 +16,7 @@ import { FinalizeTopics } from './FinalizeTopics';
 import { useResponsiveDialog } from '@local/components';
 import { useFinalizeTopics } from './hooks/useFinalizeTopics';
 import { PreloadedTopicList } from './TopicList';
+import { useSnack } from '@local/core';
 
 type TTopicContext = {
     topics: Topic[];
@@ -35,6 +36,7 @@ interface Props {}
 
 export function EventTopicSettings({}: Props) {
     const router = useRouter();
+    const { displaySnack } = useSnack();
     const [activeStep, setActiveStep] = React.useState(0);
     const [isReadingMaterialsUploaded, setIsReadingMaterialsUploaded] = React.useState(false);
     const [topics, setTopics] = React.useState<Topic[]>([]);
@@ -53,6 +55,7 @@ export function EventTopicSettings({}: Props) {
         if (activeStep === steps.length - 1) {
             const onSuccess = () => {
                 close();
+                displaySnack('Topics have been successfully generated.', { variant: 'success' });
                 router.reload();
             };
             finalizeTopics(topics, onSuccess);
@@ -126,7 +129,7 @@ export function EventTopicSettings({}: Props) {
                 )}
                 {activeStep === 1 && (
                     <Grid container justifyContent='center' padding='2rem'>
-                        <EditTopics topics={topics} setTopics={setTopics} />
+                        <EditTopics />
                     </Grid>
                 )}
                 {activeStep === 2 && (

--- a/app/client/src/features/events/EventTopics/FinalizeTopics.tsx
+++ b/app/client/src/features/events/EventTopics/FinalizeTopics.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Typography, Grid, Stack, Chip } from '@mui/material';
+import { Typography, Grid, Stack, Chip, Tooltip } from '@mui/material';
 
 import { getHashedColor } from '@local/core/getHashedColor';
 import { Topic } from './types';
@@ -9,19 +9,26 @@ interface Props {
 }
 
 export function FinalizeTopics({ topics }: Props) {
+    const finalizedTopics = React.useMemo(() => topics, [topics]);
+
+    const memoizedTopicChips = React.useMemo(() => {
+        return finalizedTopics.map((topic, index) => (
+            <Tooltip key={index} title={topic.description}>
+                <Chip
+                    label={topic.topic}
+                    sx={{ color: 'white', backgroundColor: getHashedColor(topic.topic), margin: '0.25rem' }}
+                />
+            </Tooltip>
+        ));
+    }, [finalizedTopics]);
+
     return (
         <Stack direction='column' spacing={2} alignItems='center'>
             <Grid item xs={12}>
-                <Typography variant='body1'>Are you sure you want to finalize the topics?</Typography>
+                <Typography variant='body1'>Are you sure you want to finalize these topics?</Typography>
             </Grid>
             <Grid container justifyContent='center'>
-                {topics.map((topic, index) => (
-                    <Chip
-                        key={index}
-                        label={topic.topic}
-                        sx={{ color: 'white', backgroundColor: getHashedColor(topic.topic), margin: '0.25rem' }}
-                    />
-                ))}
+                {memoizedTopicChips}
             </Grid>
         </Stack>
     );

--- a/app/client/src/features/events/EventTopics/RegenerateTopics.tsx
+++ b/app/client/src/features/events/EventTopics/RegenerateTopics.tsx
@@ -13,14 +13,19 @@ import { Topic } from './types';
  *  Excludes any locked topics.
  */
 export function RegenerateTopics() {
-    const { setTopics } = React.useContext(TopicContext);
+    const { topics, setTopics } = React.useContext(TopicContext);
     const { regenerateTopics } = useRegenerateTopics();
     const [isLoading, setIsLoading] = React.useState(false);
 
     const handleRegenerateTopics = () => {
         setIsLoading(true);
         const onSuccess = (newTopics: Topic[]) => {
-            setTopics(newTopics);
+            const filteredNewTopics = [...newTopics].filter((topic) => {
+                const isAlreadyLockedTopic = topics.some((_topic) => _topic.topic === topic.topic && _topic.locked);
+                return !isAlreadyLockedTopic;
+            });
+            const updatedTopicList = [...topics].filter((topic) => topic.locked).concat(filteredNewTopics);
+            setTopics(updatedTopicList);
             setIsLoading(false);
         };
         const onFailure = () => {

--- a/app/client/src/features/events/EventTopics/UploadReadingMaterials.tsx
+++ b/app/client/src/features/events/EventTopics/UploadReadingMaterials.tsx
@@ -84,6 +84,10 @@ export function UploadReadingMaterials({ onSuccess, setTopics }: Props) {
         return '';
     }, [readingMaterials]);
 
+    React.useEffect(() => {
+        return setReadingMaterials('');
+    }, []);
+
     // Add description for this step
     return (
         <React.Fragment>


### PR DESCRIPTION
- Improved most aspects of the topic setup process.
- Bug where locked topics disappear or change should be fixed now.
- Locked topics should always be at the top now after regenerating.
- Fixed memory leak warnings.
- Editing topics should now always work correctly and not show old topic data.