### PR TITLE
fix(on deck enqueue/dequeue): fixed data passed to optimistic response

### DIFF
--- a/app/client/src/features/events/ModeratorView/hooks/OnDeck/useOnDeckDequeued.ts
+++ b/app/client/src/features/events/ModeratorView/hooks/OnDeck/useOnDeckDequeued.ts
@@ -202,17 +202,17 @@ export function useOnDeckDequeued({ connections, topic: currentTopic }: Props) {
                                 createdAt: question.createdAt,
                                 refQuestion: question.refQuestion
                                     ? {
-                                          id: question.id,
-                                          question: question.question,
-                                          lang: question.lang,
-                                          questionTranslated: question.question,
+                                          id: question.refQuestion.id,
+                                          question: question.refQuestion.question,
+                                          lang: question.refQuestion.lang,
+                                          questionTranslated: question.refQuestion.question,
                                           createdBy: {
-                                              id: question.createdBy?.id ?? '',
-                                              firstName: question.createdBy?.firstName ?? '',
-                                              lastName: question.createdBy?.lastName ?? '',
-                                              avatar: question.createdBy?.avatar ?? '',
+                                              id: question.refQuestion.createdBy?.id ?? '',
+                                              firstName: question.refQuestion.createdBy?.firstName ?? '',
+                                              lastName: question.refQuestion.createdBy?.lastName ?? '',
+                                              avatar: question.refQuestion.createdBy?.avatar ?? '',
                                           },
-                                          createdAt: question.createdAt,
+                                          createdAt: question.refQuestion.createdAt,
                                       }
                                     : null,
                                 likedByCount: question.likedByCount,

--- a/app/client/src/features/events/ModeratorView/hooks/OnDeck/useOnDeckEnqueued.ts
+++ b/app/client/src/features/events/ModeratorView/hooks/OnDeck/useOnDeckEnqueued.ts
@@ -138,17 +138,17 @@ export function useOnDeckEnqueued({ connections, topics }: Props) {
                                 createdAt: question.createdAt,
                                 refQuestion: question.refQuestion
                                     ? {
-                                          id: question.id,
-                                          question: question.question,
-                                          lang: question.lang,
-                                          questionTranslated: question.question,
+                                          id: question.refQuestion.id,
+                                          question: question.refQuestion.question,
+                                          lang: question.refQuestion.lang,
+                                          questionTranslated: question.refQuestion.question,
                                           createdBy: {
-                                              id: question.createdBy?.id ?? '',
-                                              firstName: question.createdBy?.firstName ?? '',
-                                              lastName: question.createdBy?.lastName ?? '',
-                                              avatar: question.createdBy?.avatar ?? '',
+                                              id: question.refQuestion.createdBy?.id ?? '',
+                                              firstName: question.refQuestion.createdBy?.firstName ?? '',
+                                              lastName: question.refQuestion.createdBy?.lastName ?? '',
+                                              avatar: question.refQuestion.createdBy?.avatar ?? '',
                                           },
-                                          createdAt: question.createdAt,
+                                          createdAt: question.refQuestion.createdAt,
                                       }
                                     : null,
                                 likedByCount: question.likedByCount,


### PR DESCRIPTION
- was passing the question data rather than the ref question data in the optimistic response causing the quoted question to appear wrong for a second before updating with the server response.