### PR TITLE
GKE Backend Config Session Affinity

### DIFF
--- a/k8s/server/development/prytaneum-backend-config.yml
+++ b/k8s/server/development/prytaneum-backend-config.yml
@@ -1,10 +1,11 @@
 apiVersion: cloud.google.com/v1beta1
 kind: BackendConfig
 metadata:
-  name: prytaneum-backendconfig
-  namespace: production
+    name: prytaneum-backendconfig
+    namespace: production
 spec:
-  timeoutSec: 1800
-  connectionDraining:
-    drainingTimeoutSec: 1800
-  
+    timeoutSec: 1800
+    connectionDraining:
+        drainingTimeoutSec: 1800
+    sessionAffinity:
+        affinityType: 'CLIENT_IP'

--- a/k8s/server/production/prytaneum-backend-config.yml
+++ b/k8s/server/production/prytaneum-backend-config.yml
@@ -1,10 +1,11 @@
 apiVersion: cloud.google.com/v1beta1
 kind: BackendConfig
 metadata:
-  name: prytaneum-backendconfig
-  namespace: production
+    name: prytaneum-backendconfig
+    namespace: production
 spec:
-  timeoutSec: 1800
-  connectionDraining:
-    drainingTimeoutSec: 1800
-  
+    timeoutSec: 1800
+    connectionDraining:
+        drainingTimeoutSec: 1800
+    sessionAffinity:
+        affinityType: 'CLIENT_IP'


### PR DESCRIPTION
The service has session affinity set, but there still seem to be issues with the connection updates (some of which can only be reproduced in production, leading me to believe it may be an issue with session affinity as it doesn't happen with just one pod).
- Adding session affinity to the backend config to see if it will produce the desired load balance effect and thus fix the issue.