### PR TITLE
Participant Subscriptions Connection Fixed

### DIFF
--- a/app/client/src/features/dashboard/useDashboardEvents.ts
+++ b/app/client/src/features/dashboard/useDashboardEvents.ts
@@ -85,11 +85,13 @@ export function useDashboardEvents({ fragmentRef }: TArgs) {
         return eventList.map(({ node: event }) => event.id);
     }, [eventList]);
 
+    const connections = React.useMemo(() => (events?.__id ? [events.__id] : []), [events?.__id]);
+
     return {
         events: eventList,
         currentEvents,
         upcomingEvents,
         eventIds,
-        connections: events?.__id ? [events.__id] : [],
+        connections,
     };
 }

--- a/app/client/src/features/events/LiveFeedback/useLiveFeedbackList.tsx
+++ b/app/client/src/features/events/LiveFeedback/useLiveFeedbackList.tsx
@@ -85,7 +85,7 @@ export function useLiveFeedbackList({ fragmentRef }: Props) {
         [liveFeedback]
     );
 
-    const connections = React.useMemo(() => (liveFeedback?.__id ? [liveFeedback.__id] : []), [liveFeedback]);
+    const connections = React.useMemo(() => (liveFeedback?.__id ? [liveFeedback.__id] : []), [liveFeedback?.__id]);
 
     const config = React.useMemo<GraphQLSubscriptionConfig<useLiveFeedbackListSubscription>>(
         () => ({
@@ -108,6 +108,6 @@ export function useLiveFeedbackList({ fragmentRef }: Props) {
     return {
         liveFeedback: isModerator ? feedbackList : filteredList,
         eventId,
-        connections: liveFeedback?.__id ? [liveFeedback.__id] : [],
+        connections,
     };
 }

--- a/app/client/src/features/events/Questions/QuestionList/useQuestionList.tsx
+++ b/app/client/src/features/events/Questions/QuestionList/useQuestionList.tsx
@@ -56,10 +56,12 @@ export function useQuestionList({ fragmentRef }: TArgs) {
         [questions]
     );
 
+    const connections = React.useMemo(() => (questions?.__id ? [questions.__id] : []), [questions?.__id]);
+
     return {
         questions: questionList,
         eventId,
-        connections: questions?.__id ? [questions.__id] : [],
+        connections,
         currentQuestion,
         loadNext,
         loadPrevious,

--- a/app/client/src/features/events/Questions/ViewerOnlyQuestionList/useViewerOnlyQuestionList.ts
+++ b/app/client/src/features/events/Questions/ViewerOnlyQuestionList/useViewerOnlyQuestionList.ts
@@ -58,10 +58,12 @@ export function useViewerOnlyQuestionList({ fragmentRef }: UseViewrOnlyQuestionL
         [questions]
     );
 
+    const connections = React.useMemo(() => (questions?.__id ? [questions.__id] : []), [questions?.__id]);
+
     return {
         questions: questionList,
         eventId,
-        connections: questions?.__id ? [questions.__id] : [],
+        connections,
         currentQuestion,
         loadNext,
         loadPrevious,


### PR DESCRIPTION
- Connections for participant subscriptions were not memoized causing them to be re-created on re-renders. Once memoized, they should only ever be created once on initial load. This should prevent a bug where WS messages are missed while the connection is being re-created.
- Implemented the same fix on the mod view, but forgot to check the participant view + pre event view.