### PR TITLE
Prytaneum Email Case Sensitivity Fixed

### DIFF
--- a/app/server/src/features/accounts/account.ts
+++ b/app/server/src/features/accounts/account.ts
@@ -43,7 +43,7 @@ server.route({
         const { email, eventId } = JSON.parse(req.body as string) as ExpectedBody;
         const prisma = getPrismaClient(server.log);
         try {
-            const user = await prisma.user.findFirst({ where: { email } });
+            const user = await prisma.user.findFirst({ where: { email: email.toLowerCase() } });
             if (!user) throw new Error('User not found');
             const { id: globalEventId } = fromGlobalId(eventId);
             const event = await prisma.event.findUnique({ where: { id: globalEventId } });

--- a/app/server/src/features/events/invites/methods.ts
+++ b/app/server/src/features/events/invites/methods.ts
@@ -26,7 +26,7 @@ export async function invite(viewerId: string, prisma: PrismaClient, { email, ev
     if (!canUserModify(viewerId, globalEventId, prisma)) throw new ProtectedError({ userMessage: errors.permissions });
 
     // check if email already exists
-    let userResult = await prisma.user.findFirst({ where: { email } });
+    let userResult = await prisma.user.findFirst({ where: { email: email.toLowerCase() } });
 
     // create user if email is not in accounts system
     let invitedUser = userResult;
@@ -108,7 +108,7 @@ export async function validateInvite(
         // Ensure token is being used for the correct event
         if (eventId !== globalEventId) return { valid: false, user: null };
         // Get user if valid
-        const user = await prisma.user.findUnique({ where: { email: result.email } });
+        const user = await prisma.user.findUnique({ where: { email: result.email.toLowerCase() } });
         if (!user) throw new Error('User not found.');
         // Ensure user is invited to event
         const invitedResult = await prisma.eventInvited.findFirst({

--- a/app/server/src/features/events/moderation/methods.ts
+++ b/app/server/src/features/events/moderation/methods.ts
@@ -95,12 +95,12 @@ export async function createModerator(userId: string, prisma: PrismaClient, inpu
     if (!hasPermissions) throw new ProtectedError({ userMessage: errors.permissions });
 
     // check if email already exists
-    let userResult = await prisma.user.findFirst({ where: { email } });
+    let userResult = await prisma.user.findFirst({ where: { email: email.toLowerCase() } });
 
     // create user if email is not in accounts system
     let modUserId = userResult?.id;
     if (!modUserId) {
-        userResult = await register(prisma, { email: input.email });
+        userResult = await register(prisma, { email: input.email.toLowerCase() });
         modUserId = userResult.id;
     }
 
@@ -599,7 +599,7 @@ export async function removeQuestionFromQueue(userId: string, prisma: PrismaClie
 
 export async function findUserIdByEmail(email: string, prisma: PrismaClient) {
     return prisma.user.findUnique({
-        where: { email },
+        where: { email: email.toLowerCase() },
         select: { id: true },
     });
 }

--- a/app/server/src/features/events/speakers/methods.ts
+++ b/app/server/src/features/events/speakers/methods.ts
@@ -19,7 +19,10 @@ export async function createSpeaker(userId: string, prisma: PrismaClient, input:
     if (!hasPermissions) throw new ProtectedError({ userMessage: errors.permissions });
 
     // find user by email
-    const speakerAccount = await prisma.user.findUnique({ where: { email }, select: { id: true } });
+    const speakerAccount = await prisma.user.findUnique({
+        where: { email: email.toLowerCase() },
+        select: { id: true },
+    });
     let speakerId = speakerAccount?.id;
 
     // register the speaker with an account if they're not already in the database

--- a/app/server/src/features/organizations/methods.ts
+++ b/app/server/src/features/organizations/methods.ts
@@ -129,8 +129,8 @@ export async function createMember(userId: string, prisma: PrismaClient, input: 
     // then we'll have to check if the user exists
     // if they don't exist create a "shadow" account
     // if they do exist proceed as normal
-    let user = await prisma.user.findUnique({ where: { email: input.email } });
-    if (!user) user = await register(prisma, { email: input.email });
+    let user = await prisma.user.findUnique({ where: { email: input.email.toLowerCase() } });
+    if (!user) user = await register(prisma, { email: input.email.toLowerCase() });
 
     // check if user is already a member
     const isUserMember = await isMemberOfOrg(user.id, input.orgId, prisma);

--- a/app/server/src/lib/invite.ts
+++ b/app/server/src/lib/invite.ts
@@ -36,7 +36,7 @@ const generateInviteLink = async (
     const { email, first, last } = invitee;
     const { id: globalEventId } = fromGlobalId(eventId);
     let user: User;
-    const result = await prisma.user.findFirst({ where: { email: email } });
+    const result = await prisma.user.findFirst({ where: { email: email.toLowerCase() } });
     if (result === null) {
         const randomPassword =
             Math.random().toString(36).slice(-8) + 'zZ' + Math.floor(Math.random() * 10).toString() + '!';


### PR DESCRIPTION
- Although every email is unique regardless of case, currently we are storing the email based on what the user signed up with. This could cause confusion later if they try to log into their account using different cased characters. 
- To address this we are going to ensure the email is always transformed to lower case before a DB query, insert, or update.