### PR TITLE
Feedback prompt drafts

### DIFF
--- a/app/client/schema.graphql
+++ b/app/client/schema.graphql
@@ -55,6 +55,7 @@ input CreateFeedbackPrompt {
   choices: [String!]!
   eventId: ID!
   feedbackType: String!
+  isDraft: Boolean!
   prompt: String!
 }
 
@@ -371,6 +372,7 @@ type EventLiveFeedbackPrompt implements Node {
   createdAt: Date
   event: Event
   id: ID!
+  isDraft: Boolean
   isMultipleChoice: Boolean
   isOpenEnded: Boolean
   isVote: Boolean
@@ -726,6 +728,7 @@ type Mutation {
   returns false if an account with the provided email cannot be found
   """
   resetPasswordRequest(input: ResetPasswordRequestForm!): ResetPasswordRequestMutationResponse!
+  shareFeedbackPromptDraft(promptId: ID!): EventFeedbackPromptMutationResponse!
   shareFeedbackPromptResults(eventId: ID!, promptId: ID!): EventFeedbackPromptMutationResponse!
 
   """

--- a/app/client/src/__generated__/ActionsPanelsQuery.graphql.ts
+++ b/app/client/src/__generated__/ActionsPanelsQuery.graphql.ts
@@ -1,0 +1,864 @@
+/**
+ * @generated SignedSource<<07fe07b25b6f88f7ea1a8ca1c8300bd1>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest, Query } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type ActionsPanelsQuery$variables = {
+  eventId: string;
+};
+export type ActionsPanelsQuery$data = {
+  readonly node: {
+    readonly id: string;
+    readonly " $fragmentSpreads": FragmentRefs<"EventVideoFragment" | "SpeakerListFragment" | "useBroadcastMessageListFragment" | "useEventDetailsFragment" | "useLiveFeedbackListFragment" | "useLiveFeedbackPromptsFragment">;
+  } | null;
+};
+export type ActionsPanelsQuery = {
+  response: ActionsPanelsQuery$data;
+  variables: ActionsPanelsQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "eventId"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "eventId"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v3 = [
+  {
+    "kind": "Variable",
+    "name": "eventId",
+    "variableName": "eventId"
+  }
+],
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "cursor",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "lang",
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "description",
+  "storageKey": null
+},
+v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "title",
+  "storageKey": null
+},
+v9 = {
+  "kind": "Literal",
+  "name": "after",
+  "value": ""
+},
+v10 = [
+  (v9/*: any*/),
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 50
+  }
+],
+v11 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "firstName",
+  "storageKey": null
+},
+v12 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "lastName",
+  "storageKey": null
+},
+v13 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "avatar",
+  "storageKey": null
+},
+v14 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "createdAt",
+  "storageKey": null
+},
+v15 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "endCursor",
+  "storageKey": null
+},
+v16 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "hasNextPage",
+  "storageKey": null
+},
+v17 = {
+  "kind": "ClientExtension",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "__id",
+      "storageKey": null
+    }
+  ]
+},
+v18 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "topic",
+  "storageKey": null
+},
+v19 = [
+  (v9/*: any*/),
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 100
+  }
+],
+v20 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "message",
+  "storageKey": null
+},
+v21 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "User",
+  "kind": "LinkedField",
+  "name": "createdBy",
+  "plural": false,
+  "selections": [
+    (v2/*: any*/),
+    (v11/*: any*/),
+    {
+      "alias": null,
+      "args": (v3/*: any*/),
+      "kind": "ScalarField",
+      "name": "moderatorOf",
+      "storageKey": null
+    },
+    (v12/*: any*/),
+    (v13/*: any*/)
+  ],
+  "storageKey": null
+},
+v22 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "PageInfo",
+  "kind": "LinkedField",
+  "name": "pageInfo",
+  "plural": false,
+  "selections": [
+    (v15/*: any*/),
+    (v16/*: any*/)
+  ],
+  "storageKey": null
+},
+v23 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "prompt",
+  "storageKey": null
+},
+v24 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "isVote",
+  "storageKey": null
+},
+v25 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "isOpenEnded",
+  "storageKey": null
+},
+v26 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "isMultipleChoice",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ActionsPanelsQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          (v2/*: any*/),
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "EventVideoFragment"
+          },
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "SpeakerListFragment"
+          },
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "useBroadcastMessageListFragment"
+          },
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "useEventDetailsFragment"
+          },
+          {
+            "args": (v3/*: any*/),
+            "kind": "FragmentSpread",
+            "name": "useLiveFeedbackListFragment"
+          },
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "useLiveFeedbackPromptsFragment"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "ActionsPanelsQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          (v4/*: any*/),
+          (v2/*: any*/),
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "EventVideoConnection",
+                "kind": "LinkedField",
+                "name": "videos",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "EventVideoEdge",
+                    "kind": "LinkedField",
+                    "name": "edges",
+                    "plural": true,
+                    "selections": [
+                      (v5/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "EventVideo",
+                        "kind": "LinkedField",
+                        "name": "node",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "url",
+                            "storageKey": null
+                          },
+                          (v6/*: any*/),
+                          (v2/*: any*/)
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "EventSpeakerConnection",
+                "kind": "LinkedField",
+                "name": "speakers",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "EventSpeakerEdge",
+                    "kind": "LinkedField",
+                    "name": "edges",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "EventSpeaker",
+                        "kind": "LinkedField",
+                        "name": "node",
+                        "plural": false,
+                        "selections": [
+                          (v2/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "pictureUrl",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "name",
+                            "storageKey": null
+                          },
+                          (v7/*: any*/),
+                          (v8/*: any*/)
+                        ],
+                        "storageKey": null
+                      },
+                      (v5/*: any*/)
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "currentBroadcastMessage",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": (v10/*: any*/),
+                "concreteType": "EventBroadcastMessagesConnection",
+                "kind": "LinkedField",
+                "name": "broadcastMessages",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "EventBroadcastMessageEdge",
+                    "kind": "LinkedField",
+                    "name": "edges",
+                    "plural": true,
+                    "selections": [
+                      (v5/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "EventBroadcastMessage",
+                        "kind": "LinkedField",
+                        "name": "node",
+                        "plural": false,
+                        "selections": [
+                          (v2/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "broadcastMessage",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "isVisible",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "User",
+                            "kind": "LinkedField",
+                            "name": "createdBy",
+                            "plural": false,
+                            "selections": [
+                              (v11/*: any*/),
+                              (v2/*: any*/),
+                              (v12/*: any*/),
+                              (v13/*: any*/)
+                            ],
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "position",
+                            "storageKey": null
+                          },
+                          (v14/*: any*/),
+                          (v6/*: any*/),
+                          {
+                            "alias": null,
+                            "args": [
+                              {
+                                "kind": "Literal",
+                                "name": "lang",
+                                "value": "EN"
+                              }
+                            ],
+                            "kind": "ScalarField",
+                            "name": "translatedBroadcastMessage",
+                            "storageKey": "translatedBroadcastMessage(lang:\"EN\")"
+                          },
+                          (v4/*: any*/)
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "PageInfo",
+                    "kind": "LinkedField",
+                    "name": "pageInfo",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "startCursor",
+                        "storageKey": null
+                      },
+                      (v15/*: any*/),
+                      (v16/*: any*/)
+                    ],
+                    "storageKey": null
+                  },
+                  (v17/*: any*/)
+                ],
+                "storageKey": "broadcastMessages(after:\"\",first:50)"
+              },
+              {
+                "alias": null,
+                "args": (v10/*: any*/),
+                "filters": null,
+                "handle": "connection",
+                "key": "useBroadcastMessageListFragment_broadcastMessages",
+                "kind": "LinkedHandle",
+                "name": "broadcastMessages"
+              },
+              (v8/*: any*/),
+              (v18/*: any*/),
+              (v7/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "startDateTime",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "endDateTime",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "isActive",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "isViewerModerator",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "isPrivate",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "isViewerInvited",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "issueGuideUrl",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "EventTopic",
+                "kind": "LinkedField",
+                "name": "topics",
+                "plural": true,
+                "selections": [
+                  (v2/*: any*/),
+                  (v18/*: any*/),
+                  (v7/*: any*/)
+                ],
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": (v19/*: any*/),
+                "concreteType": "EventLiveFeedbackConnection",
+                "kind": "LinkedField",
+                "name": "liveFeedback",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "EventLiveFeedbackEdge",
+                    "kind": "LinkedField",
+                    "name": "edges",
+                    "plural": true,
+                    "selections": [
+                      (v5/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "EventLiveFeedback",
+                        "kind": "LinkedField",
+                        "name": "node",
+                        "plural": false,
+                        "selections": [
+                          (v2/*: any*/),
+                          (v20/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "isDM",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "dmRecipientId",
+                            "storageKey": null
+                          },
+                          (v21/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "EventLiveFeedback",
+                            "kind": "LinkedField",
+                            "name": "refFeedback",
+                            "plural": false,
+                            "selections": [
+                              (v21/*: any*/),
+                              (v2/*: any*/),
+                              (v20/*: any*/),
+                              (v14/*: any*/)
+                            ],
+                            "storageKey": null
+                          },
+                          (v14/*: any*/),
+                          (v4/*: any*/)
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  (v22/*: any*/),
+                  (v17/*: any*/)
+                ],
+                "storageKey": "liveFeedback(after:\"\",first:100)"
+              },
+              {
+                "alias": null,
+                "args": (v19/*: any*/),
+                "filters": null,
+                "handle": "connection",
+                "key": "useLiveFeedbackListFragment_liveFeedback",
+                "kind": "LinkedHandle",
+                "name": "liveFeedback"
+              },
+              {
+                "alias": null,
+                "args": (v19/*: any*/),
+                "concreteType": "EventLiveFeedbackPromptConnection",
+                "kind": "LinkedField",
+                "name": "liveFeedbackPrompts",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "EventLiveFeedbackPromptEdge",
+                    "kind": "LinkedField",
+                    "name": "edges",
+                    "plural": true,
+                    "selections": [
+                      (v5/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "EventLiveFeedbackPrompt",
+                        "kind": "LinkedField",
+                        "name": "node",
+                        "plural": false,
+                        "selections": [
+                          (v2/*: any*/),
+                          (v23/*: any*/),
+                          (v24/*: any*/),
+                          (v25/*: any*/),
+                          (v26/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "multipleChoiceOptions",
+                            "storageKey": null
+                          },
+                          (v14/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "isDraft",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": (v19/*: any*/),
+                            "concreteType": "EventLiveFeedbackPromptResponseConnection",
+                            "kind": "LinkedField",
+                            "name": "responses",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "EventLiveFeedbackPromptResponseEdge",
+                                "kind": "LinkedField",
+                                "name": "edges",
+                                "plural": true,
+                                "selections": [
+                                  (v5/*: any*/),
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "concreteType": "EventLiveFeedbackPromptResponse",
+                                    "kind": "LinkedField",
+                                    "name": "node",
+                                    "plural": false,
+                                    "selections": [
+                                      (v2/*: any*/),
+                                      (v25/*: any*/),
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "response",
+                                        "storageKey": null
+                                      },
+                                      (v24/*: any*/),
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "vote",
+                                        "storageKey": null
+                                      },
+                                      (v26/*: any*/),
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "multipleChoiceResponse",
+                                        "storageKey": null
+                                      },
+                                      (v14/*: any*/),
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "concreteType": "User",
+                                        "kind": "LinkedField",
+                                        "name": "createdBy",
+                                        "plural": false,
+                                        "selections": [
+                                          (v2/*: any*/),
+                                          (v11/*: any*/)
+                                        ],
+                                        "storageKey": null
+                                      },
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "concreteType": "EventLiveFeedbackPrompt",
+                                        "kind": "LinkedField",
+                                        "name": "prompt",
+                                        "plural": false,
+                                        "selections": [
+                                          (v2/*: any*/),
+                                          (v23/*: any*/)
+                                        ],
+                                        "storageKey": null
+                                      },
+                                      (v4/*: any*/)
+                                    ],
+                                    "storageKey": null
+                                  }
+                                ],
+                                "storageKey": null
+                              },
+                              (v22/*: any*/),
+                              (v17/*: any*/)
+                            ],
+                            "storageKey": "responses(after:\"\",first:100)"
+                          },
+                          {
+                            "alias": null,
+                            "args": (v19/*: any*/),
+                            "filters": null,
+                            "handle": "connection",
+                            "key": "useLiveFeedbackPromptResponsesFragment_responses",
+                            "kind": "LinkedHandle",
+                            "name": "responses"
+                          },
+                          (v4/*: any*/)
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  (v22/*: any*/),
+                  (v17/*: any*/)
+                ],
+                "storageKey": "liveFeedbackPrompts(after:\"\",first:100)"
+              },
+              {
+                "alias": null,
+                "args": (v19/*: any*/),
+                "filters": null,
+                "handle": "connection",
+                "key": "useLiveFeedbackPromptsFragment_liveFeedbackPrompts",
+                "kind": "LinkedHandle",
+                "name": "liveFeedbackPrompts"
+              }
+            ],
+            "type": "Event",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "c9f6c72410421083e9b3d295ab8f1547",
+    "id": null,
+    "metadata": {},
+    "name": "ActionsPanelsQuery",
+    "operationKind": "query",
+    "text": "query ActionsPanelsQuery(\n  $eventId: ID!\n) {\n  node(id: $eventId) {\n    __typename\n    id\n    ...EventVideoFragment\n    ...SpeakerListFragment\n    ...useBroadcastMessageListFragment\n    ...useEventDetailsFragment\n    ...useLiveFeedbackListFragment_32qNee\n    ...useLiveFeedbackPromptsFragment\n  }\n}\n\nfragment BroadcastMessageActionsFragment on EventBroadcastMessage {\n  id\n  ...DeleteBroadcastMessageButtonFragment\n  ...EditBroadcastMessageButtonFragment\n}\n\nfragment BroadcastMessageAuthorFragment on EventBroadcastMessage {\n  createdBy {\n    id\n    firstName\n    lastName\n    avatar\n  }\n  createdAt\n}\n\nfragment BroadcastMessageContentFragment_TYBrd on EventBroadcastMessage {\n  broadcastMessage\n  lang\n  translatedBroadcastMessage(lang: \"EN\")\n}\n\nfragment DeleteBroadcastMessageButtonFragment on EventBroadcastMessage {\n  id\n  position\n}\n\nfragment EditBroadcastMessageButtonFragment on EventBroadcastMessage {\n  id\n}\n\nfragment EventVideoFragment on Event {\n  videos {\n    edges {\n      cursor\n      node {\n        url\n        lang\n        id\n      }\n    }\n  }\n  id\n}\n\nfragment LiveFeedbackAuthorFragment_32qNee on EventLiveFeedback {\n  createdBy {\n    id\n    firstName\n    lastName\n    avatar\n    moderatorOf(eventId: $eventId)\n  }\n  createdAt\n}\n\nfragment LiveFeedbackReplyFragment_32qNee on EventLiveFeedback {\n  id\n  message\n  ...LiveFeedbackAuthorFragment_32qNee\n}\n\nfragment SpeakerListFragment on Event {\n  speakers {\n    edges {\n      node {\n        id\n        pictureUrl\n        name\n        description\n        title\n      }\n      cursor\n    }\n  }\n  id\n}\n\nfragment useBroadcastMessageListFragment on Event {\n  id\n  currentBroadcastMessage\n  broadcastMessages(first: 50, after: \"\") {\n    edges {\n      cursor\n      node {\n        id\n        broadcastMessage\n        isVisible\n        createdBy {\n          firstName\n          id\n        }\n        ...BroadcastMessageActionsFragment\n        ...BroadcastMessageAuthorFragment\n        ...BroadcastMessageContentFragment_TYBrd\n        __typename\n      }\n    }\n    pageInfo {\n      startCursor\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment useEventDetailsFragment on Event {\n  id\n  title\n  topic\n  description\n  startDateTime\n  endDateTime\n  isActive\n  isViewerModerator\n  isPrivate\n  isViewerInvited\n  issueGuideUrl\n  topics {\n    id\n    topic\n    description\n  }\n}\n\nfragment useLiveFeedbackListFragment_32qNee on Event {\n  id\n  liveFeedback(first: 100, after: \"\") {\n    edges {\n      cursor\n      node {\n        id\n        message\n        isDM\n        dmRecipientId\n        createdBy {\n          id\n          firstName\n          moderatorOf(eventId: $eventId)\n        }\n        refFeedback {\n          createdBy {\n            id\n            firstName\n            moderatorOf(eventId: $eventId)\n          }\n          ...LiveFeedbackReplyFragment_32qNee\n          id\n        }\n        ...LiveFeedbackReplyFragment_32qNee\n        ...LiveFeedbackAuthorFragment_32qNee\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment useLiveFeedbackPromptResponsesFragment on EventLiveFeedbackPrompt {\n  id\n  responses(first: 100, after: \"\") {\n    edges {\n      cursor\n      node {\n        id\n        isOpenEnded\n        response\n        isVote\n        vote\n        isMultipleChoice\n        multipleChoiceResponse\n        createdAt\n        createdBy {\n          id\n          firstName\n        }\n        prompt {\n          id\n          prompt\n        }\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment useLiveFeedbackPromptsFragment on Event {\n  id\n  liveFeedbackPrompts(first: 100, after: \"\") {\n    edges {\n      cursor\n      node {\n        id\n        prompt\n        isVote\n        isOpenEnded\n        isMultipleChoice\n        multipleChoiceOptions\n        createdAt\n        isDraft\n        ...useLiveFeedbackPromptResponsesFragment\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "67be41d2632a91c6ef6843373ae41d76";
+
+export default node;

--- a/app/client/src/__generated__/EventLiveNewModeratorViewQuery.graphql.ts
+++ b/app/client/src/__generated__/EventLiveNewModeratorViewQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<deaf9ada2b6ac1a6e4e97142e9e083d9>>
+ * @generated SignedSource<<3da5fb0ba532be053e6f5a2d037fc4e2>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -25,7 +25,7 @@ export type EventLiveNewModeratorViewQuery$data = {
       readonly id: string;
       readonly topic: string;
     }> | null;
-    readonly " $fragmentSpreads": FragmentRefs<"EventVideoFragment" | "QuestionCarouselFragment" | "SpeakerListFragment" | "useBroadcastMessageListFragment" | "useEventDetailsFragment" | "useLiveFeedbackListFragment" | "useOnDeckFragment" | "useQuestionModQueueFragment" | "useQuestionQueueFragment" | "useQuestionsByTopicFragment" | "useQueueByTopicFragment">;
+    readonly " $fragmentSpreads": FragmentRefs<"QuestionCarouselFragment" | "useEventDetailsFragment" | "useOnDeckFragment" | "useQuestionModQueueFragment" | "useQuestionQueueFragment" | "useQuestionsByTopicFragment" | "useQueueByTopicFragment">;
   } | null;
 };
 export type EventLiveNewModeratorViewQuery = {
@@ -116,63 +116,62 @@ v9 = [
     "variableName": "userLang"
   }
 ],
-v10 = [
-  {
-    "kind": "Variable",
-    "name": "eventId",
-    "variableName": "eventId"
-  }
-],
-v11 = {
+v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "__typename",
   "storageKey": null
 },
-v12 = {
+v11 = {
   "kind": "Literal",
   "name": "after",
   "value": ""
 },
-v13 = {
-  "kind": "Literal",
-  "name": "first",
-  "value": 50
-},
-v14 = [
-  (v12/*: any*/),
-  (v13/*: any*/)
+v12 = [
+  (v11/*: any*/),
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 1000
+  }
 ],
-v15 = {
+v13 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "cursor",
   "storageKey": null
 },
-v16 = {
+v14 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "question",
+  "storageKey": null
+},
+v15 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "firstName",
   "storageKey": null
 },
-v17 = {
+v16 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "lastName",
   "storageKey": null
 },
-v18 = {
+v17 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "avatar",
   "storageKey": null
 },
-v19 = {
+v18 = {
   "alias": null,
   "args": null,
   "concreteType": "User",
@@ -180,110 +179,35 @@ v19 = {
   "name": "createdBy",
   "plural": false,
   "selections": [
-    (v16/*: any*/),
+    (v15/*: any*/),
     (v2/*: any*/),
-    (v17/*: any*/),
-    (v18/*: any*/)
+    (v16/*: any*/),
+    (v17/*: any*/)
   ],
   "storageKey": null
 },
-v20 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "position",
-  "storageKey": null
-},
-v21 = {
+v19 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "createdAt",
   "storageKey": null
 },
-v22 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "lang",
-  "storageKey": null
-},
-v23 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "endCursor",
-  "storageKey": null
-},
-v24 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "hasNextPage",
-  "storageKey": null
-},
-v25 = {
-  "alias": null,
-  "args": null,
-  "concreteType": "PageInfo",
-  "kind": "LinkedField",
-  "name": "pageInfo",
-  "plural": false,
-  "selections": [
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "startCursor",
-      "storageKey": null
-    },
-    (v23/*: any*/),
-    (v24/*: any*/)
-  ],
-  "storageKey": null
-},
-v26 = {
-  "kind": "ClientExtension",
-  "selections": [
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "__id",
-      "storageKey": null
-    }
-  ]
-},
-v27 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "title",
-  "storageKey": null
-},
-v28 = [
-  (v12/*: any*/),
-  {
-    "kind": "Literal",
-    "name": "first",
-    "value": 1000
-  }
-],
-v29 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "question",
-  "storageKey": null
-},
-v30 = {
+v20 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "likedByCount",
   "storageKey": null
 },
-v31 = {
+v21 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "lang",
+  "storageKey": null
+},
+v22 = {
   "alias": null,
   "args": [
     {
@@ -296,7 +220,14 @@ v31 = {
   "name": "questionTranslated",
   "storageKey": null
 },
-v32 = {
+v23 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "position",
+  "storageKey": null
+},
+v24 = {
   "alias": null,
   "args": null,
   "concreteType": "User",
@@ -305,13 +236,13 @@ v32 = {
   "plural": false,
   "selections": [
     (v2/*: any*/),
+    (v15/*: any*/),
     (v16/*: any*/),
-    (v17/*: any*/),
-    (v18/*: any*/)
+    (v17/*: any*/)
   ],
   "storageKey": null
 },
-v33 = {
+v25 = {
   "alias": null,
   "args": null,
   "concreteType": "EventQuestion",
@@ -320,22 +251,22 @@ v33 = {
   "plural": false,
   "selections": [
     (v2/*: any*/),
-    (v32/*: any*/),
+    (v24/*: any*/),
+    (v19/*: any*/),
+    (v14/*: any*/),
     (v21/*: any*/),
-    (v29/*: any*/),
-    (v22/*: any*/),
-    (v31/*: any*/)
+    (v22/*: any*/)
   ],
   "storageKey": null
 },
-v34 = {
+v26 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "onDeckPosition",
   "storageKey": null
 },
-v35 = {
+v27 = {
   "alias": null,
   "args": null,
   "concreteType": "EventQuestionTopic",
@@ -345,18 +276,32 @@ v35 = {
   "selections": [
     (v6/*: any*/),
     (v7/*: any*/),
-    (v20/*: any*/)
+    (v23/*: any*/)
   ],
   "storageKey": null
 },
-v36 = {
+v28 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "isLikedByViewer",
   "storageKey": null
 },
-v37 = {
+v29 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "endCursor",
+  "storageKey": null
+},
+v30 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "hasNextPage",
+  "storageKey": null
+},
+v31 = {
   "alias": null,
   "args": null,
   "concreteType": "PageInfo",
@@ -364,59 +309,38 @@ v37 = {
   "name": "pageInfo",
   "plural": false,
   "selections": [
-    (v23/*: any*/),
-    (v24/*: any*/)
+    (v29/*: any*/),
+    (v30/*: any*/)
   ],
   "storageKey": null
 },
-v38 = [
-  (v12/*: any*/),
-  {
-    "kind": "Literal",
-    "name": "first",
-    "value": 100
-  }
-],
-v39 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "message",
-  "storageKey": null
-},
-v40 = {
-  "alias": null,
-  "args": null,
-  "concreteType": "User",
-  "kind": "LinkedField",
-  "name": "createdBy",
-  "plural": false,
+v32 = {
+  "kind": "ClientExtension",
   "selections": [
-    (v2/*: any*/),
-    (v16/*: any*/),
     {
       "alias": null,
-      "args": (v10/*: any*/),
+      "args": null,
       "kind": "ScalarField",
-      "name": "moderatorOf",
+      "name": "__id",
       "storageKey": null
-    },
-    (v17/*: any*/),
-    (v18/*: any*/)
-  ],
-  "storageKey": null
+    }
+  ]
 },
-v41 = {
+v33 = {
   "kind": "Literal",
   "name": "topic",
   "value": "default"
 },
-v42 = [
-  (v12/*: any*/),
-  (v13/*: any*/),
-  (v41/*: any*/)
+v34 = [
+  (v11/*: any*/),
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 50
+  },
+  (v33/*: any*/)
 ],
-v43 = [
+v35 = [
   {
     "alias": null,
     "args": null,
@@ -425,7 +349,7 @@ v43 = [
     "name": "edges",
     "plural": true,
     "selections": [
-      (v15/*: any*/),
+      (v13/*: any*/),
       {
         "alias": null,
         "args": null,
@@ -435,16 +359,16 @@ v43 = [
         "plural": false,
         "selections": [
           (v2/*: any*/),
-          (v29/*: any*/),
-          (v22/*: any*/),
-          (v20/*: any*/),
-          (v34/*: any*/),
-          (v35/*: any*/),
-          (v32/*: any*/),
+          (v14/*: any*/),
           (v21/*: any*/),
-          (v30/*: any*/),
-          (v36/*: any*/),
-          (v31/*: any*/),
+          (v23/*: any*/),
+          (v26/*: any*/),
+          (v27/*: any*/),
+          (v24/*: any*/),
+          (v19/*: any*/),
+          (v20/*: any*/),
+          (v28/*: any*/),
+          (v22/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -454,35 +378,54 @@ v43 = [
             "plural": false,
             "selections": [
               (v2/*: any*/),
-              (v29/*: any*/),
+              (v14/*: any*/),
+              (v21/*: any*/),
               (v22/*: any*/),
-              (v31/*: any*/),
-              (v32/*: any*/),
-              (v21/*: any*/)
+              (v24/*: any*/),
+              (v19/*: any*/)
             ],
             "storageKey": null
           },
-          (v11/*: any*/)
+          (v10/*: any*/)
         ],
         "storageKey": null
       }
     ],
     "storageKey": null
   },
-  (v25/*: any*/),
-  (v26/*: any*/)
+  {
+    "alias": null,
+    "args": null,
+    "concreteType": "PageInfo",
+    "kind": "LinkedField",
+    "name": "pageInfo",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "startCursor",
+        "storageKey": null
+      },
+      (v29/*: any*/),
+      (v30/*: any*/)
+    ],
+    "storageKey": null
+  },
+  (v32/*: any*/)
 ],
-v44 = [
+v36 = [
   "topic"
 ],
-v45 = [
-  (v12/*: any*/),
+v37 = [
+  (v11/*: any*/),
   {
     "kind": "Literal",
     "name": "first",
     "value": 500
   },
-  (v41/*: any*/)
+  (v33/*: any*/)
 ];
 return {
   "fragment": {
@@ -510,22 +453,7 @@ return {
               {
                 "args": null,
                 "kind": "FragmentSpread",
-                "name": "useBroadcastMessageListFragment"
-              },
-              {
-                "args": null,
-                "kind": "FragmentSpread",
-                "name": "EventVideoFragment"
-              },
-              {
-                "args": null,
-                "kind": "FragmentSpread",
                 "name": "useEventDetailsFragment"
-              },
-              {
-                "args": null,
-                "kind": "FragmentSpread",
-                "name": "SpeakerListFragment"
               },
               {
                 "args": (v9/*: any*/),
@@ -536,11 +464,6 @@ return {
                 "args": (v9/*: any*/),
                 "kind": "FragmentSpread",
                 "name": "QuestionCarouselFragment"
-              },
-              {
-                "args": (v10/*: any*/),
-                "kind": "FragmentSpread",
-                "name": "useLiveFeedbackListFragment"
               },
               {
                 "args": (v9/*: any*/),
@@ -587,7 +510,7 @@ return {
         "name": "node",
         "plural": false,
         "selections": [
-          (v11/*: any*/),
+          (v10/*: any*/),
           (v2/*: any*/),
           {
             "kind": "InlineFragment",
@@ -600,131 +523,9 @@ return {
                 "alias": null,
                 "args": null,
                 "kind": "ScalarField",
-                "name": "currentBroadcastMessage",
+                "name": "title",
                 "storageKey": null
               },
-              {
-                "alias": null,
-                "args": (v14/*: any*/),
-                "concreteType": "EventBroadcastMessagesConnection",
-                "kind": "LinkedField",
-                "name": "broadcastMessages",
-                "plural": false,
-                "selections": [
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "EventBroadcastMessageEdge",
-                    "kind": "LinkedField",
-                    "name": "edges",
-                    "plural": true,
-                    "selections": [
-                      (v15/*: any*/),
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "EventBroadcastMessage",
-                        "kind": "LinkedField",
-                        "name": "node",
-                        "plural": false,
-                        "selections": [
-                          (v2/*: any*/),
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "broadcastMessage",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "isVisible",
-                            "storageKey": null
-                          },
-                          (v19/*: any*/),
-                          (v20/*: any*/),
-                          (v21/*: any*/),
-                          (v22/*: any*/),
-                          {
-                            "alias": null,
-                            "args": [
-                              {
-                                "kind": "Literal",
-                                "name": "lang",
-                                "value": "EN"
-                              }
-                            ],
-                            "kind": "ScalarField",
-                            "name": "translatedBroadcastMessage",
-                            "storageKey": "translatedBroadcastMessage(lang:\"EN\")"
-                          },
-                          (v11/*: any*/)
-                        ],
-                        "storageKey": null
-                      }
-                    ],
-                    "storageKey": null
-                  },
-                  (v25/*: any*/),
-                  (v26/*: any*/)
-                ],
-                "storageKey": "broadcastMessages(after:\"\",first:50)"
-              },
-              {
-                "alias": null,
-                "args": (v14/*: any*/),
-                "filters": null,
-                "handle": "connection",
-                "key": "useBroadcastMessageListFragment_broadcastMessages",
-                "kind": "LinkedHandle",
-                "name": "broadcastMessages"
-              },
-              {
-                "alias": null,
-                "args": null,
-                "concreteType": "EventVideoConnection",
-                "kind": "LinkedField",
-                "name": "videos",
-                "plural": false,
-                "selections": [
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "EventVideoEdge",
-                    "kind": "LinkedField",
-                    "name": "edges",
-                    "plural": true,
-                    "selections": [
-                      (v15/*: any*/),
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "EventVideo",
-                        "kind": "LinkedField",
-                        "name": "node",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "url",
-                            "storageKey": null
-                          },
-                          (v22/*: any*/),
-                          (v2/*: any*/)
-                        ],
-                        "storageKey": null
-                      }
-                    ],
-                    "storageKey": null
-                  }
-                ],
-                "storageKey": null
-              },
-              (v27/*: any*/),
               (v6/*: any*/),
               (v7/*: any*/),
               {
@@ -758,57 +559,6 @@ return {
               {
                 "alias": null,
                 "args": null,
-                "concreteType": "EventSpeakerConnection",
-                "kind": "LinkedField",
-                "name": "speakers",
-                "plural": false,
-                "selections": [
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "EventSpeakerEdge",
-                    "kind": "LinkedField",
-                    "name": "edges",
-                    "plural": true,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "EventSpeaker",
-                        "kind": "LinkedField",
-                        "name": "node",
-                        "plural": false,
-                        "selections": [
-                          (v2/*: any*/),
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "pictureUrl",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "name",
-                            "storageKey": null
-                          },
-                          (v7/*: any*/),
-                          (v27/*: any*/)
-                        ],
-                        "storageKey": null
-                      },
-                      (v15/*: any*/)
-                    ],
-                    "storageKey": null
-                  }
-                ],
-                "storageKey": null
-              },
-              {
-                "alias": null,
-                "args": null,
                 "kind": "ScalarField",
                 "name": "currentQuestion",
                 "storageKey": null
@@ -823,7 +573,7 @@ return {
                 "selections": [
                   {
                     "alias": null,
-                    "args": (v28/*: any*/),
+                    "args": (v12/*: any*/),
                     "concreteType": "EventQuestionConnection",
                     "kind": "LinkedField",
                     "name": "questionRecord",
@@ -837,7 +587,7 @@ return {
                         "name": "edges",
                         "plural": true,
                         "selections": [
-                          (v15/*: any*/),
+                          (v13/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -847,32 +597,32 @@ return {
                             "plural": false,
                             "selections": [
                               (v2/*: any*/),
-                              (v29/*: any*/),
+                              (v14/*: any*/),
+                              (v18/*: any*/),
                               (v19/*: any*/),
-                              (v21/*: any*/),
-                              (v30/*: any*/),
-                              (v22/*: any*/),
-                              (v31/*: any*/),
                               (v20/*: any*/),
-                              (v33/*: any*/),
-                              (v11/*: any*/),
-                              (v34/*: any*/),
-                              (v35/*: any*/),
-                              (v36/*: any*/)
+                              (v21/*: any*/),
+                              (v22/*: any*/),
+                              (v23/*: any*/),
+                              (v25/*: any*/),
+                              (v10/*: any*/),
+                              (v26/*: any*/),
+                              (v27/*: any*/),
+                              (v28/*: any*/)
                             ],
                             "storageKey": null
                           }
                         ],
                         "storageKey": null
                       },
-                      (v37/*: any*/),
-                      (v26/*: any*/)
+                      (v31/*: any*/),
+                      (v32/*: any*/)
                     ],
                     "storageKey": "questionRecord(after:\"\",first:1000)"
                   },
                   {
                     "alias": null,
-                    "args": (v28/*: any*/),
+                    "args": (v12/*: any*/),
                     "filters": null,
                     "handle": "connection",
                     "key": "QuestionQueueFragment_questionRecord",
@@ -881,7 +631,7 @@ return {
                   },
                   {
                     "alias": null,
-                    "args": (v28/*: any*/),
+                    "args": (v12/*: any*/),
                     "filters": null,
                     "handle": "connection",
                     "key": "QuestionCarousel_questionRecord",
@@ -890,7 +640,7 @@ return {
                   },
                   {
                     "alias": null,
-                    "args": (v28/*: any*/),
+                    "args": (v12/*: any*/),
                     "filters": null,
                     "handle": "connection",
                     "key": "useOnDeckFragment_questionRecord",
@@ -899,7 +649,7 @@ return {
                   },
                   {
                     "alias": null,
-                    "args": (v28/*: any*/),
+                    "args": (v12/*: any*/),
                     "concreteType": "EventQuestionConnection",
                     "kind": "LinkedField",
                     "name": "enqueuedQuestions",
@@ -913,7 +663,7 @@ return {
                         "name": "edges",
                         "plural": true,
                         "selections": [
-                          (v15/*: any*/),
+                          (v13/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -923,13 +673,13 @@ return {
                             "plural": false,
                             "selections": [
                               (v2/*: any*/),
-                              (v29/*: any*/),
+                              (v14/*: any*/),
+                              (v18/*: any*/),
                               (v19/*: any*/),
                               (v21/*: any*/),
                               (v22/*: any*/),
-                              (v31/*: any*/),
-                              (v36/*: any*/),
-                              (v20/*: any*/),
+                              (v28/*: any*/),
+                              (v23/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -939,29 +689,29 @@ return {
                                 "plural": true,
                                 "selections": [
                                   (v6/*: any*/),
-                                  (v20/*: any*/),
+                                  (v23/*: any*/),
                                   (v7/*: any*/)
                                 ],
                                 "storageKey": null
                               },
-                              (v30/*: any*/),
-                              (v33/*: any*/),
-                              (v11/*: any*/),
-                              (v34/*: any*/)
+                              (v20/*: any*/),
+                              (v25/*: any*/),
+                              (v10/*: any*/),
+                              (v26/*: any*/)
                             ],
                             "storageKey": null
                           }
                         ],
                         "storageKey": null
                       },
-                      (v37/*: any*/),
-                      (v26/*: any*/)
+                      (v31/*: any*/),
+                      (v32/*: any*/)
                     ],
                     "storageKey": "enqueuedQuestions(after:\"\",first:1000)"
                   },
                   {
                     "alias": null,
-                    "args": (v28/*: any*/),
+                    "args": (v12/*: any*/),
                     "filters": null,
                     "handle": "connection",
                     "key": "QuestionQueueFragment_enqueuedQuestions",
@@ -970,7 +720,7 @@ return {
                   },
                   {
                     "alias": null,
-                    "args": (v28/*: any*/),
+                    "args": (v12/*: any*/),
                     "filters": null,
                     "handle": "connection",
                     "key": "useOnDeckFragment_enqueuedQuestions",
@@ -982,97 +732,18 @@ return {
               },
               {
                 "alias": null,
-                "args": (v38/*: any*/),
-                "concreteType": "EventLiveFeedbackConnection",
-                "kind": "LinkedField",
-                "name": "liveFeedback",
-                "plural": false,
-                "selections": [
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "EventLiveFeedbackEdge",
-                    "kind": "LinkedField",
-                    "name": "edges",
-                    "plural": true,
-                    "selections": [
-                      (v15/*: any*/),
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "EventLiveFeedback",
-                        "kind": "LinkedField",
-                        "name": "node",
-                        "plural": false,
-                        "selections": [
-                          (v2/*: any*/),
-                          (v39/*: any*/),
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "isDM",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "dmRecipientId",
-                            "storageKey": null
-                          },
-                          (v40/*: any*/),
-                          {
-                            "alias": null,
-                            "args": null,
-                            "concreteType": "EventLiveFeedback",
-                            "kind": "LinkedField",
-                            "name": "refFeedback",
-                            "plural": false,
-                            "selections": [
-                              (v40/*: any*/),
-                              (v2/*: any*/),
-                              (v39/*: any*/),
-                              (v21/*: any*/)
-                            ],
-                            "storageKey": null
-                          },
-                          (v21/*: any*/),
-                          (v11/*: any*/)
-                        ],
-                        "storageKey": null
-                      }
-                    ],
-                    "storageKey": null
-                  },
-                  (v37/*: any*/),
-                  (v26/*: any*/)
-                ],
-                "storageKey": "liveFeedback(after:\"\",first:100)"
-              },
-              {
-                "alias": null,
-                "args": (v38/*: any*/),
-                "filters": null,
-                "handle": "connection",
-                "key": "useLiveFeedbackListFragment_liveFeedback",
-                "kind": "LinkedHandle",
-                "name": "liveFeedback"
-              },
-              {
-                "alias": null,
-                "args": (v42/*: any*/),
+                "args": (v34/*: any*/),
                 "concreteType": "EventQuestionConnection",
                 "kind": "LinkedField",
                 "name": "questionsByTopic",
                 "plural": false,
-                "selections": (v43/*: any*/),
+                "selections": (v35/*: any*/),
                 "storageKey": "questionsByTopic(after:\"\",first:50,topic:\"default\")"
               },
               {
                 "alias": null,
-                "args": (v42/*: any*/),
-                "filters": (v44/*: any*/),
+                "args": (v34/*: any*/),
+                "filters": (v36/*: any*/),
                 "handle": "connection",
                 "key": "useQuestionsByTopicFragment_questionsByTopic",
                 "kind": "LinkedHandle",
@@ -1080,18 +751,18 @@ return {
               },
               {
                 "alias": null,
-                "args": (v45/*: any*/),
+                "args": (v37/*: any*/),
                 "concreteType": "EventQuestionConnection",
                 "kind": "LinkedField",
                 "name": "topicQueue",
                 "plural": false,
-                "selections": (v43/*: any*/),
+                "selections": (v35/*: any*/),
                 "storageKey": "topicQueue(after:\"\",first:500,topic:\"default\")"
               },
               {
                 "alias": null,
-                "args": (v45/*: any*/),
-                "filters": (v44/*: any*/),
+                "args": (v37/*: any*/),
+                "filters": (v36/*: any*/),
                 "handle": "connection",
                 "key": "useQueueByTopicFragment_topicQueue",
                 "kind": "LinkedHandle",
@@ -1099,17 +770,17 @@ return {
               },
               {
                 "alias": null,
-                "args": (v28/*: any*/),
+                "args": (v12/*: any*/),
                 "concreteType": "EventQuestionConnection",
                 "kind": "LinkedField",
                 "name": "questionModQueue",
                 "plural": false,
-                "selections": (v43/*: any*/),
+                "selections": (v35/*: any*/),
                 "storageKey": "questionModQueue(after:\"\",first:1000)"
               },
               {
                 "alias": null,
-                "args": (v28/*: any*/),
+                "args": (v12/*: any*/),
                 "filters": null,
                 "handle": "connection",
                 "key": "useQuestionModQueueFragment_questionModQueue",
@@ -1126,16 +797,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "4c1a0f9a1cdd72832fb2186d4c4a8da9",
+    "cacheID": "7e03ca16e781c4e3580211f2d8e5a2b3",
     "id": null,
     "metadata": {},
     "name": "EventLiveNewModeratorViewQuery",
     "operationKind": "query",
-    "text": "query EventLiveNewModeratorViewQuery(\n  $eventId: ID!\n  $userLang: String!\n) {\n  node(id: $eventId) {\n    __typename\n    id\n    ... on Event {\n      isViewerModerator\n      isActive\n      isPrivate\n      topics {\n        id\n        topic\n        description\n      }\n      ...useBroadcastMessageListFragment\n      ...EventVideoFragment\n      ...useEventDetailsFragment\n      ...SpeakerListFragment\n      ...useQuestionQueueFragment_2ktdWx\n      ...QuestionCarouselFragment_2ktdWx\n      ...useLiveFeedbackListFragment_32qNee\n      ...useQuestionsByTopicFragment_2ktdWx\n      ...useQueueByTopicFragment_2ktdWx\n      ...useOnDeckFragment_2ktdWx\n      ...useQuestionModQueueFragment_2ktdWx\n    }\n  }\n}\n\nfragment BroadcastMessageActionsFragment on EventBroadcastMessage {\n  id\n  ...DeleteBroadcastMessageButtonFragment\n  ...EditBroadcastMessageButtonFragment\n}\n\nfragment BroadcastMessageAuthorFragment on EventBroadcastMessage {\n  createdBy {\n    id\n    firstName\n    lastName\n    avatar\n  }\n  createdAt\n}\n\nfragment BroadcastMessageContentFragment_TYBrd on EventBroadcastMessage {\n  broadcastMessage\n  lang\n  translatedBroadcastMessage(lang: \"EN\")\n}\n\nfragment DeleteBroadcastMessageButtonFragment on EventBroadcastMessage {\n  id\n  position\n}\n\nfragment DeleteButtonFragment on EventQuestion {\n  id\n  position\n}\n\nfragment EditBroadcastMessageButtonFragment on EventBroadcastMessage {\n  id\n}\n\nfragment EventVideoFragment on Event {\n  videos {\n    edges {\n      cursor\n      node {\n        url\n        lang\n        id\n      }\n    }\n  }\n  id\n}\n\nfragment LikeFragment on EventQuestion {\n  id\n  isLikedByViewer\n}\n\nfragment LiveFeedbackAuthorFragment_32qNee on EventLiveFeedback {\n  createdBy {\n    id\n    firstName\n    lastName\n    avatar\n    moderatorOf(eventId: $eventId)\n  }\n  createdAt\n}\n\nfragment LiveFeedbackReplyFragment_32qNee on EventLiveFeedback {\n  id\n  message\n  ...LiveFeedbackAuthorFragment_32qNee\n}\n\nfragment QuestionActionsFragment_43mCLt on EventQuestion {\n  id\n  ...QuoteFragment_43mCLt\n  ...LikeFragment\n  ...QueueButtonFragment\n  ...DeleteButtonFragment\n}\n\nfragment QuestionAuthorFragment on EventQuestion {\n  createdBy {\n    id\n    firstName\n    lastName\n    avatar\n  }\n  createdAt\n}\n\nfragment QuestionCarouselFragment_2ktdWx on Event {\n  id\n  currentQuestion\n  questionQueue {\n    questionRecord(first: 1000, after: \"\") {\n      edges {\n        cursor\n        node {\n          position\n          ...QuestionAuthorFragment\n          ...QuestionContentFragment_43mCLt\n          refQuestion {\n            ...QuestionQuoteFragment_43mCLt\n            id\n          }\n          id\n          __typename\n        }\n      }\n      pageInfo {\n        endCursor\n        hasNextPage\n      }\n    }\n  }\n}\n\nfragment QuestionContentFragment_43mCLt on EventQuestion {\n  question\n  lang\n  questionTranslated(lang: $userLang)\n}\n\nfragment QuestionQuoteFragment_43mCLt on EventQuestion {\n  id\n  ...QuestionAuthorFragment\n  ...QuestionContentFragment_43mCLt\n}\n\nfragment QuestionStatsFragment on EventQuestion {\n  id\n  likedByCount\n}\n\nfragment QuestionTopicsFragment on EventQuestion {\n  topics {\n    topic\n    description\n    position\n  }\n}\n\nfragment QueueButtonFragment on EventQuestion {\n  id\n  question\n  position\n  topics {\n    topic\n    position\n  }\n}\n\nfragment QuoteFragment_43mCLt on EventQuestion {\n  id\n  ...QuestionAuthorFragment\n  ...QuestionContentFragment_43mCLt\n}\n\nfragment SpeakerListFragment on Event {\n  speakers {\n    edges {\n      node {\n        id\n        pictureUrl\n        name\n        description\n        title\n      }\n      cursor\n    }\n  }\n  id\n}\n\nfragment useBroadcastMessageListFragment on Event {\n  id\n  currentBroadcastMessage\n  broadcastMessages(first: 50, after: \"\") {\n    edges {\n      cursor\n      node {\n        id\n        broadcastMessage\n        isVisible\n        createdBy {\n          firstName\n          id\n        }\n        ...BroadcastMessageActionsFragment\n        ...BroadcastMessageAuthorFragment\n        ...BroadcastMessageContentFragment_TYBrd\n        __typename\n      }\n    }\n    pageInfo {\n      startCursor\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment useEventDetailsFragment on Event {\n  id\n  title\n  topic\n  description\n  startDateTime\n  endDateTime\n  isActive\n  isViewerModerator\n  isPrivate\n  isViewerInvited\n  issueGuideUrl\n  topics {\n    id\n    topic\n    description\n  }\n}\n\nfragment useLiveFeedbackListFragment_32qNee on Event {\n  id\n  liveFeedback(first: 100, after: \"\") {\n    edges {\n      cursor\n      node {\n        id\n        message\n        isDM\n        dmRecipientId\n        createdBy {\n          id\n          firstName\n          moderatorOf(eventId: $eventId)\n        }\n        refFeedback {\n          createdBy {\n            id\n            firstName\n            moderatorOf(eventId: $eventId)\n          }\n          ...LiveFeedbackReplyFragment_32qNee\n          id\n        }\n        ...LiveFeedbackReplyFragment_32qNee\n        ...LiveFeedbackAuthorFragment_32qNee\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment useOnDeckFragment_2ktdWx on Event {\n  id\n  currentQuestion\n  questionQueue {\n    questionRecord(first: 1000, after: \"\") {\n      edges {\n        cursor\n        node {\n          id\n          question\n          lang\n          position\n          onDeckPosition\n          topics {\n            topic\n            description\n            position\n          }\n          createdBy {\n            id\n            firstName\n            lastName\n            avatar\n          }\n          createdAt\n          likedByCount\n          isLikedByViewer\n          ...QuestionActionsFragment_43mCLt\n          ...QuestionAuthorFragment\n          ...QuestionStatsFragment\n          ...QuestionContentFragment_43mCLt\n          ...QuestionTopicsFragment\n          refQuestion {\n            id\n            question\n            lang\n            questionTranslated(lang: $userLang)\n            createdBy {\n              id\n              firstName\n              lastName\n              avatar\n            }\n            createdAt\n            ...QuestionQuoteFragment_43mCLt\n          }\n          __typename\n        }\n      }\n      pageInfo {\n        endCursor\n        hasNextPage\n      }\n    }\n    enqueuedQuestions(first: 1000, after: \"\") {\n      edges {\n        cursor\n        node {\n          id\n          question\n          lang\n          position\n          onDeckPosition\n          topics {\n            topic\n            description\n            position\n          }\n          createdBy {\n            id\n            firstName\n            lastName\n            avatar\n          }\n          createdAt\n          likedByCount\n          isLikedByViewer\n          ...QuestionActionsFragment_43mCLt\n          ...QuestionAuthorFragment\n          ...QuestionStatsFragment\n          ...QuestionContentFragment_43mCLt\n          ...QuestionTopicsFragment\n          refQuestion {\n            id\n            question\n            lang\n            questionTranslated(lang: $userLang)\n            createdBy {\n              id\n              firstName\n              lastName\n              avatar\n            }\n            createdAt\n            ...QuestionQuoteFragment_43mCLt\n          }\n          __typename\n        }\n      }\n      pageInfo {\n        endCursor\n        hasNextPage\n      }\n    }\n  }\n}\n\nfragment useQuestionModQueueFragment_2ktdWx on Event {\n  id\n  currentQuestion\n  questionModQueue(first: 1000, after: \"\") {\n    edges {\n      cursor\n      node {\n        id\n        question\n        lang\n        position\n        onDeckPosition\n        topics {\n          topic\n          description\n          position\n        }\n        createdBy {\n          id\n          firstName\n          lastName\n          avatar\n        }\n        createdAt\n        likedByCount\n        isLikedByViewer\n        ...QuestionActionsFragment_43mCLt\n        ...QuestionAuthorFragment\n        ...QuestionStatsFragment\n        ...QuestionContentFragment_43mCLt\n        ...QuestionTopicsFragment\n        refQuestion {\n          id\n          question\n          lang\n          questionTranslated(lang: $userLang)\n          createdBy {\n            id\n            firstName\n            lastName\n            avatar\n          }\n          createdAt\n          ...QuestionQuoteFragment_43mCLt\n        }\n        __typename\n      }\n    }\n    pageInfo {\n      startCursor\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment useQuestionQueueFragment_2ktdWx on Event {\n  id\n  currentQuestion\n  questionQueue {\n    questionRecord(first: 1000, after: \"\") {\n      edges {\n        cursor\n        node {\n          id\n          question\n          createdBy {\n            firstName\n            id\n          }\n          ...QuestionAuthorFragment\n          ...QuestionStatsFragment\n          ...QuestionContentFragment_43mCLt\n          position\n          refQuestion {\n            ...QuestionQuoteFragment_43mCLt\n            id\n          }\n          __typename\n        }\n      }\n      pageInfo {\n        endCursor\n        hasNextPage\n      }\n    }\n    enqueuedQuestions(first: 1000, after: \"\") {\n      edges {\n        cursor\n        node {\n          id\n          question\n          createdBy {\n            firstName\n            id\n          }\n          ...QuestionActionsFragment_43mCLt\n          ...QuestionAuthorFragment\n          ...QuestionStatsFragment\n          ...QuestionContentFragment_43mCLt\n          position\n          refQuestion {\n            ...QuestionQuoteFragment_43mCLt\n            id\n          }\n          __typename\n        }\n      }\n      pageInfo {\n        endCursor\n        hasNextPage\n      }\n    }\n  }\n}\n\nfragment useQuestionsByTopicFragment_2ktdWx on Event {\n  id\n  currentQuestion\n  questionsByTopic(first: 50, after: \"\", topic: \"default\") {\n    edges {\n      cursor\n      node {\n        id\n        question\n        lang\n        position\n        onDeckPosition\n        topics {\n          topic\n          description\n          position\n        }\n        createdBy {\n          id\n          firstName\n          lastName\n          avatar\n        }\n        createdAt\n        likedByCount\n        isLikedByViewer\n        ...QuestionActionsFragment_43mCLt\n        ...QuestionAuthorFragment\n        ...QuestionStatsFragment\n        ...QuestionContentFragment_43mCLt\n        ...QuestionTopicsFragment\n        refQuestion {\n          id\n          question\n          lang\n          questionTranslated(lang: $userLang)\n          createdBy {\n            id\n            firstName\n            lastName\n            avatar\n          }\n          createdAt\n          ...QuestionQuoteFragment_43mCLt\n        }\n        __typename\n      }\n    }\n    pageInfo {\n      startCursor\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment useQueueByTopicFragment_2ktdWx on Event {\n  id\n  currentQuestion\n  topicQueue(first: 500, after: \"\", topic: \"default\") {\n    edges {\n      cursor\n      node {\n        id\n        question\n        lang\n        position\n        onDeckPosition\n        topics {\n          topic\n          description\n          position\n        }\n        createdBy {\n          id\n          firstName\n          lastName\n          avatar\n        }\n        createdAt\n        likedByCount\n        isLikedByViewer\n        ...QuestionActionsFragment_43mCLt\n        ...QuestionAuthorFragment\n        ...QuestionStatsFragment\n        ...QuestionContentFragment_43mCLt\n        ...QuestionTopicsFragment\n        refQuestion {\n          id\n          question\n          lang\n          questionTranslated(lang: $userLang)\n          createdBy {\n            id\n            firstName\n            lastName\n            avatar\n          }\n          createdAt\n          ...QuestionQuoteFragment_43mCLt\n        }\n        __typename\n      }\n    }\n    pageInfo {\n      startCursor\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query EventLiveNewModeratorViewQuery(\n  $eventId: ID!\n  $userLang: String!\n) {\n  node(id: $eventId) {\n    __typename\n    id\n    ... on Event {\n      isViewerModerator\n      isActive\n      isPrivate\n      topics {\n        id\n        topic\n        description\n      }\n      ...useEventDetailsFragment\n      ...useQuestionQueueFragment_2ktdWx\n      ...QuestionCarouselFragment_2ktdWx\n      ...useQuestionsByTopicFragment_2ktdWx\n      ...useQueueByTopicFragment_2ktdWx\n      ...useOnDeckFragment_2ktdWx\n      ...useQuestionModQueueFragment_2ktdWx\n    }\n  }\n}\n\nfragment DeleteButtonFragment on EventQuestion {\n  id\n  position\n}\n\nfragment LikeFragment on EventQuestion {\n  id\n  isLikedByViewer\n}\n\nfragment QuestionActionsFragment_43mCLt on EventQuestion {\n  id\n  ...QuoteFragment_43mCLt\n  ...LikeFragment\n  ...QueueButtonFragment\n  ...DeleteButtonFragment\n}\n\nfragment QuestionAuthorFragment on EventQuestion {\n  createdBy {\n    id\n    firstName\n    lastName\n    avatar\n  }\n  createdAt\n}\n\nfragment QuestionCarouselFragment_2ktdWx on Event {\n  id\n  currentQuestion\n  questionQueue {\n    questionRecord(first: 1000, after: \"\") {\n      edges {\n        cursor\n        node {\n          position\n          ...QuestionAuthorFragment\n          ...QuestionContentFragment_43mCLt\n          refQuestion {\n            ...QuestionQuoteFragment_43mCLt\n            id\n          }\n          id\n          __typename\n        }\n      }\n      pageInfo {\n        endCursor\n        hasNextPage\n      }\n    }\n  }\n}\n\nfragment QuestionContentFragment_43mCLt on EventQuestion {\n  question\n  lang\n  questionTranslated(lang: $userLang)\n}\n\nfragment QuestionQuoteFragment_43mCLt on EventQuestion {\n  id\n  ...QuestionAuthorFragment\n  ...QuestionContentFragment_43mCLt\n}\n\nfragment QuestionStatsFragment on EventQuestion {\n  id\n  likedByCount\n}\n\nfragment QuestionTopicsFragment on EventQuestion {\n  topics {\n    topic\n    description\n    position\n  }\n}\n\nfragment QueueButtonFragment on EventQuestion {\n  id\n  question\n  position\n  topics {\n    topic\n    position\n  }\n}\n\nfragment QuoteFragment_43mCLt on EventQuestion {\n  id\n  ...QuestionAuthorFragment\n  ...QuestionContentFragment_43mCLt\n}\n\nfragment useEventDetailsFragment on Event {\n  id\n  title\n  topic\n  description\n  startDateTime\n  endDateTime\n  isActive\n  isViewerModerator\n  isPrivate\n  isViewerInvited\n  issueGuideUrl\n  topics {\n    id\n    topic\n    description\n  }\n}\n\nfragment useOnDeckFragment_2ktdWx on Event {\n  id\n  currentQuestion\n  questionQueue {\n    questionRecord(first: 1000, after: \"\") {\n      edges {\n        cursor\n        node {\n          id\n          question\n          lang\n          position\n          onDeckPosition\n          topics {\n            topic\n            description\n            position\n          }\n          createdBy {\n            id\n            firstName\n            lastName\n            avatar\n          }\n          createdAt\n          likedByCount\n          isLikedByViewer\n          ...QuestionActionsFragment_43mCLt\n          ...QuestionAuthorFragment\n          ...QuestionStatsFragment\n          ...QuestionContentFragment_43mCLt\n          ...QuestionTopicsFragment\n          refQuestion {\n            id\n            question\n            lang\n            questionTranslated(lang: $userLang)\n            createdBy {\n              id\n              firstName\n              lastName\n              avatar\n            }\n            createdAt\n            ...QuestionQuoteFragment_43mCLt\n          }\n          __typename\n        }\n      }\n      pageInfo {\n        endCursor\n        hasNextPage\n      }\n    }\n    enqueuedQuestions(first: 1000, after: \"\") {\n      edges {\n        cursor\n        node {\n          id\n          question\n          lang\n          position\n          onDeckPosition\n          topics {\n            topic\n            description\n            position\n          }\n          createdBy {\n            id\n            firstName\n            lastName\n            avatar\n          }\n          createdAt\n          likedByCount\n          isLikedByViewer\n          ...QuestionActionsFragment_43mCLt\n          ...QuestionAuthorFragment\n          ...QuestionStatsFragment\n          ...QuestionContentFragment_43mCLt\n          ...QuestionTopicsFragment\n          refQuestion {\n            id\n            question\n            lang\n            questionTranslated(lang: $userLang)\n            createdBy {\n              id\n              firstName\n              lastName\n              avatar\n            }\n            createdAt\n            ...QuestionQuoteFragment_43mCLt\n          }\n          __typename\n        }\n      }\n      pageInfo {\n        endCursor\n        hasNextPage\n      }\n    }\n  }\n}\n\nfragment useQuestionModQueueFragment_2ktdWx on Event {\n  id\n  currentQuestion\n  questionModQueue(first: 1000, after: \"\") {\n    edges {\n      cursor\n      node {\n        id\n        question\n        lang\n        position\n        onDeckPosition\n        topics {\n          topic\n          description\n          position\n        }\n        createdBy {\n          id\n          firstName\n          lastName\n          avatar\n        }\n        createdAt\n        likedByCount\n        isLikedByViewer\n        ...QuestionActionsFragment_43mCLt\n        ...QuestionAuthorFragment\n        ...QuestionStatsFragment\n        ...QuestionContentFragment_43mCLt\n        ...QuestionTopicsFragment\n        refQuestion {\n          id\n          question\n          lang\n          questionTranslated(lang: $userLang)\n          createdBy {\n            id\n            firstName\n            lastName\n            avatar\n          }\n          createdAt\n          ...QuestionQuoteFragment_43mCLt\n        }\n        __typename\n      }\n    }\n    pageInfo {\n      startCursor\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment useQuestionQueueFragment_2ktdWx on Event {\n  id\n  currentQuestion\n  questionQueue {\n    questionRecord(first: 1000, after: \"\") {\n      edges {\n        cursor\n        node {\n          id\n          question\n          createdBy {\n            firstName\n            id\n          }\n          ...QuestionAuthorFragment\n          ...QuestionStatsFragment\n          ...QuestionContentFragment_43mCLt\n          position\n          refQuestion {\n            ...QuestionQuoteFragment_43mCLt\n            id\n          }\n          __typename\n        }\n      }\n      pageInfo {\n        endCursor\n        hasNextPage\n      }\n    }\n    enqueuedQuestions(first: 1000, after: \"\") {\n      edges {\n        cursor\n        node {\n          id\n          question\n          createdBy {\n            firstName\n            id\n          }\n          ...QuestionActionsFragment_43mCLt\n          ...QuestionAuthorFragment\n          ...QuestionStatsFragment\n          ...QuestionContentFragment_43mCLt\n          position\n          refQuestion {\n            ...QuestionQuoteFragment_43mCLt\n            id\n          }\n          __typename\n        }\n      }\n      pageInfo {\n        endCursor\n        hasNextPage\n      }\n    }\n  }\n}\n\nfragment useQuestionsByTopicFragment_2ktdWx on Event {\n  id\n  currentQuestion\n  questionsByTopic(first: 50, after: \"\", topic: \"default\") {\n    edges {\n      cursor\n      node {\n        id\n        question\n        lang\n        position\n        onDeckPosition\n        topics {\n          topic\n          description\n          position\n        }\n        createdBy {\n          id\n          firstName\n          lastName\n          avatar\n        }\n        createdAt\n        likedByCount\n        isLikedByViewer\n        ...QuestionActionsFragment_43mCLt\n        ...QuestionAuthorFragment\n        ...QuestionStatsFragment\n        ...QuestionContentFragment_43mCLt\n        ...QuestionTopicsFragment\n        refQuestion {\n          id\n          question\n          lang\n          questionTranslated(lang: $userLang)\n          createdBy {\n            id\n            firstName\n            lastName\n            avatar\n          }\n          createdAt\n          ...QuestionQuoteFragment_43mCLt\n        }\n        __typename\n      }\n    }\n    pageInfo {\n      startCursor\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment useQueueByTopicFragment_2ktdWx on Event {\n  id\n  currentQuestion\n  topicQueue(first: 500, after: \"\", topic: \"default\") {\n    edges {\n      cursor\n      node {\n        id\n        question\n        lang\n        position\n        onDeckPosition\n        topics {\n          topic\n          description\n          position\n        }\n        createdBy {\n          id\n          firstName\n          lastName\n          avatar\n        }\n        createdAt\n        likedByCount\n        isLikedByViewer\n        ...QuestionActionsFragment_43mCLt\n        ...QuestionAuthorFragment\n        ...QuestionStatsFragment\n        ...QuestionContentFragment_43mCLt\n        ...QuestionTopicsFragment\n        refQuestion {\n          id\n          question\n          lang\n          questionTranslated(lang: $userLang)\n          createdBy {\n            id\n            firstName\n            lastName\n            avatar\n          }\n          createdAt\n          ...QuestionQuoteFragment_43mCLt\n        }\n        __typename\n      }\n    }\n    pageInfo {\n      startCursor\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "fda64dbc5d5155a7bd606743d13f979c";
+(node as any).hash = "a056d4535be8d1b717007cd9706dc212";
 
 export default node;

--- a/app/client/src/__generated__/LiveFeedbackPromptListQuery.graphql.ts
+++ b/app/client/src/__generated__/LiveFeedbackPromptListQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<84ee54f1708561a5fe709e611c1700aa>>
+ * @generated SignedSource<<25544f616efb4a8cd317fcda83c0a5f5>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -16,6 +16,7 @@ export type LiveFeedbackPromptListQuery$data = {
   readonly prompts: ReadonlyArray<{
     readonly createdAt: Date | null;
     readonly id: string;
+    readonly isDraft: boolean | null;
     readonly isMultipleChoice: boolean | null;
     readonly isOpenEnded: boolean | null;
     readonly isVote: boolean | null;
@@ -99,6 +100,13 @@ v1 = [
         "kind": "ScalarField",
         "name": "createdAt",
         "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "isDraft",
+        "storageKey": null
       }
     ],
     "storageKey": null
@@ -122,16 +130,16 @@ return {
     "selections": (v1/*: any*/)
   },
   "params": {
-    "cacheID": "e9176f8e469f4c201b51c7b34fc8fedf",
+    "cacheID": "64a08e29ef45a98e69780a5f92f8e6c6",
     "id": null,
     "metadata": {},
     "name": "LiveFeedbackPromptListQuery",
     "operationKind": "query",
-    "text": "query LiveFeedbackPromptListQuery(\n  $eventId: ID!\n) {\n  prompts(eventId: $eventId) {\n    id\n    prompt\n    isVote\n    isOpenEnded\n    isMultipleChoice\n    multipleChoiceOptions\n    createdAt\n  }\n}\n"
+    "text": "query LiveFeedbackPromptListQuery(\n  $eventId: ID!\n) {\n  prompts(eventId: $eventId) {\n    id\n    prompt\n    isVote\n    isOpenEnded\n    isMultipleChoice\n    multipleChoiceOptions\n    createdAt\n    isDraft\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "670c938adc08344b88d0d215058bb087";
+(node as any).hash = "819cd55290e3a4e76fc35973d5359334";
 
 export default node;

--- a/app/client/src/__generated__/ShareFeedbackPromptDraftMutation.graphql.ts
+++ b/app/client/src/__generated__/ShareFeedbackPromptDraftMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<33f3b694485e7772020dfcc95af3a47a>>
+ * @generated SignedSource<<7dae3e5cd57cfc374c72f18c77a93cc3>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -17,9 +17,8 @@ export type ShareFeedbackPromptDraftMutation$data = {
     readonly body: {
       readonly cursor: string;
       readonly node: {
-        readonly createdAt: Date | null;
         readonly id: string;
-        readonly prompt: string;
+        readonly isDraft: boolean | null;
       };
     } | null;
     readonly isError: boolean;
@@ -102,14 +101,7 @@ v1 = [
                 "alias": null,
                 "args": null,
                 "kind": "ScalarField",
-                "name": "createdAt",
-                "storageKey": null
-              },
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "prompt",
+                "name": "isDraft",
                 "storageKey": null
               }
             ],
@@ -140,16 +132,16 @@ return {
     "selections": (v1/*: any*/)
   },
   "params": {
-    "cacheID": "356453ddbff2a7bcb811bd5f6669279b",
+    "cacheID": "05117cd188b209d760c45045f795854a",
     "id": null,
     "metadata": {},
     "name": "ShareFeedbackPromptDraftMutation",
     "operationKind": "mutation",
-    "text": "mutation ShareFeedbackPromptDraftMutation(\n  $promptId: ID!\n) {\n  shareFeedbackPromptDraft(promptId: $promptId) {\n    isError\n    message\n    body {\n      cursor\n      node {\n        id\n        createdAt\n        prompt\n      }\n    }\n  }\n}\n"
+    "text": "mutation ShareFeedbackPromptDraftMutation(\n  $promptId: ID!\n) {\n  shareFeedbackPromptDraft(promptId: $promptId) {\n    isError\n    message\n    body {\n      cursor\n      node {\n        id\n        isDraft\n      }\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "61fc7c499aa303e7d949b45f71958f09";
+(node as any).hash = "1d638ee75cb7c20f9eb6967756c3f20e";
 
 export default node;

--- a/app/client/src/__generated__/ShareFeedbackPromptDraftMutation.graphql.ts
+++ b/app/client/src/__generated__/ShareFeedbackPromptDraftMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<e440992c0e01aff9cdef7488361468d8>>
+ * @generated SignedSource<<33f3b694485e7772020dfcc95af3a47a>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,18 +9,11 @@
 // @ts-nocheck
 
 import { ConcreteRequest, Mutation } from 'relay-runtime';
-export type CreateFeedbackPrompt = {
-  choices: ReadonlyArray<string>;
-  eventId: string;
-  feedbackType: string;
-  isDraft: boolean;
-  prompt: string;
+export type ShareFeedbackPromptDraftMutation$variables = {
+  promptId: string;
 };
-export type SubmitLiveFeedbackPromptMutation$variables = {
-  input: CreateFeedbackPrompt;
-};
-export type SubmitLiveFeedbackPromptMutation$data = {
-  readonly createFeedbackPrompt: {
+export type ShareFeedbackPromptDraftMutation$data = {
+  readonly shareFeedbackPromptDraft: {
     readonly body: {
       readonly cursor: string;
       readonly node: {
@@ -33,9 +26,9 @@ export type SubmitLiveFeedbackPromptMutation$data = {
     readonly message: string;
   };
 };
-export type SubmitLiveFeedbackPromptMutation = {
-  response: SubmitLiveFeedbackPromptMutation$data;
-  variables: SubmitLiveFeedbackPromptMutation$variables;
+export type ShareFeedbackPromptDraftMutation = {
+  response: ShareFeedbackPromptDraftMutation$data;
+  variables: ShareFeedbackPromptDraftMutation$variables;
 };
 
 const node: ConcreteRequest = (function(){
@@ -43,7 +36,7 @@ var v0 = [
   {
     "defaultValue": null,
     "kind": "LocalArgument",
-    "name": "input"
+    "name": "promptId"
   }
 ],
 v1 = [
@@ -52,13 +45,13 @@ v1 = [
     "args": [
       {
         "kind": "Variable",
-        "name": "input",
-        "variableName": "input"
+        "name": "promptId",
+        "variableName": "promptId"
       }
     ],
     "concreteType": "EventFeedbackPromptMutationResponse",
     "kind": "LinkedField",
-    "name": "createFeedbackPrompt",
+    "name": "shareFeedbackPromptDraft",
     "plural": false,
     "selections": [
       {
@@ -134,7 +127,7 @@ return {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Fragment",
     "metadata": null,
-    "name": "SubmitLiveFeedbackPromptMutation",
+    "name": "ShareFeedbackPromptDraftMutation",
     "selections": (v1/*: any*/),
     "type": "Mutation",
     "abstractKey": null
@@ -143,20 +136,20 @@ return {
   "operation": {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Operation",
-    "name": "SubmitLiveFeedbackPromptMutation",
+    "name": "ShareFeedbackPromptDraftMutation",
     "selections": (v1/*: any*/)
   },
   "params": {
-    "cacheID": "a078d8b00b1ca67c2f3a2be949836e8a",
+    "cacheID": "356453ddbff2a7bcb811bd5f6669279b",
     "id": null,
     "metadata": {},
-    "name": "SubmitLiveFeedbackPromptMutation",
+    "name": "ShareFeedbackPromptDraftMutation",
     "operationKind": "mutation",
-    "text": "mutation SubmitLiveFeedbackPromptMutation(\n  $input: CreateFeedbackPrompt!\n) {\n  createFeedbackPrompt(input: $input) {\n    isError\n    message\n    body {\n      cursor\n      node {\n        id\n        createdAt\n        prompt\n      }\n    }\n  }\n}\n"
+    "text": "mutation ShareFeedbackPromptDraftMutation(\n  $promptId: ID!\n) {\n  shareFeedbackPromptDraft(promptId: $promptId) {\n    isError\n    message\n    body {\n      cursor\n      node {\n        id\n        createdAt\n        prompt\n      }\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "1526af588ad93ae620168862b0f64a3f";
+(node as any).hash = "61fc7c499aa303e7d949b45f71958f09";
 
 export default node;

--- a/app/client/src/__generated__/SubmitLiveFeedbackPromptMutation.graphql.ts
+++ b/app/client/src/__generated__/SubmitLiveFeedbackPromptMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<e440992c0e01aff9cdef7488361468d8>>
+ * @generated SignedSource<<78151c8ff4ad120f16c1d61075af9857>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,6 +9,7 @@
 // @ts-nocheck
 
 import { ConcreteRequest, Mutation } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
 export type CreateFeedbackPrompt = {
   choices: ReadonlyArray<string>;
   eventId: string;
@@ -17,6 +18,7 @@ export type CreateFeedbackPrompt = {
   prompt: string;
 };
 export type SubmitLiveFeedbackPromptMutation$variables = {
+  connections: ReadonlyArray<string>;
   input: CreateFeedbackPrompt;
 };
 export type SubmitLiveFeedbackPromptMutation$data = {
@@ -26,7 +28,13 @@ export type SubmitLiveFeedbackPromptMutation$data = {
       readonly node: {
         readonly createdAt: Date | null;
         readonly id: string;
+        readonly isDraft: boolean | null;
+        readonly isMultipleChoice: boolean | null;
+        readonly isOpenEnded: boolean | null;
+        readonly isVote: boolean | null;
+        readonly multipleChoiceOptions: ReadonlyArray<string> | null;
         readonly prompt: string;
+        readonly " $fragmentSpreads": FragmentRefs<"useLiveFeedbackPromptResponsesFragment">;
       };
     } | null;
     readonly isError: boolean;
@@ -39,84 +47,163 @@ export type SubmitLiveFeedbackPromptMutation = {
 };
 
 const node: ConcreteRequest = (function(){
-var v0 = [
+var v0 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "connections"
+},
+v1 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "input"
+},
+v2 = [
   {
-    "defaultValue": null,
-    "kind": "LocalArgument",
-    "name": "input"
+    "kind": "Variable",
+    "name": "input",
+    "variableName": "input"
   }
 ],
-v1 = [
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "isError",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "message",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "cursor",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "prompt",
+  "storageKey": null
+},
+v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "isVote",
+  "storageKey": null
+},
+v9 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "isOpenEnded",
+  "storageKey": null
+},
+v10 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "isMultipleChoice",
+  "storageKey": null
+},
+v11 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "multipleChoiceOptions",
+  "storageKey": null
+},
+v12 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "createdAt",
+  "storageKey": null
+},
+v13 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "isDraft",
+  "storageKey": null
+},
+v14 = [
   {
-    "alias": null,
-    "args": [
-      {
-        "kind": "Variable",
-        "name": "input",
-        "variableName": "input"
-      }
+    "kind": "Literal",
+    "name": "after",
+    "value": ""
+  },
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 100
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v1/*: any*/)
     ],
-    "concreteType": "EventFeedbackPromptMutationResponse",
-    "kind": "LinkedField",
-    "name": "createFeedbackPrompt",
-    "plural": false,
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "SubmitLiveFeedbackPromptMutation",
     "selections": [
       {
         "alias": null,
-        "args": null,
-        "kind": "ScalarField",
-        "name": "isError",
-        "storageKey": null
-      },
-      {
-        "alias": null,
-        "args": null,
-        "kind": "ScalarField",
-        "name": "message",
-        "storageKey": null
-      },
-      {
-        "alias": null,
-        "args": null,
-        "concreteType": "EventLiveFeedbackPromptEdge",
+        "args": (v2/*: any*/),
+        "concreteType": "EventFeedbackPromptMutationResponse",
         "kind": "LinkedField",
-        "name": "body",
+        "name": "createFeedbackPrompt",
         "plural": false,
         "selections": [
+          (v3/*: any*/),
+          (v4/*: any*/),
           {
             "alias": null,
             "args": null,
-            "kind": "ScalarField",
-            "name": "cursor",
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "concreteType": "EventLiveFeedbackPrompt",
+            "concreteType": "EventLiveFeedbackPromptEdge",
             "kind": "LinkedField",
-            "name": "node",
+            "name": "body",
             "plural": false,
             "selections": [
+              (v5/*: any*/),
               {
                 "alias": null,
                 "args": null,
-                "kind": "ScalarField",
-                "name": "id",
-                "storageKey": null
-              },
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "createdAt",
-                "storageKey": null
-              },
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "prompt",
+                "concreteType": "EventLiveFeedbackPrompt",
+                "kind": "LinkedField",
+                "name": "node",
+                "plural": false,
+                "selections": [
+                  (v6/*: any*/),
+                  (v7/*: any*/),
+                  (v8/*: any*/),
+                  (v9/*: any*/),
+                  (v10/*: any*/),
+                  (v11/*: any*/),
+                  (v12/*: any*/),
+                  (v13/*: any*/),
+                  {
+                    "args": null,
+                    "kind": "FragmentSpread",
+                    "name": "useLiveFeedbackPromptResponsesFragment"
+                  }
+                ],
                 "storageKey": null
               }
             ],
@@ -126,37 +213,236 @@ v1 = [
         "storageKey": null
       }
     ],
-    "storageKey": null
-  }
-];
-return {
-  "fragment": {
-    "argumentDefinitions": (v0/*: any*/),
-    "kind": "Fragment",
-    "metadata": null,
-    "name": "SubmitLiveFeedbackPromptMutation",
-    "selections": (v1/*: any*/),
     "type": "Mutation",
     "abstractKey": null
   },
   "kind": "Request",
   "operation": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": [
+      (v1/*: any*/),
+      (v0/*: any*/)
+    ],
     "kind": "Operation",
     "name": "SubmitLiveFeedbackPromptMutation",
-    "selections": (v1/*: any*/)
+    "selections": [
+      {
+        "alias": null,
+        "args": (v2/*: any*/),
+        "concreteType": "EventFeedbackPromptMutationResponse",
+        "kind": "LinkedField",
+        "name": "createFeedbackPrompt",
+        "plural": false,
+        "selections": [
+          (v3/*: any*/),
+          (v4/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "EventLiveFeedbackPromptEdge",
+            "kind": "LinkedField",
+            "name": "body",
+            "plural": false,
+            "selections": [
+              (v5/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "EventLiveFeedbackPrompt",
+                "kind": "LinkedField",
+                "name": "node",
+                "plural": false,
+                "selections": [
+                  (v6/*: any*/),
+                  (v7/*: any*/),
+                  (v8/*: any*/),
+                  (v9/*: any*/),
+                  (v10/*: any*/),
+                  (v11/*: any*/),
+                  (v12/*: any*/),
+                  (v13/*: any*/),
+                  {
+                    "alias": null,
+                    "args": (v14/*: any*/),
+                    "concreteType": "EventLiveFeedbackPromptResponseConnection",
+                    "kind": "LinkedField",
+                    "name": "responses",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "EventLiveFeedbackPromptResponseEdge",
+                        "kind": "LinkedField",
+                        "name": "edges",
+                        "plural": true,
+                        "selections": [
+                          (v5/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "EventLiveFeedbackPromptResponse",
+                            "kind": "LinkedField",
+                            "name": "node",
+                            "plural": false,
+                            "selections": [
+                              (v6/*: any*/),
+                              (v9/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "response",
+                                "storageKey": null
+                              },
+                              (v8/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "vote",
+                                "storageKey": null
+                              },
+                              (v10/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "multipleChoiceResponse",
+                                "storageKey": null
+                              },
+                              (v12/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "User",
+                                "kind": "LinkedField",
+                                "name": "createdBy",
+                                "plural": false,
+                                "selections": [
+                                  (v6/*: any*/),
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "firstName",
+                                    "storageKey": null
+                                  }
+                                ],
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "EventLiveFeedbackPrompt",
+                                "kind": "LinkedField",
+                                "name": "prompt",
+                                "plural": false,
+                                "selections": [
+                                  (v6/*: any*/),
+                                  (v7/*: any*/)
+                                ],
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "__typename",
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "PageInfo",
+                        "kind": "LinkedField",
+                        "name": "pageInfo",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "endCursor",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "hasNextPage",
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "ClientExtension",
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "__id",
+                            "storageKey": null
+                          }
+                        ]
+                      }
+                    ],
+                    "storageKey": "responses(after:\"\",first:100)"
+                  },
+                  {
+                    "alias": null,
+                    "args": (v14/*: any*/),
+                    "filters": null,
+                    "handle": "connection",
+                    "key": "useLiveFeedbackPromptResponsesFragment_responses",
+                    "kind": "LinkedHandle",
+                    "name": "responses"
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "filters": null,
+            "handle": "appendEdge",
+            "key": "",
+            "kind": "LinkedHandle",
+            "name": "body",
+            "handleArgs": [
+              {
+                "kind": "Variable",
+                "name": "connections",
+                "variableName": "connections"
+              }
+            ]
+          }
+        ],
+        "storageKey": null
+      }
+    ]
   },
   "params": {
-    "cacheID": "a078d8b00b1ca67c2f3a2be949836e8a",
+    "cacheID": "e39b92e5fce6643cf6430beaaf121f3d",
     "id": null,
     "metadata": {},
     "name": "SubmitLiveFeedbackPromptMutation",
     "operationKind": "mutation",
-    "text": "mutation SubmitLiveFeedbackPromptMutation(\n  $input: CreateFeedbackPrompt!\n) {\n  createFeedbackPrompt(input: $input) {\n    isError\n    message\n    body {\n      cursor\n      node {\n        id\n        createdAt\n        prompt\n      }\n    }\n  }\n}\n"
+    "text": "mutation SubmitLiveFeedbackPromptMutation(\n  $input: CreateFeedbackPrompt!\n) {\n  createFeedbackPrompt(input: $input) {\n    isError\n    message\n    body {\n      cursor\n      node {\n        id\n        prompt\n        isVote\n        isOpenEnded\n        isMultipleChoice\n        multipleChoiceOptions\n        createdAt\n        isDraft\n        ...useLiveFeedbackPromptResponsesFragment\n      }\n    }\n  }\n}\n\nfragment useLiveFeedbackPromptResponsesFragment on EventLiveFeedbackPrompt {\n  id\n  responses(first: 100, after: \"\") {\n    edges {\n      cursor\n      node {\n        id\n        isOpenEnded\n        response\n        isVote\n        vote\n        isMultipleChoice\n        multipleChoiceResponse\n        createdAt\n        createdBy {\n          id\n          firstName\n        }\n        prompt {\n          id\n          prompt\n        }\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "1526af588ad93ae620168862b0f64a3f";
+(node as any).hash = "f74350ab9d12e1620fdfd61e7eab091a";
 
 export default node;

--- a/app/client/src/__generated__/liveFeedbackPromptPagination.graphql.ts
+++ b/app/client/src/__generated__/liveFeedbackPromptPagination.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<20dd5724ae36070c6e31d0d0b86dcb0e>>
+ * @generated SignedSource<<6485e28718254ff21c71d8ab2821f4f2>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -108,10 +108,17 @@ v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
+  "name": "isMultipleChoice",
+  "storageKey": null
+},
+v10 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
   "name": "createdAt",
   "storageKey": null
 },
-v10 = [
+v11 = [
   {
     "kind": "Literal",
     "name": "after",
@@ -123,7 +130,7 @@ v10 = [
     "value": 100
   }
 ],
-v11 = {
+v12 = {
   "alias": null,
   "args": null,
   "concreteType": "PageInfo",
@@ -148,7 +155,7 @@ v11 = {
   ],
   "storageKey": null
 },
-v12 = {
+v13 = {
   "kind": "ClientExtension",
   "selections": [
     {
@@ -238,7 +245,22 @@ return {
                           (v9/*: any*/),
                           {
                             "alias": null,
-                            "args": (v10/*: any*/),
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "multipleChoiceOptions",
+                            "storageKey": null
+                          },
+                          (v10/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "isDraft",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": (v11/*: any*/),
                             "concreteType": "EventLiveFeedbackPromptResponseConnection",
                             "kind": "LinkedField",
                             "name": "responses",
@@ -278,13 +300,7 @@ return {
                                         "name": "vote",
                                         "storageKey": null
                                       },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "isMultipleChoice",
-                                        "storageKey": null
-                                      },
+                                      (v9/*: any*/),
                                       {
                                         "alias": null,
                                         "args": null,
@@ -292,7 +308,7 @@ return {
                                         "name": "multipleChoiceResponse",
                                         "storageKey": null
                                       },
-                                      (v9/*: any*/),
+                                      (v10/*: any*/),
                                       {
                                         "alias": null,
                                         "args": null,
@@ -332,14 +348,14 @@ return {
                                 ],
                                 "storageKey": null
                               },
-                              (v11/*: any*/),
-                              (v12/*: any*/)
+                              (v12/*: any*/),
+                              (v13/*: any*/)
                             ],
                             "storageKey": "responses(after:\"\",first:100)"
                           },
                           {
                             "alias": null,
-                            "args": (v10/*: any*/),
+                            "args": (v11/*: any*/),
                             "filters": null,
                             "handle": "connection",
                             "key": "useLiveFeedbackPromptResponsesFragment_responses",
@@ -353,8 +369,8 @@ return {
                     ],
                     "storageKey": null
                   },
-                  (v11/*: any*/),
-                  (v12/*: any*/)
+                  (v12/*: any*/),
+                  (v13/*: any*/)
                 ],
                 "storageKey": null
               },
@@ -377,16 +393,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "1fd7977d8575d87a747a5dfe3d67c1f4",
+    "cacheID": "3f757520fb1c8542885356b00b761dbe",
     "id": null,
     "metadata": {},
     "name": "liveFeedbackPromptPagination",
     "operationKind": "query",
-    "text": "query liveFeedbackPromptPagination(\n  $after: String = \"\"\n  $first: Int = 100\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ...useLiveFeedbackPromptsFragment_2HEEH6\n    id\n  }\n}\n\nfragment useLiveFeedbackPromptResponsesFragment on EventLiveFeedbackPrompt {\n  id\n  responses(first: 100, after: \"\") {\n    edges {\n      cursor\n      node {\n        id\n        isOpenEnded\n        response\n        isVote\n        vote\n        isMultipleChoice\n        multipleChoiceResponse\n        createdAt\n        createdBy {\n          id\n          firstName\n        }\n        prompt {\n          id\n          prompt\n        }\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment useLiveFeedbackPromptsFragment_2HEEH6 on Event {\n  id\n  liveFeedbackPrompts(first: $first, after: $after) {\n    edges {\n      cursor\n      node {\n        id\n        prompt\n        isVote\n        isOpenEnded\n        createdAt\n        ...useLiveFeedbackPromptResponsesFragment\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query liveFeedbackPromptPagination(\n  $after: String = \"\"\n  $first: Int = 100\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ...useLiveFeedbackPromptsFragment_2HEEH6\n    id\n  }\n}\n\nfragment useLiveFeedbackPromptResponsesFragment on EventLiveFeedbackPrompt {\n  id\n  responses(first: 100, after: \"\") {\n    edges {\n      cursor\n      node {\n        id\n        isOpenEnded\n        response\n        isVote\n        vote\n        isMultipleChoice\n        multipleChoiceResponse\n        createdAt\n        createdBy {\n          id\n          firstName\n        }\n        prompt {\n          id\n          prompt\n        }\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment useLiveFeedbackPromptsFragment_2HEEH6 on Event {\n  id\n  liveFeedbackPrompts(first: $first, after: $after) {\n    edges {\n      cursor\n      node {\n        id\n        prompt\n        isVote\n        isOpenEnded\n        isMultipleChoice\n        multipleChoiceOptions\n        createdAt\n        isDraft\n        ...useLiveFeedbackPromptResponsesFragment\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "c2b59a234a10b7a15a32749b775ab6d6";
+(node as any).hash = "a5e3537c394d291525e3f7a7a48f92bd";
 
 export default node;

--- a/app/client/src/__generated__/useLiveFeedbackPromptSubscription.graphql.ts
+++ b/app/client/src/__generated__/useLiveFeedbackPromptSubscription.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<f5a02a6845f0fadb316f7d61fd347a57>>
+ * @generated SignedSource<<f03c568493d8733a94f5ba6381b05dcd>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -15,6 +15,7 @@ export type useLiveFeedbackPromptSubscription$variables = {
 export type useLiveFeedbackPromptSubscription$data = {
   readonly feedbackPrompted: {
     readonly id: string;
+    readonly isDraft: boolean | null;
     readonly isMultipleChoice: boolean | null;
     readonly isOpenEnded: boolean | null;
     readonly isVote: boolean | null;
@@ -75,6 +76,13 @@ v1 = [
         "alias": null,
         "args": null,
         "kind": "ScalarField",
+        "name": "isDraft",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
         "name": "isOpenEnded",
         "storageKey": null
       },
@@ -114,16 +122,16 @@ return {
     "selections": (v1/*: any*/)
   },
   "params": {
-    "cacheID": "1922549799038c80e3d921b84a25e7a7",
+    "cacheID": "d252d6ad06a7bbf09e1a22d19d75cd87",
     "id": null,
     "metadata": {},
     "name": "useLiveFeedbackPromptSubscription",
     "operationKind": "subscription",
-    "text": "subscription useLiveFeedbackPromptSubscription(\n  $eventId: ID!\n) {\n  feedbackPrompted(eventId: $eventId) {\n    id\n    prompt\n    isVote\n    isOpenEnded\n    isMultipleChoice\n    multipleChoiceOptions\n  }\n}\n"
+    "text": "subscription useLiveFeedbackPromptSubscription(\n  $eventId: ID!\n) {\n  feedbackPrompted(eventId: $eventId) {\n    id\n    prompt\n    isVote\n    isDraft\n    isOpenEnded\n    isMultipleChoice\n    multipleChoiceOptions\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "630834bac36a26e4c55a6efec64f6c87";
+(node as any).hash = "734052273232777e5039afae3dbdc9cb";
 
 export default node;

--- a/app/client/src/__generated__/useLiveFeedbackPromptsFragment.graphql.ts
+++ b/app/client/src/__generated__/useLiveFeedbackPromptsFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<f7050f4bc16b2c24a40d2c44779e9818>>
+ * @generated SignedSource<<f9a12a85389b7cc7edf1a431899fa34c>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -19,8 +19,11 @@ export type useLiveFeedbackPromptsFragment$data = {
       readonly node: {
         readonly createdAt: Date | null;
         readonly id: string;
+        readonly isDraft: boolean | null;
+        readonly isMultipleChoice: boolean | null;
         readonly isOpenEnded: boolean | null;
         readonly isVote: boolean | null;
+        readonly multipleChoiceOptions: ReadonlyArray<string> | null;
         readonly prompt: string;
         readonly " $fragmentSpreads": FragmentRefs<"useLiveFeedbackPromptResponsesFragment">;
       };
@@ -146,7 +149,28 @@ return {
                   "alias": null,
                   "args": null,
                   "kind": "ScalarField",
+                  "name": "isMultipleChoice",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "multipleChoiceOptions",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
                   "name": "createdAt",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "isDraft",
                   "storageKey": null
                 },
                 {
@@ -213,6 +237,6 @@ return {
 };
 })();
 
-(node as any).hash = "c2b59a234a10b7a15a32749b775ab6d6";
+(node as any).hash = "a5e3537c394d291525e3f7a7a48f92bd";
 
 export default node;

--- a/app/client/src/components/EventInfoPoppers/EventInfoPoppers.tsx
+++ b/app/client/src/components/EventInfoPoppers/EventInfoPoppers.tsx
@@ -187,7 +187,7 @@ export function EventFeedbackInfoPopper({ feedbackContainerRef }: EventFeedbackI
                             <InfoIcon sx={{ color: 'white' }} />
                         </Tooltip>
                         <Typography fontWeight='bold' color='white' width='25rem'>
-                            In the feedback tab you can directly message the event moderators with your feedback or
+                            In the messages tab you can directly message the event moderators with your feedback or
                             about any technical issues you may be experiencing.
                         </Typography>
                         <Tooltip title='Dismiss' placement='bottom-start'>

--- a/app/client/src/features/events/EventLiveModeratorView.tsx
+++ b/app/client/src/features/events/EventLiveModeratorView.tsx
@@ -18,7 +18,7 @@ import { StyledColumnGrid } from '@local/components/StyledColumnGrid';
 import { StyledTabs } from '@local/components/StyledTabs';
 import { QuestionList } from './Questions';
 import { CurrentQuestionCard } from './Moderation/ManageQuestions/CurrentQuestionCard';
-import { ActionsPanels } from './ModeratorView/ActionsPanels';
+import { PreloadedActionsPanels } from './ModeratorView/ActionsPanels';
 import { EventTopicContext } from './ModeratorView/EventTopicContext';
 import { useUser } from '../accounts';
 
@@ -56,7 +56,7 @@ interface EventLiveProps {
 }
 
 function EventLiveModeratorView({ node }: EventLiveProps) {
-    const { eventData, isLive, setIsLive, pauseEventDetailsRefresh, resumeEventDetailsRefresh } = useEventDetails({
+    const { pauseEventDetailsRefresh, resumeEventDetailsRefresh } = useEventDetails({
         fragmentRef: node,
     });
     const { id: eventId } = node;
@@ -84,7 +84,7 @@ function EventLiveModeratorView({ node }: EventLiveProps) {
             <EventTopicContext.Provider value={{ topic: 'default', topics: [] }}>
                 <PanelGroup autoSaveId='mod-panels-persistence' direction='horizontal'>
                     <Panel defaultSize={33} minSize={21}>
-                        <ActionsPanels node={node} eventData={eventData} isLive={isLive} setIsLive={setIsLive} />
+                        <PreloadedActionsPanels />
                     </Panel>
                     <PanelResizeHandle>
                         <Grid container justifyContent='center' height='100%' width='0.5rem'>

--- a/app/client/src/features/events/EventSidebar/EventSidebar.tsx
+++ b/app/client/src/features/events/EventSidebar/EventSidebar.tsx
@@ -104,7 +104,7 @@ export const EventSidebar = ({ fragmentRef, participants }: EventSidebarProps) =
         if (smDownBreakpoint) {
             return (
                 <React.Fragment>
-                    <Typography variant='caption'>Feedback</Typography>
+                    <Typography variant='caption'>Messages</Typography>
                     <Badge
                         badgeContent={numOfFeedbackMsgs}
                         color='error'
@@ -115,7 +115,7 @@ export const EventSidebar = ({ fragmentRef, participants }: EventSidebarProps) =
         }
         return (
             <React.Fragment>
-                Feedback
+                Messages
                 <Badge badgeContent={numOfFeedbackMsgs} color='error' sx={{ transform: 'translate(40px, -23px)' }} />
             </React.Fragment>
         );

--- a/app/client/src/features/events/LiveFeedback/LiveFeedbackList.tsx
+++ b/app/client/src/features/events/LiveFeedback/LiveFeedbackList.tsx
@@ -14,8 +14,6 @@ import { LiveFeedbackAuthor } from './LiveFeedbackAuthor';
 import { useEvent } from '../useEvent';
 import { LiveFeedbackReplyAction } from './LiveFeedbackReplyAction';
 import { LiveFeedbackReply } from './LiveFeedbackReply';
-import { SubmitLiveFeedbackPrompt } from '../LiveFeedbackPrompts/LiveFeedbackPrompt';
-import { ShareFeedbackResults } from '../LiveFeedbackPrompts';
 import { SubmitLiveFeedback } from './SubmitLiveFeedback';
 
 interface LiveFeedbackListProps {
@@ -107,13 +105,11 @@ export function LiveFeedbackList({ fragmentRef, isVisible, setNumOfFeedbackMsgs 
     const ActionButtons = React.useMemo(() => {
         if (isModerator) {
             return (
-                <Grid
-                    container
+                <Stack
                     direction='row'
-                    justifyContent='space-around'
+                    justifyContent='space-between'
                     alignItems='center'
                     marginBottom={isSearchOpen ? '.5rem' : '0rem'}
-                    spacing={0.5}
                 >
                     <Grid item xs='auto'>
                         <IconButton
@@ -126,16 +122,8 @@ export function LiveFeedbackList({ fragmentRef, isVisible, setNumOfFeedbackMsgs 
                             </Tooltip>
                         </IconButton>
                     </Grid>
-                    <Grid item xs='auto'>
-                        <SubmitLiveFeedback eventId={eventId} connections={connections} />
-                    </Grid>
-                    <Grid item xs='auto'>
-                        <SubmitLiveFeedbackPrompt eventId={eventId} />
-                    </Grid>
-                    <Grid item xs='auto'>
-                        <ShareFeedbackResults />
-                    </Grid>
-                </Grid>
+                    <SubmitLiveFeedback eventId={eventId} connections={connections} />
+                </Stack>
             );
         } else {
             return (
@@ -175,7 +163,7 @@ export function LiveFeedbackList({ fragmentRef, isVisible, setNumOfFeedbackMsgs 
     if (!isVisible) return <React.Fragment />;
 
     return (
-        <Stack direction='column' alignItems='stretch' width='100%' padding={1} paddingRight={0}>
+        <Stack direction='column' alignItems='stretch' width='100%' paddingRight={0}>
             <Paper sx={{ padding: '1rem', marginX: '8px', marginBottom: '0.5rem' }}>
                 {ActionButtons}
                 <ListFilter

--- a/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackPrompt/FeedbackPromptsList.tsx
+++ b/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackPrompt/FeedbackPromptsList.tsx
@@ -1,0 +1,292 @@
+import * as React from 'react';
+import {
+    List,
+    Card,
+    CardContent,
+    Typography,
+    Grid,
+    IconButton,
+    DialogContent,
+    Tabs,
+    Tab,
+    CardActions,
+    CardHeader,
+} from '@mui/material';
+import DescriptionIcon from '@mui/icons-material/Description';
+import { OpenInNew as OpenInNewIcon } from '@mui/icons-material';
+import { useTheme, alpha } from '@mui/material/styles';
+import useMediaQuery from '@mui/material/useMediaQuery';
+
+import { PreloadedLiveFeedbackPromptResponseList } from '../LiveFeedbackPromptResponses/LiveFeedbackPromptResponseList';
+import { ShareFeedbackPromptResults } from '../LiveFeedbackPromptResponses';
+import { useEvent } from '@local/features/events/useEvent';
+import { StyledDialogTitle, Loader, StyledDialog, ConditionalRender } from '@local/components';
+import { ShareFeedbackPromptDraft } from './ShareFeedbackPromptDraft';
+import { SubmitLiveFeedbackPrompt } from './SubmitLiveFeedbackPrompt';
+import { useLiveFeedbackPrompts } from './useLiveFeedbackPrompts';
+import { useLiveFeedbackPromptsFragment$key } from '@local/__generated__/useLiveFeedbackPromptsFragment.graphql';
+
+export type Prompt = {
+    readonly id: string;
+    readonly prompt: string;
+    readonly isVote: boolean | null;
+    readonly isOpenEnded: boolean | null;
+    readonly isMultipleChoice: boolean | null;
+    readonly multipleChoiceOptions: ReadonlyArray<string> | null;
+    readonly isDraft: boolean | null;
+    readonly createdAt: Date | null;
+};
+
+interface PromptItemProps {
+    prompt: Prompt;
+    handleClick: (prompt: Prompt) => void;
+}
+
+function PromptItem({ prompt, handleClick }: PromptItemProps) {
+    return (
+        <Card sx={{ margin: '0.25rem' }}>
+            {prompt.isDraft ? (
+                <CardHeader
+                    title={
+                        <IconButton disabled={true}>
+                            <DescriptionIcon />
+                            <Typography>Draft</Typography>
+                        </IconButton>
+                    }
+                />
+            ) : null}
+            <CardContent>
+                <Grid container direction='row' alignItems='center' justifyContent='space-around'>
+                    <Grid item>
+                        <Typography variant='inherit' sx={{ wordBreak: 'break-word' }}>
+                            {prompt.prompt}
+                        </Typography>
+                    </Grid>
+                </Grid>
+            </CardContent>
+            <CardActions sx={{ justifyContent: 'center' }}>
+                {prompt.isDraft ? (
+                    <ShareFeedbackPromptDraft prompt={prompt} />
+                ) : (
+                    <IconButton onClick={() => handleClick(prompt)}>
+                        <OpenInNewIcon />
+                        <Typography variant='subtitle1'>View</Typography>
+                    </IconButton>
+                )}
+            </CardActions>
+        </Card>
+    );
+}
+
+interface PromptListProps {
+    prompts: readonly Prompt[];
+    handleClick: (prompt: Prompt) => void;
+}
+
+/**
+ * This component is responsible for rendering the live feedback prompts using the provided fragment Ref
+ */
+function PromptList({ prompts: readonlyPrompts, handleClick }: PromptListProps) {
+    const theme = useTheme();
+    // Reverse the prompts so that the most recent are at the top
+    const prompts = React.useMemo(() => [...readonlyPrompts].reverse(), [readonlyPrompts]);
+    const [value, setValue] = React.useState<'open-ended' | 'vote' | 'multiple-choice'>('open-ended');
+    const MAX_LIST_LENGTH = 100;
+
+    const handleChange = (e: React.SyntheticEvent, newValue: 'open-ended' | 'vote') => {
+        e.preventDefault();
+        setValue(newValue);
+    };
+
+    const openEndedPrompts = React.useMemo(() => prompts.filter((prompt) => prompt.isOpenEnded), [prompts]);
+    const votePrompts = React.useMemo(() => prompts.filter((prompt) => prompt.isVote), [prompts]);
+    const multipleChoicePrompts = React.useMemo(() => prompts.filter((prompt) => prompt.isMultipleChoice), [prompts]);
+
+    return (
+        <React.Fragment>
+            <Tabs
+                sx={{
+                    '& .MuiTabs-indicator': { backgroundColor: 'custom.creamCan' },
+                    '& .MuiTab-root': {
+                        color: 'white',
+                        backgroundColor: alpha(theme.palette.custom.darkCreamCan, 0.25),
+                        borderRadius: '20px 20px 0 0',
+                    },
+                    '& .Mui-selected': { backgroundColor: 'custom.creamCan' },
+                }}
+                value={value}
+                onChange={handleChange}
+                centered
+                aria-label='secondary tabs example'
+            >
+                <Tab label='Open Ended' value='open-ended' />
+                <Tab label='Vote' value='vote' />
+                <Tab label='Multiple Choice' value='multiple-choice' />
+            </Tabs>
+            {value === 'open-ended' && (
+                <React.Fragment>
+                    {openEndedPrompts.length > 0 ? (
+                        <List
+                            id='live-feedback-open-ended-prompt-list'
+                            sx={{
+                                border: 5,
+                                borderImage: `linear-gradient(${theme.palette.custom.creamCan},white) 10`,
+                                width: '100%',
+                            }}
+                        >
+                            {openEndedPrompts.slice(0, MAX_LIST_LENGTH).map((prompt) => (
+                                <PromptItem key={prompt.id} prompt={prompt} handleClick={handleClick} />
+                            ))}
+                        </List>
+                    ) : (
+                        <Typography>No Open Ended Prompts To Display Yet</Typography>
+                    )}
+                </React.Fragment>
+            )}
+            {value === 'vote' && (
+                <React.Fragment>
+                    {votePrompts.length > 0 ? (
+                        <List
+                            id='live-feedback-vote-prompt-list'
+                            sx={{
+                                border: 5,
+                                borderImage: `linear-gradient(${theme.palette.custom.creamCan},white) 10`,
+                                width: '100%',
+                            }}
+                        >
+                            {votePrompts.map((prompt) => (
+                                <PromptItem key={prompt.id} prompt={prompt} handleClick={handleClick} />
+                            ))}
+                        </List>
+                    ) : (
+                        <Typography>No Vote Prompts To Display Yet</Typography>
+                    )}
+                </React.Fragment>
+            )}
+            {value === 'multiple-choice' && (
+                <React.Fragment>
+                    {multipleChoicePrompts.length > 0 ? (
+                        <List
+                            id='live-feedback-multiple-choice-prompt-list'
+                            sx={{
+                                border: 5,
+                                borderImage: `linear-gradient(${theme.palette.custom.creamCan},white) 10`,
+                                width: '100%',
+                            }}
+                        >
+                            {multipleChoicePrompts.map((prompt) => (
+                                <PromptItem key={prompt.id} prompt={prompt} handleClick={handleClick} />
+                            ))}
+                        </List>
+                    ) : (
+                        <Typography>No Multiple Choice Prompts To Display Yet</Typography>
+                    )}
+                </React.Fragment>
+            )}
+        </React.Fragment>
+    );
+}
+
+interface FeedbackPromptsListProps {
+    fragmentRef: useLiveFeedbackPromptsFragment$key;
+    isShareResultsOpen: boolean;
+}
+
+/**
+ * This component is responsible for loading the query and passing the fragment ref to the PromptList component
+ */
+export function FeedbackPromptsList({ fragmentRef, isShareResultsOpen }: FeedbackPromptsListProps) {
+    const [open, setOpen] = React.useState(false);
+    const theme = useTheme();
+    const fullscreen = useMediaQuery(theme.breakpoints.down('md'));
+    const { prompts, connections } = useLiveFeedbackPrompts({
+        fragmentRef,
+        isModalOpen: open,
+        isShareResultsOpen,
+    });
+    const selectedPromptRef = React.useRef<Prompt | null>(null);
+    const { pauseParentRefreshing, resumeParentRefreshing, eventId } = useEvent();
+
+    const handleOpen = () => {
+        setOpen(true);
+        pauseParentRefreshing();
+    };
+    const handleClose = () => {
+        setOpen(false);
+        resumeParentRefreshing();
+    };
+
+    const handlePromptClick = (prompt: Prompt) => {
+        // Update the selected prompt ref
+        selectedPromptRef.current = prompt;
+        // Open the modal
+        handleOpen();
+    };
+
+    const PromptResponseList = () => {
+        if (selectedPromptRef.current)
+            return (
+                <ConditionalRender client>
+                    <React.Suspense fallback={<Loader />}>
+                        <PreloadedLiveFeedbackPromptResponseList prompt={selectedPromptRef.current} />
+                    </React.Suspense>
+                </ConditionalRender>
+            );
+        return <React.Fragment />;
+    };
+
+    const PromptText = React.useCallback(() => {
+        if (selectedPromptRef.current)
+            return (
+                <Grid container padding='1rem'>
+                    <Grid item xs>
+                        <Typography variant='h5' style={{ overflowWrap: 'break-word' }}>
+                            Prompt: {selectedPromptRef.current.prompt}
+                        </Typography>
+                    </Grid>
+                </Grid>
+            );
+        return <React.Fragment />;
+    }, []);
+
+    const ShareFeedbackResultsButton = () => {
+        if (
+            selectedPromptRef.current &&
+            (selectedPromptRef.current.isVote || selectedPromptRef.current.isMultipleChoice)
+        )
+            return (
+                <Grid item paddingBottom='1rem'>
+                    <ShareFeedbackPromptResults prompt={selectedPromptRef.current} />
+                </Grid>
+            );
+        return <React.Fragment />;
+    };
+
+    return (
+        <React.Fragment>
+            <SubmitLiveFeedbackPrompt eventId={eventId} connections={connections} />
+            <Typography variant='h6'>Select view on a prompt to see its responses</Typography>
+            {!prompts ? <Loader /> : <PromptList prompts={prompts} handleClick={handlePromptClick} />}
+            <StyledDialog
+                fullScreen={fullscreen}
+                maxWidth='lg'
+                fullWidth={true}
+                scroll='paper'
+                open={open}
+                onClose={handleClose}
+                aria-labelledby='feedback-responses-dialog'
+            >
+                <StyledDialogTitle id='feedback-responses-dialog-title' onClose={handleClose}>
+                    Feedback Responses
+                </StyledDialogTitle>
+                <DialogContent dividers>
+                    <Grid container direction='column' alignItems='center' alignContent='center'>
+                        <PromptText />
+                        <ShareFeedbackResultsButton />
+                        <PromptResponseList />
+                    </Grid>
+                </DialogContent>
+            </StyledDialog>
+        </React.Fragment>
+    );
+}

--- a/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackPrompt/LiveFeedbackPromptForm.tsx
+++ b/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackPrompt/LiveFeedbackPromptForm.tsx
@@ -22,7 +22,7 @@ export type TLiveFeedbackPromptFormState = {
 };
 
 export interface LiveFeedbackPromptFormProps {
-    onSubmit?: (state: TLiveFeedbackPromptFormState) => void;
+    onSubmit?: (state: TLiveFeedbackPromptFormState, isDraft: boolean) => void;
     onCancel?: () => void;
 }
 
@@ -78,8 +78,16 @@ export function LiveFeedbackPromptForm({ onSubmit, onCancel }: LiveFeedbackPromp
         return true;
     };
 
+    const onSaveDraft = () => {
+        if (onSubmit) onSubmit(form, true);
+    };
+
     return (
-        <Form onSubmit={handleSubmit(onSubmit)}>
+        <Form
+            onSubmit={handleSubmit((_form) => {
+                if (onSubmit) onSubmit(_form, false);
+            })}
+        >
             <FormTitle title='Feedback Prompt' />
             <FormContent>
                 <Grid container alignItems='center' justifyContent='space-around'>
@@ -184,6 +192,14 @@ export function LiveFeedbackPromptForm({ onSubmit, onCancel }: LiveFeedbackPromp
                         Cancel
                     </Button>
                 )}
+                <Button
+                    disabled={!isPromptValidForSubmission()}
+                    onClick={onSaveDraft}
+                    variant='contained'
+                    color='primary'
+                >
+                    Save as Draft
+                </Button>
                 <Button disabled={!isPromptValidForSubmission()} type='submit' variant='contained' color='primary'>
                     Create
                 </Button>

--- a/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackPrompt/LiveFeedbackPromptList.tsx
+++ b/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackPrompt/LiveFeedbackPromptList.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { graphql, PreloadedQuery, useQueryLoader, usePreloadedQuery, fetchQuery } from 'react-relay';
 import {
     List,
-    ListItem,
     Card,
     CardContent,
     Typography,
@@ -11,7 +10,10 @@ import {
     DialogContent,
     Tabs,
     Tab,
+    CardActions,
+    CardHeader,
 } from '@mui/material';
+import DescriptionIcon from '@mui/icons-material/Description';
 import { OpenInNew as OpenInNewIcon } from '@mui/icons-material';
 import { useTheme, alpha } from '@mui/material/styles';
 import useMediaQuery from '@mui/material/useMediaQuery';
@@ -22,6 +24,7 @@ import { ShareFeedbackPromptResults } from '../LiveFeedbackPromptResponses';
 import { useEnvironment } from '@local/core';
 import { useEvent } from '@local/features/events/useEvent';
 import { StyledDialogTitle, Loader, StyledDialog, ConditionalRender } from '@local/components';
+import { ShareFeedbackPromptDraft } from './ShareFeedbackPromptDraft';
 
 export const LIVE_FEEDBACK_PROMPT_LIST_QUERY = graphql`
     query LiveFeedbackPromptListQuery($eventId: ID!) {
@@ -33,6 +36,7 @@ export const LIVE_FEEDBACK_PROMPT_LIST_QUERY = graphql`
             isMultipleChoice
             multipleChoiceOptions
             createdAt
+            isDraft
         }
     }
 `;
@@ -44,6 +48,7 @@ export type Prompt = {
     readonly isOpenEnded: boolean | null;
     readonly isMultipleChoice: boolean | null;
     readonly multipleChoiceOptions: ReadonlyArray<string> | null;
+    readonly isDraft: boolean | null;
     readonly createdAt: Date | null;
 };
 
@@ -54,27 +59,37 @@ interface PromptItemProps {
 
 function PromptItem({ prompt, handleClick }: PromptItemProps) {
     return (
-        <ListItem style={{ paddingBottom: '.5rem', paddingTop: '.5rem' }}>
-            <Grid container direction='column' alignContent='center' spacing={1}>
-                <Card>
-                    <CardContent>
-                        <Grid container direction='row' alignItems='center' justifyContent='space-around'>
-                            <Grid item>
-                                <Typography variant='inherit' sx={{ wordBreak: 'break-word' }}>
-                                    {prompt.prompt}
-                                </Typography>
-                            </Grid>
-                            <Grid item paddingRight={0.5}>
-                                <IconButton onClick={() => handleClick(prompt)}>
-                                    <OpenInNewIcon />
-                                    <Typography variant='subtitle1'>View</Typography>
-                                </IconButton>
-                            </Grid>
-                        </Grid>
-                    </CardContent>
-                </Card>
-            </Grid>
-        </ListItem>
+        <Card sx={{ margin: '0.25rem' }}>
+            {prompt.isDraft ? (
+                <CardHeader
+                    title={
+                        <IconButton disabled={true}>
+                            <DescriptionIcon />
+                            <Typography>Draft</Typography>
+                        </IconButton>
+                    }
+                />
+            ) : null}
+            <CardContent>
+                <Grid container direction='row' alignItems='center' justifyContent='space-around'>
+                    <Grid item>
+                        <Typography variant='inherit' sx={{ wordBreak: 'break-word' }}>
+                            {prompt.prompt}
+                        </Typography>
+                    </Grid>
+                </Grid>
+            </CardContent>
+            <CardActions sx={{ justifyContent: 'center' }}>
+                {prompt.isDraft ? (
+                    <ShareFeedbackPromptDraft prompt={prompt} />
+                ) : (
+                    <IconButton onClick={() => handleClick(prompt)}>
+                        <OpenInNewIcon />
+                        <Typography variant='subtitle1'>View</Typography>
+                    </IconButton>
+                )}
+            </CardActions>
+        </Card>
     );
 }
 

--- a/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackPrompt/ShareFeedbackPromptDraft.tsx
+++ b/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackPrompt/ShareFeedbackPromptDraft.tsx
@@ -21,8 +21,7 @@ export const SHARE_PROMPT_DRAFT_MUTATION = graphql`
                 cursor
                 node {
                     id
-                    createdAt
-                    prompt
+                    isDraft
                 }
             }
         }
@@ -48,6 +47,11 @@ export function ShareFeedbackPromptDraft({ prompt }: Props) {
                         if (err instanceof Error) displaySnack(err.message, { variant: 'error' });
                         else displaySnack('Something went wrong!');
                     }
+                },
+                updater(store) {
+                    const promptRecord = store.get(prompt.id);
+                    if (!promptRecord) return console.error('Prompt not found in store');
+                    promptRecord.setValue(false, 'isDraft');
                 },
             });
         } catch (err) {

--- a/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackPrompt/ShareFeedbackPromptDraft.tsx
+++ b/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackPrompt/ShareFeedbackPromptDraft.tsx
@@ -1,0 +1,79 @@
+import * as React from 'react';
+import { Button, DialogContent, Grid, IconButton, Typography } from '@mui/material';
+import SendIcon from '@mui/icons-material/Send';
+import { useMutation, graphql } from 'react-relay';
+
+import type { ShareFeedbackPromptDraftMutation } from '@local/__generated__/ShareFeedbackPromptDraftMutation.graphql';
+import { ResponsiveDialog, useResponsiveDialog } from '@local/components/ResponsiveDialog';
+import { useSnack } from '@local/core';
+import { Prompt } from './LiveFeedbackPromptList';
+
+interface Props {
+    prompt: Prompt;
+}
+
+export const SHARE_PROMPT_DRAFT_MUTATION = graphql`
+    mutation ShareFeedbackPromptDraftMutation($promptId: ID!) {
+        shareFeedbackPromptDraft(promptId: $promptId) {
+            isError
+            message
+            body {
+                cursor
+                node {
+                    id
+                    createdAt
+                    prompt
+                }
+            }
+        }
+    }
+`;
+
+export function ShareFeedbackPromptDraft({ prompt }: Props) {
+    const [isOpen, open, close] = useResponsiveDialog();
+    const { displaySnack } = useSnack();
+    const [commit] = useMutation<ShareFeedbackPromptDraftMutation>(SHARE_PROMPT_DRAFT_MUTATION);
+
+    function handleSubmit() {
+        try {
+            commit({
+                variables: { promptId: prompt.id },
+                onCompleted(payload) {
+                    try {
+                        if (payload.shareFeedbackPromptDraft.isError)
+                            throw new Error(payload.shareFeedbackPromptDraft.message);
+                        close();
+                        displaySnack('Prompt submitted successfully!', { variant: 'success' });
+                    } catch (err) {
+                        if (err instanceof Error) displaySnack(err.message, { variant: 'error' });
+                        else displaySnack('Something went wrong!');
+                    }
+                },
+            });
+        } catch (err) {
+            if (err instanceof Error) displaySnack(err.message, { variant: 'error' });
+            else displaySnack('Something went wrong!');
+        }
+    }
+
+    return (
+        <React.Fragment>
+            <ResponsiveDialog open={isOpen} onClose={close}>
+                <DialogContent>
+                    <Typography variant='h6'>Are you sure you want to share this prompt?</Typography>
+                    <Typography variant='body1'>Prompt: {prompt.prompt}</Typography>
+                    <Grid container justifyContent='end'>
+                        <Button onClick={close}>Cancel</Button>
+                        <Button variant='contained' color='primary' onClick={handleSubmit}>
+                            Share
+                        </Button>
+                    </Grid>
+                </DialogContent>
+            </ResponsiveDialog>
+            <IconButton onClick={open}>
+                <SendIcon />
+                <Typography variant='subtitle1'>Share Draft</Typography>
+            </IconButton>
+        </React.Fragment>
+    );
+}

--- a/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackPrompt/SubmitLiveFeedbackPrompt.tsx
+++ b/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackPrompt/SubmitLiveFeedbackPrompt.tsx
@@ -15,26 +15,33 @@ import { isURL } from '@local/utils';
 interface Props {
     className?: string;
     eventId: string;
+    connections: string[];
 }
 
 export const SUBMIT_LIVE_FEEDBACK_PROMPT_MUTATION = graphql`
-    mutation SubmitLiveFeedbackPromptMutation($input: CreateFeedbackPrompt!) {
+    mutation SubmitLiveFeedbackPromptMutation($input: CreateFeedbackPrompt!, $connections: [ID!]!) {
         createFeedbackPrompt(input: $input) {
             isError
             message
-            body {
+            body @appendEdge(connections: $connections) {
                 cursor
                 node {
                     id
-                    createdAt
                     prompt
+                    isVote
+                    isOpenEnded
+                    isMultipleChoice
+                    multipleChoiceOptions
+                    createdAt
+                    isDraft
+                    ...useLiveFeedbackPromptResponsesFragment
                 }
             }
         }
     }
 `;
 
-export function SubmitLiveFeedbackPrompt({ className, eventId }: Props) {
+export function SubmitLiveFeedbackPrompt({ className, eventId, connections }: Props) {
     const [isOpen, open, close] = useResponsiveDialog();
     const { user } = useUser();
     const { displaySnack } = useSnack();
@@ -46,7 +53,7 @@ export function SubmitLiveFeedbackPrompt({ className, eventId }: Props) {
             if (form.prompt.length > FEEDBACK_PROMPT_MAX_LENGTH) throw new Error('Prompt is too long!');
             if (isURL(form.prompt)) throw new Error('no links are allowed!');
             commit({
-                variables: { input: { ...form, eventId, isDraft } },
+                variables: { input: { ...form, eventId, isDraft }, connections },
                 onCompleted(payload) {
                     try {
                         if (payload.createFeedbackPrompt.isError) throw new Error(payload.createFeedbackPrompt.message);

--- a/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackPrompt/SubmitLiveFeedbackPrompt.tsx
+++ b/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackPrompt/SubmitLiveFeedbackPrompt.tsx
@@ -40,13 +40,13 @@ export function SubmitLiveFeedbackPrompt({ className, eventId }: Props) {
     const { displaySnack } = useSnack();
     const [commit] = useMutation<SubmitLiveFeedbackPromptMutation>(SUBMIT_LIVE_FEEDBACK_PROMPT_MUTATION);
 
-    function handleSubmit(form: TLiveFeedbackPromptFormState) {
+    function handleSubmit(form: TLiveFeedbackPromptFormState, isDraft: boolean = false) {
         try {
             // Validate length and url presence before submitting to avoid unessisary serverside validation
             if (form.prompt.length > FEEDBACK_PROMPT_MAX_LENGTH) throw new Error('Prompt is too long!');
             if (isURL(form.prompt)) throw new Error('no links are allowed!');
             commit({
-                variables: { input: { ...form, eventId } },
+                variables: { input: { ...form, eventId, isDraft } },
                 onCompleted(payload) {
                     try {
                         if (payload.createFeedbackPrompt.isError) throw new Error(payload.createFeedbackPrompt.message);

--- a/app/client/src/features/events/LiveFeedbackPrompts/ShareFeedbackResults.tsx
+++ b/app/client/src/features/events/LiveFeedbackPrompts/ShareFeedbackResults.tsx
@@ -26,7 +26,8 @@ export function ShareFeedbackResults() {
             </Button>
             <StyledDialog
                 fullScreen={fullscreen}
-                maxWidth='lg'
+                maxWidth='md'
+                fullWidth
                 scroll='paper'
                 open={open}
                 onClose={handleClose}

--- a/app/client/src/features/events/LiveFeedbackPrompts/ShareFeedbackResults.tsx
+++ b/app/client/src/features/events/LiveFeedbackPrompts/ShareFeedbackResults.tsx
@@ -1,18 +1,23 @@
 import * as React from 'react';
-import { Button, Typography, Grid, DialogContent } from '@mui/material';
-import { PresentToAll as PresentToAllIcon } from '@mui/icons-material';
+import { Button, Grid, DialogContent } from '@mui/material';
+import DashboardIcon from '@mui/icons-material/Dashboard';
 import { useTheme } from '@mui/material/styles';
 import useMediaQuery from '@mui/material/useMediaQuery';
 
-import { PreloadedLiveFeedbackPromptList } from './LiveFeedbackPrompt/LiveFeedbackPromptList';
-import { ConditionalRender, Loader, StyledDialogTitle, StyledDialog } from '@local/components';
+import { StyledDialogTitle, StyledDialog } from '@local/components';
+import { useLiveFeedbackPromptsFragment$key } from '@local/__generated__/useLiveFeedbackPromptsFragment.graphql';
+import { FeedbackPromptsList } from './LiveFeedbackPrompt/FeedbackPromptsList';
+
+interface ShareFeedbackResultsProps {
+    fragmentRef: useLiveFeedbackPromptsFragment$key;
+}
 
 /**
  * A modal that opens when moderators click on the "Share Feedback Results" button
  * A list of previous feedback prompts are displayed, and moderators can click on each one to see the responses
  * A button can be pressed to share the results card for one of the prompts with the audience
  */
-export function ShareFeedbackResults() {
+export function ShareFeedbackResults({ fragmentRef }: ShareFeedbackResultsProps) {
     const theme = useTheme();
     const fullscreen = useMediaQuery(theme.breakpoints.down('md'));
     const [open, setOpen] = React.useState(false);
@@ -21,8 +26,8 @@ export function ShareFeedbackResults() {
 
     return (
         <React.Fragment>
-            <Button variant='contained' color='primary' onClick={handleOpen} startIcon={<PresentToAllIcon />}>
-                Share Feedback Results
+            <Button variant='contained' color='primary' onClick={handleOpen} startIcon={<DashboardIcon />}>
+                Feedback Dashboard
             </Button>
             <StyledDialog
                 fullScreen={fullscreen}
@@ -34,16 +39,11 @@ export function ShareFeedbackResults() {
                 aria-labelledby='share-feedback-results-dialog'
             >
                 <StyledDialogTitle id='share-feedback-results-dialog-title' onClose={handleClose}>
-                    Share Feedback Results
+                    Feedback Dashboard
                 </StyledDialogTitle>
                 <DialogContent dividers>
                     <Grid container direction='column' alignItems='center'>
-                        <Typography variant='h6'>Select view on a prompt to see its responses</Typography>
-                        <ConditionalRender client>
-                            <React.Suspense fallback={<Loader />}>
-                                <PreloadedLiveFeedbackPromptList />
-                            </React.Suspense>
-                        </ConditionalRender>
+                        <FeedbackPromptsList fragmentRef={fragmentRef} isShareResultsOpen={open} />
                     </Grid>
                 </DialogContent>
             </StyledDialog>

--- a/app/client/src/features/events/LiveFeedbackPrompts/useLiveFeedbackPrompt.tsx
+++ b/app/client/src/features/events/LiveFeedbackPrompts/useLiveFeedbackPrompt.tsx
@@ -11,6 +11,7 @@ export const USE_LIVE_FEEDBACK_PROMPT_SUBSCRIPTION = graphql`
             id
             prompt
             isVote
+            isDraft
             isOpenEnded
             isMultipleChoice
             multipleChoiceOptions

--- a/app/client/src/features/events/Moderation/ModeratorActions.tsx
+++ b/app/client/src/features/events/Moderation/ModeratorActions.tsx
@@ -6,6 +6,8 @@ import type { ModeratorActionsStartEventMutation } from '@local/__generated__/Mo
 import type { ModeratorActionsEndEventMutation } from '@local/__generated__/ModeratorActionsEndEventMutation.graphql';
 import { useSnack } from '@local/core';
 import { ConfirmationDialog } from '@local/components/ConfirmationDialog';
+import { ShareFeedbackResults } from '../LiveFeedbackPrompts';
+import { useLiveFeedbackPromptsFragment$key } from '@local/__generated__/useLiveFeedbackPromptsFragment.graphql';
 
 export const START_EVENT_MUTATION = graphql`
     mutation ModeratorActionsStartEventMutation($eventId: String!) {
@@ -27,9 +29,10 @@ export interface ModeratorActionsProps {
     isLive: Boolean;
     setIsLive: React.Dispatch<React.SetStateAction<boolean>>;
     eventId: string;
+    fragmentRef: useLiveFeedbackPromptsFragment$key;
 }
 
-export function ModeratorActions({ isLive, setIsLive, eventId }: ModeratorActionsProps) {
+export function ModeratorActions({ isLive, setIsLive, eventId, fragmentRef }: ModeratorActionsProps) {
     const { displaySnack } = useSnack();
     const [isConfirmationDialogOpen, setIsConfirmationDialogOpen] = React.useState(false);
 
@@ -85,6 +88,9 @@ export function ModeratorActions({ isLive, setIsLive, eventId }: ModeratorAction
                 <Button variant='contained' color={isLive ? 'error' : 'success'} onClick={openConfirmationDialog}>
                     {isLive ? 'End Event' : 'Start Event'}
                 </Button>
+                <React.Suspense fallback={<ShareFeedbackResults fragmentRef={fragmentRef} />}>
+                    <ShareFeedbackResults fragmentRef={fragmentRef} />
+                </React.Suspense>
             </Stack>
             <ConfirmationDialog
                 title='Update Event Status'

--- a/app/client/src/features/events/ModeratorView/ActionsPanels.tsx
+++ b/app/client/src/features/events/ModeratorView/ActionsPanels.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable react/prop-types */
 import * as React from 'react';
+import { FragmentRefs, graphql } from 'relay-runtime';
 import { Badge, Grid, Stack, Tab, Tooltip } from '@mui/material';
 import PeopleAltIcon from '@mui/icons-material/PeopleAlt';
 import HandymanIcon from '@mui/icons-material/Handyman';
@@ -7,7 +8,7 @@ import PodcastsIcon from '@mui/icons-material/Podcasts';
 import FeedbackIcon from '@mui/icons-material/Feedback';
 import { Panel, PanelGroup } from 'react-resizable-panels';
 
-import { EventVideo } from '@local/features/events';
+import { EventVideo, useEvent } from '@local/features/events';
 import { EventDetailsCard } from '../EventDetailsCard';
 import { SpeakerList } from '../Speakers';
 
@@ -17,18 +18,39 @@ import { StyledColumnGrid } from '@local/components/StyledColumnGrid';
 import { StyledTabs } from '@local/components/StyledTabs';
 import { LiveFeedbackList } from '../LiveFeedback';
 import { BroadcastMessageList } from '../BroadcastMessages/BroadcastMessageList';
-import { Node } from './EventLiveNewModeratorView';
-import { useEventDetailsFragment$data } from '@local/__generated__/useEventDetailsFragment.graphql';
 import { HorizontalResizeHandle } from '@local/components/PanelHandle';
+import { PreloadedQuery, usePreloadedQuery, useQueryLoader } from 'react-relay';
+import { ActionsPanelsQuery } from '@local/__generated__/ActionsPanelsQuery.graphql';
+import { ConditionalRender, Loader } from '@local/components';
+import { useEventDetails } from '../useEventDetails';
+
+export const ACTIONS_PANELS_QUERY = graphql`
+    query ActionsPanelsQuery($eventId: ID!) {
+        node(id: $eventId) {
+            id
+            ...EventVideoFragment
+            ...SpeakerListFragment
+            ...useBroadcastMessageListFragment
+            ...useEventDetailsFragment
+            ...useLiveFeedbackListFragment @arguments(eventId: $eventId)
+            ...useLiveFeedbackPromptsFragment
+        }
+    }
+`;
+
+export type ActionsPanelsNode = {
+    readonly id: string;
+    readonly ' $fragmentSpreads': FragmentRefs<any>;
+};
 
 interface ActionsPanelProps {
-    node: Node;
-    eventData: useEventDetailsFragment$data;
-    isLive: boolean;
-    setIsLive: React.Dispatch<React.SetStateAction<boolean>>;
+    node: ActionsPanelsNode;
 }
 
-export function ActionsPanels({ node, eventData, isLive, setIsLive }: ActionsPanelProps) {
+function ActionsPanels({ node }: ActionsPanelProps) {
+    const { eventData, isLive, setIsLive } = useEventDetails({
+        fragmentRef: node,
+    });
     type Tabs = 'Moderator' | 'Feedback' | 'Broadcast' | 'Participants';
     const selectedTabFromSession = sessionStorage.getItem(`${node.id}-tab`) as Tabs | null;
     const [tab, setTab] = React.useState<Tabs>(selectedTabFromSession ?? 'Moderator');
@@ -193,7 +215,12 @@ export function ActionsPanels({ node, eventData, isLive, setIsLive }: ActionsPan
                     >
                         {tab === 'Participants' && <PreloadedParticipantsList eventId={eventData.id} />}
                         {tab === 'Moderator' && (
-                            <ModeratorActions isLive={isLive} setIsLive={setIsLive} eventId={eventData.id} />
+                            <ModeratorActions
+                                fragmentRef={node}
+                                isLive={isLive}
+                                setIsLive={setIsLive}
+                                eventId={eventData.id}
+                            />
                         )}
                         <BroadcastMessageList fragmentRef={node} isVisible={tab === 'Broadcast'} />
                         <LiveFeedbackList
@@ -205,5 +232,36 @@ export function ActionsPanels({ node, eventData, isLive, setIsLive }: ActionsPan
                 </Stack>
             </Panel>
         </PanelGroup>
+    );
+}
+
+interface ActionsPanelsContainerProps {
+    queryRef: PreloadedQuery<ActionsPanelsQuery>;
+}
+
+function ActionsPanelsContainer({ queryRef }: ActionsPanelsContainerProps) {
+    const { node } = usePreloadedQuery<ActionsPanelsQuery>(ACTIONS_PANELS_QUERY, queryRef);
+
+    if (!node) return null;
+    return <ActionsPanels node={node} />;
+}
+
+export function PreloadedActionsPanels() {
+    const [queryRef, loadQuery, disposeQuery] = useQueryLoader<ActionsPanelsQuery>(ACTIONS_PANELS_QUERY);
+    const { eventId } = useEvent();
+
+    React.useEffect(() => {
+        if (!queryRef) loadQuery({ eventId });
+        return disposeQuery;
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+    if (!queryRef) return <Loader />;
+
+    return (
+        <ConditionalRender client={true}>
+            <React.Suspense fallback={<Loader />}>
+                <ActionsPanelsContainer queryRef={queryRef} />
+            </React.Suspense>
+        </ConditionalRender>
     );
 }

--- a/app/client/src/features/events/ModeratorView/ActionsPanels.tsx
+++ b/app/client/src/features/events/ModeratorView/ActionsPanels.tsx
@@ -172,31 +172,31 @@ function ActionsPanels({ node }: ActionsPanelProps) {
                         />
                         <Tab
                             label={
-                                <Tooltip
-                                    title='Feedback'
-                                    placement='top'
-                                    slotProps={{
-                                        popper: {
-                                            modifiers: [
-                                                {
-                                                    name: 'offset',
-                                                    options: {
-                                                        offset: [0, +2],
+                                <React.Fragment>
+                                    <Tooltip
+                                        title='Messages'
+                                        placement='top'
+                                        slotProps={{
+                                            popper: {
+                                                modifiers: [
+                                                    {
+                                                        name: 'offset',
+                                                        options: {
+                                                            offset: [0, +2],
+                                                        },
                                                     },
-                                                },
-                                            ],
-                                        },
-                                    }}
-                                >
-                                    <React.Fragment>
+                                                ],
+                                            },
+                                        }}
+                                    >
                                         <FeedbackIcon />
-                                        <Badge
-                                            badgeContent={numOfFeedbackMsgs}
-                                            color='error'
-                                            sx={{ transform: 'translate(25px, -23px)' }}
-                                        />
-                                    </React.Fragment>
-                                </Tooltip>
+                                    </Tooltip>
+                                    <Badge
+                                        badgeContent={numOfFeedbackMsgs}
+                                        color='error'
+                                        sx={{ transform: 'translate(25px, -23px)' }}
+                                    />
+                                </React.Fragment>
                             }
                             value='Feedback'
                             sx={{

--- a/app/client/src/features/events/ModeratorView/EventLiveNewModeratorView.tsx
+++ b/app/client/src/features/events/ModeratorView/EventLiveNewModeratorView.tsx
@@ -14,7 +14,7 @@ import { useEventDetails } from '../useEventDetails';
 import { usePingEvent } from '../Participants/usePingEvent';
 
 import { EventLiveNewModeratorViewQuery } from '@local/__generated__/EventLiveNewModeratorViewQuery.graphql';
-import { ActionsPanels } from './ActionsPanels';
+import { PreloadedActionsPanels } from './ActionsPanels';
 import { QuestionModerationPanels } from './QuestionModerationPanels';
 import { VerticalPanelResizeHandle } from '@local/components/PanelHandle';
 import { useUser } from '@local/features/accounts';
@@ -32,14 +32,9 @@ export const EVENT_LIVE_MODERATOR_VIEW_QUERY = graphql`
                     topic
                     description
                 }
-                ...useBroadcastMessageListFragment
-                ...EventVideoFragment
                 ...useEventDetailsFragment
-                ...SpeakerListFragment
-                ...useBroadcastMessageListFragment
                 ...useQuestionQueueFragment @arguments(userLang: $userLang)
                 ...QuestionCarouselFragment @arguments(userLang: $userLang)
-                ...useLiveFeedbackListFragment @arguments(eventId: $eventId)
                 ...useQuestionsByTopicFragment @arguments(userLang: $userLang)
                 ...useQueueByTopicFragment @arguments(userLang: $userLang)
                 ...useOnDeckFragment @arguments(userLang: $userLang)
@@ -64,7 +59,7 @@ interface EventLiveProps {
 function EventLiveNewModeratorView({ node, refresh }: EventLiveProps) {
     const theme = useTheme();
     const isXlDownBreakpoint = useMediaQuery(theme.breakpoints.down('xl')); // Below 1080p (likely 720p)
-    const { eventData, isLive, setIsLive, pauseEventDetailsRefresh, resumeEventDetailsRefresh } = useEventDetails({
+    const { eventData, pauseEventDetailsRefresh, resumeEventDetailsRefresh } = useEventDetails({
         fragmentRef: node,
     });
     const { id: eventId } = node;
@@ -94,7 +89,7 @@ function EventLiveNewModeratorView({ node, refresh }: EventLiveProps) {
             <PanelGroup direction='horizontal'>
                 <Panel defaultSize={isXlDownBreakpoint ? 30 : 20} minSize={isXlDownBreakpoint ? 25 : 18} maxSize={40}>
                     <React.Suspense fallback={<Loader />}>
-                        <ActionsPanels node={node} eventData={eventData} isLive={isLive} setIsLive={setIsLive} />
+                        <PreloadedActionsPanels />
                     </React.Suspense>
                 </Panel>
                 <VerticalPanelResizeHandle />

--- a/app/client/src/graphql-types.ts
+++ b/app/client/src/graphql-types.ts
@@ -67,6 +67,7 @@ export type CreateFeedbackPrompt = {
   choices: Array<Scalars['String']>;
   eventId: Scalars['ID'];
   feedbackType: Scalars['String'];
+  isDraft: Scalars['Boolean'];
   prompt: Scalars['String'];
 };
 
@@ -447,6 +448,7 @@ export type EventLiveFeedbackPrompt = Node & {
   createdAt?: Maybe<Scalars['Date']>;
   event?: Maybe<Event>;
   id: Scalars['ID'];
+  isDraft?: Maybe<Scalars['Boolean']>;
   isMultipleChoice?: Maybe<Scalars['Boolean']>;
   isOpenEnded?: Maybe<Scalars['Boolean']>;
   isVote?: Maybe<Scalars['Boolean']>;
@@ -823,6 +825,7 @@ export type Mutation = {
    * returns false if an account with the provided email cannot be found
    */
   resetPasswordRequest: ResetPasswordRequestMutationResponse;
+  shareFeedbackPromptDraft: EventFeedbackPromptMutationResponse;
   shareFeedbackPromptResults: EventFeedbackPromptMutationResponse;
   /** Start the event so that it is "live" */
   startEvent: EventMutationResponse;
@@ -1110,6 +1113,11 @@ export type MutationResetPasswordArgs = {
 
 export type MutationResetPasswordRequestArgs = {
   input: ResetPasswordRequestForm;
+};
+
+
+export type MutationShareFeedbackPromptDraftArgs = {
+  promptId: Scalars['ID'];
 };
 
 

--- a/app/server/prisma/migrations/20240709052415_add_is_draft_to_feedback_prompt/migration.sql
+++ b/app/server/prisma/migrations/20240709052415_add_is_draft_to_feedback_prompt/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "EventLiveFeedbackPrompt" ADD COLUMN     "isDraft" BOOLEAN NOT NULL DEFAULT false;

--- a/app/server/prisma/schema.prisma
+++ b/app/server/prisma/schema.prisma
@@ -155,6 +155,7 @@ model EventLiveFeedbackPrompt {
     isOpenEnded Boolean @default(false)
     isMultipleChoice Boolean @default(false)
     multipleChoiceOptions String[] @default([]) // Format is ["option1", "option2"]
+    isDraft Boolean @default(false)
     responses EventLiveFeedbackPromptResponse[]
 }
 

--- a/app/server/src/features/events/feedback/methods.ts
+++ b/app/server/src/features/events/feedback/methods.ts
@@ -23,8 +23,15 @@ export async function promptResponses(promptId: string, prisma: PrismaClient) {
     });
 }
 
-export async function findPromptByPromptId(promptId: string, prisma: PrismaClient) {
+export function findPromptByPromptId(promptId: string, prisma: PrismaClient) {
     return prisma.eventLiveFeedbackPrompt.findUnique({ where: { id: promptId } });
+}
+
+export function shareFeedbackPromptDraft(promptId: string, prisma: PrismaClient) {
+    return prisma.eventLiveFeedbackPrompt.update({
+        where: { id: promptId },
+        data: { isDraft: false },
+    });
 }
 
 export async function findPromptsByEventId(eventId: string, prisma: PrismaClient) {
@@ -91,6 +98,7 @@ export async function createFeedbackPrompt(
             isOpenEnded: feedbackType === 'open-ended',
             isMultipleChoice: feedbackType === 'multiple-choice',
             multipleChoiceOptions: input.choices,
+            isDraft: input.isDraft,
         },
     });
 }

--- a/app/server/src/features/events/feedback/schema.graphql
+++ b/app/server/src/features/events/feedback/schema.graphql
@@ -20,6 +20,7 @@ type EventLiveFeedbackPrompt implements Node {
     isOpenEnded: Boolean
     isMultipleChoice: Boolean
     multipleChoiceOptions: [String!]
+    isDraft: Boolean
     responses(first: Int, after: String): EventLiveFeedbackPromptResponseConnection
 }
 
@@ -121,6 +122,7 @@ input CreateFeedbackPrompt {
     eventId: ID!
     feedbackType: String!
     choices: [String!]!
+    isDraft: Boolean!
 }
 
 input CreateFeedbackPromptResponse {
@@ -141,6 +143,7 @@ type Mutation {
     createFeedback(input: CreateFeedback!): EventFeedbackMutationResponse!
     createFeedbackDM(input: CreateFeedbackDM!): EventFeedbackMutationResponse!
     createFeedbackPrompt(input: CreateFeedbackPrompt!): EventFeedbackPromptMutationResponse!
+    shareFeedbackPromptDraft(promptId: ID!): EventFeedbackPromptMutationResponse!
     createFeedbackPromptResponse(input: CreateFeedbackPromptResponse!): EventFeedbackPromptResponseMutationResponse!
     shareFeedbackPromptResults(eventId: ID!, promptId: ID!): EventFeedbackPromptMutationResponse!
     submitPostEventFeedback(feedback: String!, eventId: ID!): PostEventFeedbackMutationResponse!

--- a/app/server/src/graphql-types.ts
+++ b/app/server/src/graphql-types.ts
@@ -351,6 +351,7 @@ export type Mutation = {
     createFeedback: EventFeedbackMutationResponse;
     createFeedbackDM: EventFeedbackMutationResponse;
     createFeedbackPrompt: EventFeedbackPromptMutationResponse;
+    shareFeedbackPromptDraft: EventFeedbackPromptMutationResponse;
     createFeedbackPromptResponse: EventFeedbackPromptResponseMutationResponse;
     shareFeedbackPromptResults: EventFeedbackPromptMutationResponse;
     submitPostEventFeedback: PostEventFeedbackMutationResponse;
@@ -519,6 +520,10 @@ export type MutationcreateFeedbackDMArgs = {
 
 export type MutationcreateFeedbackPromptArgs = {
     input: CreateFeedbackPrompt;
+};
+
+export type MutationshareFeedbackPromptDraftArgs = {
+    promptId: Scalars['ID'];
 };
 
 export type MutationcreateFeedbackPromptResponseArgs = {
@@ -1218,6 +1223,7 @@ export type EventLiveFeedbackPrompt = Node & {
     isOpenEnded?: Maybe<Scalars['Boolean']>;
     isMultipleChoice?: Maybe<Scalars['Boolean']>;
     multipleChoiceOptions?: Maybe<Array<Scalars['String']>>;
+    isDraft?: Maybe<Scalars['Boolean']>;
     responses?: Maybe<EventLiveFeedbackPromptResponseConnection>;
 };
 
@@ -1336,6 +1342,7 @@ export type CreateFeedbackPrompt = {
     eventId: Scalars['ID'];
     feedbackType: Scalars['String'];
     choices: Array<Scalars['String']>;
+    isDraft: Scalars['Boolean'];
 };
 
 export type CreateFeedbackPromptResponse = {
@@ -2647,6 +2654,12 @@ export type MutationResolvers<
         ContextType,
         RequireFields<MutationcreateFeedbackPromptArgs, 'input'>
     >;
+    shareFeedbackPromptDraft?: Resolver<
+        ResolversTypes['EventFeedbackPromptMutationResponse'],
+        ParentType,
+        ContextType,
+        RequireFields<MutationshareFeedbackPromptDraftArgs, 'promptId'>
+    >;
     createFeedbackPromptResponse?: Resolver<
         ResolversTypes['EventFeedbackPromptResponseMutationResponse'],
         ParentType,
@@ -3396,6 +3409,7 @@ export type EventLiveFeedbackPromptResolvers<
     isOpenEnded?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
     isMultipleChoice?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
     multipleChoiceOptions?: Resolver<Maybe<Array<ResolversTypes['String']>>, ParentType, ContextType>;
+    isDraft?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
     responses?: Resolver<
         Maybe<ResolversTypes['EventLiveFeedbackPromptResponseConnection']>,
         ParentType,
@@ -4246,6 +4260,7 @@ export interface Loaders<TContext = import('mercurius').MercuriusContext & { rep
         isOpenEnded?: LoaderResolver<Maybe<Scalars['Boolean']>, EventLiveFeedbackPrompt, {}, TContext>;
         isMultipleChoice?: LoaderResolver<Maybe<Scalars['Boolean']>, EventLiveFeedbackPrompt, {}, TContext>;
         multipleChoiceOptions?: LoaderResolver<Maybe<Array<Scalars['String']>>, EventLiveFeedbackPrompt, {}, TContext>;
+        isDraft?: LoaderResolver<Maybe<Scalars['Boolean']>, EventLiveFeedbackPrompt, {}, TContext>;
         responses?: LoaderResolver<
             Maybe<EventLiveFeedbackPromptResponseConnection>,
             EventLiveFeedbackPrompt,


### PR DESCRIPTION
- Ability to create a feedback prompt draft rather than having it be sent to participants immediately. 
- This way a moderator could set up prompts before hand and easily deploy them to participants when ready without needing to write them each time.
- Moved mod actions fragments to a separate query
- Updated to using connections fragment for the feedback prompt lists
- Updated share draft mutation to immediately update local state (so user doesn't need to wait for polling update to see that it was shared).
- Updated name of feedback tab to "messages" since feedback prompting was moved.