### PR TITLE
On Deck Enqueue Hotfix

### DIFF
--- a/app/client/src/features/events/ModeratorView/hooks/useDndLists.ts
+++ b/app/client/src/features/events/ModeratorView/hooks/useDndLists.ts
@@ -44,6 +44,7 @@ export function useDndLists({ node, topic, topics }: Props) {
         enqueuedQuestions,
         questionRecord,
         connections: onDeckConnections,
+        queueConnection,
         currentQuestionPosition,
     } = useOnDeck({ fragmentRef: node });
 
@@ -52,7 +53,7 @@ export function useDndLists({ node, topic, topics }: Props) {
     useTopicQueueRemove({ eventId, topic, connections: queueConnections });
 
     const { updateTopicQueuePosition } = useUpdateTopicQueuePosition({ eventId, topic });
-    const { addQuestionToOnDeck } = useOnDeckEnqueued({ connections: onDeckConnections, topics, topic });
+    const { addQuestionToOnDeck } = useOnDeckEnqueued({ connections: [queueConnection], topics, topic });
     const { removeFromOnDeck } = useOnDeckDequeued({ connections: onDeckConnections, topics, topic });
     const { updateOnDeckPosition } = useUpdateOnDeckPosition({ eventId });
 


### PR DESCRIPTION
- The question record was being updated on the enqueue mutation, but we only want the on deck queue to be updated. By passing only the queue connection this bug should be fixed.