### PR TITLE
Feedback prompt snack fixed

### DIFF
--- a/app/client/src/features/events/EventSidebar/EventSidebar.tsx
+++ b/app/client/src/features/events/EventSidebar/EventSidebar.tsx
@@ -61,7 +61,7 @@ export const EventSidebar = ({ fragmentRef }: EventSidebarProps) => {
     const eventId = data.id;
 
     // Subscribe to live feedback prompts
-    const { feedbackPromptRef, closeFeedbackPromptSnack } = useLiveFeedbackPrompt({ openFeedbackPromptResponse });
+    const { feedbackPromptRef } = useLiveFeedbackPrompt({ openFeedbackPromptResponse });
     const { feedbackPromptResultsRef, closeFeedbackPromptResultsSnack } = useLiveFeedbackPromptResultsShared({
         openFeedbackPromptResults,
     });
@@ -138,7 +138,6 @@ export const EventSidebar = ({ fragmentRef }: EventSidebarProps) => {
             <SubmitLiveFeedbackPromptResponse
                 eventId={eventId}
                 promptRef={feedbackPromptRef}
-                closeSnack={closeFeedbackPromptSnack}
                 isOpen={isFeedbackPromptResponseOpen}
                 open={openFeedbackPromptResponse}
                 close={closeFeedbackPromptResponse}

--- a/app/client/src/features/events/EventSidebar/EventSidebar.tsx
+++ b/app/client/src/features/events/EventSidebar/EventSidebar.tsx
@@ -62,7 +62,7 @@ export const EventSidebar = ({ fragmentRef }: EventSidebarProps) => {
 
     // Subscribe to live feedback prompts
     const { feedbackPromptRef } = useLiveFeedbackPrompt({ openFeedbackPromptResponse });
-    const { feedbackPromptResultsRef, closeFeedbackPromptResultsSnack } = useLiveFeedbackPromptResultsShared({
+    const { feedbackPromptResultsRef } = useLiveFeedbackPromptResultsShared({
         openFeedbackPromptResults,
     });
 
@@ -144,7 +144,6 @@ export const EventSidebar = ({ fragmentRef }: EventSidebarProps) => {
             />
             <ViewLiveFeedbackPromptResults
                 promptRef={feedbackPromptResultsRef}
-                closeSnack={closeFeedbackPromptResultsSnack}
                 open={isFeedbackPromptResultsOpen}
                 setOpen={openFeedbackPromptResults}
                 close={closeFeedbackPromptResults}

--- a/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackPromptResponse/SubmitLiveFeedbackPromptResponse.tsx
+++ b/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackPromptResponse/SubmitLiveFeedbackPromptResponse.tsx
@@ -14,7 +14,6 @@ import { isURL } from '@local/utils';
 interface Props {
     eventId: string;
     promptRef: MutableRefObject<Prompt>;
-    closeSnack: () => void;
     isOpen: boolean;
     open: () => void;
     close: () => void;
@@ -35,7 +34,7 @@ export const SUBMIT_LIVE_FEEDBACK_PROMPT_RESPONSE_MUTATION = graphql`
     }
 `;
 
-export function SubmitLiveFeedbackPromptResponse({ eventId, promptRef, closeSnack, isOpen, close }: Props) {
+export function SubmitLiveFeedbackPromptResponse({ eventId, promptRef, isOpen, close }: Props) {
     const { displaySnack } = useSnack();
     const [commit] = useMutation<SubmitLiveFeedbackPromptResponseMutation>(
         SUBMIT_LIVE_FEEDBACK_PROMPT_RESPONSE_MUTATION
@@ -53,7 +52,6 @@ export function SubmitLiveFeedbackPromptResponse({ eventId, promptRef, closeSnac
                             throw new Error(response.createFeedbackPromptResponse.message);
                         displaySnack('Response submitted', { variant: 'success' });
                         close();
-                        closeSnack();
                     } catch (err) {
                         if (err instanceof Error) displaySnack(err.message, { variant: 'error' });
                         else displaySnack('Something went wrong!');
@@ -68,16 +66,10 @@ export function SubmitLiveFeedbackPromptResponse({ eventId, promptRef, closeSnac
 
     return (
         <React.Fragment>
-            <ResponsiveDialog
-                open={isOpen}
-                onClose={() => {
-                    closeSnack();
-                }}
-            >
+            <ResponsiveDialog open={isOpen}>
                 <DialogContent>
                     <LiveFeedbackPromptResponseForm
                         onCancel={() => {
-                            closeSnack();
                             close();
                         }}
                         onSubmit={handleSubmit}

--- a/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackPromptResponse/useLiveFeedbackPromptResponseSnack.tsx
+++ b/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackPromptResponse/useLiveFeedbackPromptResponseSnack.tsx
@@ -5,40 +5,44 @@ import Close from '@mui/icons-material/Close';
 import QuestionAnswerIcon from '@mui/icons-material/QuestionAnswer';
 
 interface Props {
-    openFeedbackPromptResponse: () => void;
+    openPrompt: (promptId: string) => void;
 }
 
-export function useLiveFeedbackPromptResponseSnack({ openFeedbackPromptResponse }: Props) {
+export function useLiveFeedbackPromptResponseSnack({ openPrompt }: Props) {
     const { enqueueSnackbar, closeSnackbar } = useSnackbar();
 
-    const onClick = useCallback(() => {
-        openFeedbackPromptResponse();
-        closeSnackbar();
-    }, [closeSnackbar, openFeedbackPromptResponse]);
+    const onClick = useCallback(
+        (key: SnackbarKey, promptId: string) => {
+            openPrompt(promptId);
+            closeSnackbar(key);
+        },
+        [closeSnackbar, openPrompt]
+    );
 
     const feedbackPromptAction = useCallback(
-        (key: SnackbarKey) => (
+        (key: SnackbarKey, promptId: string) => (
             <div>
-                <Button variant='contained' color='primary' onClick={onClick} startIcon={<QuestionAnswerIcon />}>
+                <Button
+                    variant='contained'
+                    color='primary'
+                    onClick={() => onClick(key, promptId)}
+                    startIcon={<QuestionAnswerIcon />}
+                >
                     Respond
                 </Button>
-                <Button
-                    onClick={() => {
-                        closeSnackbar(key);
-                    }}
-                >
+                <Button onClick={() => closeSnackbar(key)}>
                     <Close />
                 </Button>
             </div>
         ),
-        [closeSnackbar, onClick]
+        [onClick, closeSnackbar]
     );
 
-    const makeSnack = useCallback(
-        (message: string, options?: OptionsObject) => {
+    const displaySnack = useCallback(
+        (promptId: string, message: string, options?: OptionsObject) => {
             enqueueSnackbar(message, {
                 variant: options?.variant || 'default',
-                action: options?.action || feedbackPromptAction,
+                action: (key) => options?.action || feedbackPromptAction(key, promptId),
                 onExited: options?.onExited,
                 color: 'inherit',
                 anchorOrigin: {
@@ -50,5 +54,5 @@ export function useLiveFeedbackPromptResponseSnack({ openFeedbackPromptResponse 
         },
         [enqueueSnackbar, feedbackPromptAction]
     );
-    return { displaySnack: makeSnack, closeSnack: closeSnackbar };
+    return { displaySnack };
 }

--- a/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackPromptResponse/useLiveFeedbackPromptResponseSnack.tsx
+++ b/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackPromptResponse/useLiveFeedbackPromptResponseSnack.tsx
@@ -6,9 +6,10 @@ import QuestionAnswerIcon from '@mui/icons-material/QuestionAnswer';
 
 interface Props {
     openPrompt: (promptId: string) => void;
+    removePrompt: (promptId: string) => void;
 }
 
-export function useLiveFeedbackPromptResponseSnack({ openPrompt }: Props) {
+export function useLiveFeedbackPromptResponseSnack({ openPrompt, removePrompt }: Props) {
     const { enqueueSnackbar, closeSnackbar } = useSnackbar();
 
     const onClick = useCallback(
@@ -30,12 +31,17 @@ export function useLiveFeedbackPromptResponseSnack({ openPrompt }: Props) {
                 >
                     Respond
                 </Button>
-                <Button onClick={() => closeSnackbar(key)}>
+                <Button
+                    onClick={() => {
+                        removePrompt(promptId);
+                        closeSnackbar(key);
+                    }}
+                >
                     <Close />
                 </Button>
             </div>
         ),
-        [onClick, closeSnackbar]
+        [onClick, removePrompt, closeSnackbar]
     );
 
     const displaySnack = useCallback(

--- a/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackPromptResults/ViewLiveFeedbackPromptResults.tsx
+++ b/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackPromptResults/ViewLiveFeedbackPromptResults.tsx
@@ -129,7 +129,6 @@ function PreloadedViewLiveFeedbackPromptResults({ promptId }: { promptId: string
 
 interface ViewLiveFeedbackPromptResultsProps {
     promptRef: React.MutableRefObject<Prompt>;
-    closeSnack: () => void;
     open: boolean;
     setOpen: (value: boolean) => void;
     close: () => void;

--- a/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackPromptResults/useLiveFeedbackPromptResultsShared.tsx
+++ b/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackPromptResults/useLiveFeedbackPromptResultsShared.tsx
@@ -28,6 +28,15 @@ export function useLiveFeedbackPromptResultsShared({ openFeedbackPromptResults }
     const { isModerator, eventId } = useEvent();
     const enqueuedPromptResults: Array<Prompt> = React.useMemo(() => [], []);
 
+    const removePromptResult = React.useCallback(
+        (promptId: string) => {
+            const promptResultIndex = enqueuedPromptResults.findIndex((_prompt) => _prompt.id === promptId);
+            if (promptResultIndex === -1) return console.error(`Prompt with id ${promptId} not found`);
+            enqueuedPromptResults.splice(promptResultIndex, 1);
+        },
+        [enqueuedPromptResults]
+    );
+
     const promptRef = React.useRef<Prompt>({ id: '', prompt: '' });
 
     const openPromptResults = React.useCallback(
@@ -45,7 +54,7 @@ export function useLiveFeedbackPromptResultsShared({ openFeedbackPromptResults }
     const updateCurrentPrompt = ({ id, prompt }: Prompt) => {
         promptRef.current = { ...promptRef.current, id: id, prompt: prompt };
     };
-    const { displaySnack } = useLiveFeedbackPromptResultsSnack({ openPromptResults });
+    const { displaySnack } = useLiveFeedbackPromptResultsSnack({ openPromptResults, removePromptResult });
 
     const config = React.useMemo<GraphQLSubscriptionConfig<useLiveFeedbackPromptResultsSharedSubscription>>(
         () => ({

--- a/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackPromptResults/useLiveFeedbackPromptResultsSnack.tsx
+++ b/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackPromptResults/useLiveFeedbackPromptResultsSnack.tsx
@@ -4,22 +4,25 @@ import { Button } from '@mui/material';
 import Close from '@mui/icons-material/Close';
 
 interface Props {
-    openFeedbackPromptResults: () => void;
+    openPromptResults: (promptId: string) => void;
 }
 
-export function useLiveFeedbackPromptResultsSnack({ openFeedbackPromptResults }: Props) {
+export function useLiveFeedbackPromptResultsSnack({ openPromptResults }: Props) {
     const { enqueueSnackbar, closeSnackbar } = useSnackbar();
 
-    const onClick = useCallback(() => {
-        openFeedbackPromptResults();
-        closeSnackbar();
-    }, [closeSnackbar, openFeedbackPromptResults]);
+    const onClick = useCallback(
+        (promptId: string) => {
+            openPromptResults(promptId);
+            closeSnackbar();
+        },
+        [closeSnackbar, openPromptResults]
+    );
 
     const feedbackPromptAction = useCallback(
-        (key: SnackbarKey) => (
+        (key: SnackbarKey, promptId: string) => (
             <div style={{ display: 'flex' }}>
                 <div>
-                    <Button variant='contained' color='primary' onClick={onClick}>
+                    <Button variant='contained' color='primary' onClick={() => onClick(promptId)}>
                         View Results
                     </Button>
                 </div>
@@ -37,11 +40,11 @@ export function useLiveFeedbackPromptResultsSnack({ openFeedbackPromptResults }:
         [closeSnackbar, onClick]
     );
 
-    const makeSnack = useCallback(
-        (message: string, options?: OptionsObject) => {
+    const displaySnack = useCallback(
+        (promptId: string, message: string, options?: OptionsObject) => {
             enqueueSnackbar(message, {
                 variant: options?.variant || 'default',
-                action: options?.action || feedbackPromptAction,
+                action: (key) => options?.action || feedbackPromptAction(key, promptId),
                 onExited: options?.onExited,
                 color: 'inherit',
                 anchorOrigin: {
@@ -53,5 +56,5 @@ export function useLiveFeedbackPromptResultsSnack({ openFeedbackPromptResults }:
         },
         [enqueueSnackbar, feedbackPromptAction]
     );
-    return { displaySnack: makeSnack, closeSnack: closeSnackbar };
+    return { displaySnack };
 }

--- a/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackPromptResults/useLiveFeedbackPromptResultsSnack.tsx
+++ b/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackPromptResults/useLiveFeedbackPromptResultsSnack.tsx
@@ -5,9 +5,10 @@ import Close from '@mui/icons-material/Close';
 
 interface Props {
     openPromptResults: (promptId: string) => void;
+    removePromptResult: (promptId: string) => void;
 }
 
-export function useLiveFeedbackPromptResultsSnack({ openPromptResults }: Props) {
+export function useLiveFeedbackPromptResultsSnack({ openPromptResults, removePromptResult }: Props) {
     const { enqueueSnackbar, closeSnackbar } = useSnackbar();
 
     const onClick = useCallback(
@@ -29,6 +30,7 @@ export function useLiveFeedbackPromptResultsSnack({ openPromptResults }: Props) 
                 <div>
                     <Button
                         onClick={() => {
+                            removePromptResult(promptId);
                             closeSnackbar(key);
                         }}
                     >
@@ -37,7 +39,7 @@ export function useLiveFeedbackPromptResultsSnack({ openPromptResults }: Props) 
                 </div>
             </div>
         ),
-        [closeSnackbar, onClick]
+        [closeSnackbar, onClick, removePromptResult]
     );
 
     const displaySnack = useCallback(

--- a/app/client/src/features/events/LiveFeedbackPrompts/useLiveFeedbackPrompt.tsx
+++ b/app/client/src/features/events/LiveFeedbackPrompts/useLiveFeedbackPrompt.tsx
@@ -35,6 +35,15 @@ export function useLiveFeedbackPrompt({ openFeedbackPromptResponse }: Props) {
     const { eventId } = useEvent();
     const enqueuedPrompts: Array<Prompt> = React.useMemo(() => [], []);
 
+    const removePrompt = React.useCallback(
+        (promptId: string) => {
+            const promptIndex = enqueuedPrompts.findIndex((_prompt) => _prompt.id === promptId);
+            if (promptIndex === -1) return console.error(`Prompt with id ${promptId} not found`);
+            enqueuedPrompts.splice(promptIndex, 1);
+        },
+        [enqueuedPrompts]
+    );
+
     const promptRef = React.useRef<Prompt>({
         id: '',
         prompt: '',
@@ -66,7 +75,7 @@ export function useLiveFeedbackPrompt({ openFeedbackPromptResponse }: Props) {
         [enqueuedPrompts, openFeedbackPromptResponse]
     );
 
-    const { displaySnack } = useLiveFeedbackPromptResponseSnack({ openPrompt });
+    const { displaySnack } = useLiveFeedbackPromptResponseSnack({ openPrompt, removePrompt });
 
     const config = React.useMemo<GraphQLSubscriptionConfig<useLiveFeedbackPromptSubscription>>(
         () => ({

--- a/app/client/src/features/events/LiveFeedbackPrompts/useLiveFeedbackPrompt.tsx
+++ b/app/client/src/features/events/LiveFeedbackPrompts/useLiveFeedbackPrompt.tsx
@@ -33,6 +33,7 @@ interface Props {
 
 export function useLiveFeedbackPrompt({ openFeedbackPromptResponse }: Props) {
     const { eventId } = useEvent();
+    const enqueuedPrompts: Array<Prompt> = React.useMemo(() => [], []);
 
     const promptRef = React.useRef<Prompt>({
         id: '',
@@ -43,25 +44,29 @@ export function useLiveFeedbackPrompt({ openFeedbackPromptResponse }: Props) {
         multipleChoiceOptions: [],
     });
 
-    const updateCurrentPrompt = ({
-        id,
-        prompt,
-        isVote,
-        isOpenEnded,
-        isMultipleChoice,
-        multipleChoiceOptions,
-    }: Prompt) => {
-        promptRef.current = {
-            ...promptRef.current,
-            id: id,
-            prompt: prompt,
-            isVote: isVote,
-            isOpenEnded: isOpenEnded,
-            isMultipleChoice: isMultipleChoice,
-            multipleChoiceOptions: multipleChoiceOptions,
-        };
-    };
-    const { displaySnack, closeSnack } = useLiveFeedbackPromptResponseSnack({ openFeedbackPromptResponse });
+    const openPrompt = React.useCallback(
+        (promptId: string) => {
+            const promptIndex = enqueuedPrompts.findIndex((_prompt) => _prompt.id === promptId);
+            if (promptIndex === -1) return console.error(`Prompt with id ${promptId} not found`);
+            const prompt = enqueuedPrompts[promptIndex];
+            if (!prompt) return console.error(`Prompt with id ${promptId} not found`);
+            promptRef.current = {
+                ...promptRef.current,
+                id: prompt.id,
+                prompt: prompt.prompt,
+                isVote: prompt.isVote,
+                isOpenEnded: prompt.isOpenEnded,
+                isMultipleChoice: prompt.isMultipleChoice,
+                multipleChoiceOptions: prompt.multipleChoiceOptions,
+            };
+            openFeedbackPromptResponse();
+            // Remove prompt from enqueuedPrompts
+            enqueuedPrompts.splice(promptIndex, 1);
+        },
+        [enqueuedPrompts, openFeedbackPromptResponse]
+    );
+
+    const { displaySnack } = useLiveFeedbackPromptResponseSnack({ openPrompt });
 
     const config = React.useMemo<GraphQLSubscriptionConfig<useLiveFeedbackPromptSubscription>>(
         () => ({
@@ -72,9 +77,16 @@ export function useLiveFeedbackPrompt({ openFeedbackPromptResponse }: Props) {
             onNext: (data) => {
                 if (!data) return;
                 const { feedbackPrompted } = data;
-                const { id, prompt, isVote, isOpenEnded, isMultipleChoice, multipleChoiceOptions } = feedbackPrompted;
-                updateCurrentPrompt({
-                    id,
+                const {
+                    id: promptId,
+                    prompt,
+                    isVote,
+                    isOpenEnded,
+                    isMultipleChoice,
+                    multipleChoiceOptions,
+                } = feedbackPrompted;
+                enqueuedPrompts.push({
+                    id: promptId,
                     prompt,
                     isVote: !!isVote,
                     isOpenEnded: !!isOpenEnded,
@@ -82,13 +94,12 @@ export function useLiveFeedbackPrompt({ openFeedbackPromptResponse }: Props) {
                     multipleChoiceOptions: multipleChoiceOptions === null ? [] : [...multipleChoiceOptions],
                 });
 
-                // TODO: add moderator check
-                displaySnack('New Feedback Prompt', { variant: 'info' });
+                displaySnack(promptId, 'New Feedback Prompt', { variant: 'info' });
             },
         }),
-        [displaySnack, eventId]
+        [displaySnack, enqueuedPrompts, eventId]
     );
 
     useSubscription<useLiveFeedbackPromptSubscription>(config);
-    return { feedbackPromptRef: promptRef, closeFeedbackPromptSnack: closeSnack };
+    return { feedbackPromptRef: promptRef };
 }


### PR DESCRIPTION
- If multiple prompts were submitted before the participant interacted with the notification, it would only have the reference for the last pushed one. 
- Also, dismissing/responding to one prompt would cause the other notification to disappear. 
- Fixed this by ensuring the promptId and snackbar key are being passed. The reference is now set when the notification is interacted with, rather than when it comes in. All prompt references are stored in an array and removed once responded to.
TODO:
- [x] Ensure that the prompts are being removed from the list on a dismiss (only doing so when responding currently).