### PR TITLE
fix(dnd lists): added debouncer to drag over to fix runtime error

### DIFF
--- a/app/client/src/features/events/ModeratorView/hooks/useDndLists.ts
+++ b/app/client/src/features/events/ModeratorView/hooks/useDndLists.ts
@@ -22,6 +22,7 @@ import { useOnDeckDequeued } from './OnDeck/useOnDeckDequeued';
 import { useUpdateOnDeckPosition } from './OnDeck/useUpdateOnDeckPosition';
 import { useUpdateTopicQueuePosition } from './TopicQueue/useUpdateTopicQueuePosition';
 import { Question, Topic } from '../types';
+import { useDebounce } from '@local/core/useDebounce';
 
 type ItemsType = {
     topicQueue: Question[];
@@ -300,12 +301,15 @@ export function useDndLists({ node, topic, topics }: Props) {
     });
     const sensors = useSensors(pointerSensor, mouseSensor, useSensor(KeyboardSensor));
 
+    // -- Debounce drag over -- Prevents the drag over event from firing too frequently causing a runtime error
+    const debouncedDragOver = useDebounce(handleDragOver, 250);
+
     return {
         items,
         activeId,
         handleDragStart,
         handleDragEnd,
-        handleDragOver,
+        handleDragOver: debouncedDragOver,
         heldQuestion,
         onDeckQuestions,
         topicQueueQuestions,


### PR DESCRIPTION
- Forgot to add the debouncer back in after earlier refactor, this adds it back in to fix the "Max depth reached" runtime error caused by too many updates to dnd dragOver callback. 