### PR TITLE
Migrate to Gcloud Memorystore Redis Cluster

### DIFF
--- a/app/moderation-algo/main.py
+++ b/app/moderation-algo/main.py
@@ -64,26 +64,15 @@ def ProcessQuestion(issue: str, topics: dict, question: str) -> dict:
 def ConnectToRedis() -> redis.Redis:
     "Establish a connection to Redis for temporary persistent memory. Returns the connection object."
     # Get connection details from environment variables
-    REDIS_HOST = os.environ.get('REDIS_HOST')
-    REDIS_PORT = os.environ.get('REDIS_PORT')
-    REDIS_USERNAME = os.environ.get('REDIS_USERNAME')
-    REDIS_PASSWORD = os.environ.get('REDIS_PASSWORD')
+    REDIS_HOST = os.environ.get('REDIS_HOST', 'localhost')
+    REDIS_PORT = os.environ.get('REDIS_PORT', 6379)
+    REDIS_USERNAME = os.environ.get('REDIS_USERNAME', None)
+    REDIS_PASSWORD = os.environ.get('REDIS_PASSWORD', None)
     NODE_ENV = os.environ.get('NODE_ENV')
     if NODE_ENV == 'production':
-        nodes = list()
-        REDIS_HOST_NODE_1 = os.environ.get('REDIS_HOST_1')
-        REDIS_HOST_NODE_2 = os.environ.get('REDIS_HOST_2')
-        REDIS_HOST_NODE_3 = os.environ.get('REDIS_HOST_3')
-        REDIS_HOST_NODE_4 = os.environ.get('REDIS_HOST_4')
-        REDIS_HOST_NODE_5 = os.environ.get('REDIS_HOST_5')
-        REDIS_HOST_NODE_6 = os.environ.get('REDIS_HOST_6')
-        nodes.append(ClusterNode(host=REDIS_HOST_NODE_1, port=REDIS_PORT))
-        nodes.append(ClusterNode(host=REDIS_HOST_NODE_2, port=REDIS_PORT))
-        nodes.append(ClusterNode(host=REDIS_HOST_NODE_3, port=REDIS_PORT))
-        nodes.append(ClusterNode(host=REDIS_HOST_NODE_4, port=REDIS_PORT))
-        nodes.append(ClusterNode(host=REDIS_HOST_NODE_5, port=REDIS_PORT))
-        nodes.append(ClusterNode(host=REDIS_HOST_NODE_6, port=REDIS_PORT))
-        return RedisCluster(startup_nodes=nodes, host=REDIS_HOST, port=REDIS_PORT)
+        startup_nodes = [ClusterNode(host=REDIS_HOST, port=REDIS_PORT)]
+        return RedisCluster(startup_nodes=startup_nodes, skip_full_coverage_check=True, decode_responses=True, 
+                            socket_timeout=5, socket_connect_timeout=5)
     return redis.StrictRedis(host=REDIS_HOST, port=REDIS_PORT, username=REDIS_USERNAME, password=REDIS_PASSWORD,
                             charset='utf-8', decode_responses=True)
 

--- a/k8s/moderation-algo/development/moderation-algo-configmap.yml
+++ b/k8s/moderation-algo/development/moderation-algo-configmap.yml
@@ -9,12 +9,6 @@ data:
     HOST: 0.0.0.0
     NODE_ENV: production
     GCP_PROJECT_ID: prytaneum-project
-    REDIS_HOST: staging-redis-cluster.development.svc.cluster.local
-    REDIS_HOST_NODE_1: staging-redis-cluster-0.development.svc.cluster.local
-    REDIS_HOST_NODE_2: staging-redis-cluster-1.development.svc.cluster.local
-    REDIS_HOST_NODE_3: staging-redis-cluster-2.development.svc.cluster.local
-    REDIS_HOST_NODE_4: staging-redis-cluster-3.development.svc.cluster.local
-    REDIS_HOST_NODE_5: staging-redis-cluster-4.development.svc.cluster.local
-    REDIS_HOST_NODE_6: staging-redis-cluster-5.development.svc.cluster.local
+    REDIS_HOST: 10.128.15.195 # Memstore IP
     REDIS_PORT: '6379'
     REDIS_USERNAME: default

--- a/k8s/moderation-algo/production/moderation-algo-configmap.yml
+++ b/k8s/moderation-algo/production/moderation-algo-configmap.yml
@@ -9,12 +9,6 @@ data:
     HOST: 0.0.0.0
     NODE_ENV: production
     GCP_PROJECT_ID: prytaneum-project
-    REDIS_HOST: prod-redis-cluster.production.svc.cluster.local
-    REDIS_HOST_NODE_1: prod-redis-cluster-0.production.svc.cluster.local
-    REDIS_HOST_NODE_2: prod-redis-cluster-1.production.svc.cluster.local
-    REDIS_HOST_NODE_3: prod-redis-cluster-2.production.svc.cluster.local
-    REDIS_HOST_NODE_4: prod-redis-cluster-3.production.svc.cluster.local
-    REDIS_HOST_NODE_5: prod-redis-cluster-4.production.svc.cluster.local
-    REDIS_HOST_NODE_6: prod-redis-cluster-5.production.svc.cluster.local
+    REDIS_HOST: 10.128.15.195 # Memstore IP
     REDIS_PORT: '6379'
     REDIS_USERNAME: default

--- a/k8s/server/development/prytaneum-server-configmap.yml
+++ b/k8s/server/development/prytaneum-server-configmap.yml
@@ -11,7 +11,7 @@ data:
     SERVER_PORT: '3002'
     GCP_PROJECT_ID: prytaneum-project
     PUB_SUB_PREFIX: projects/prytaneum-project/topics/
-    REDIS_HOST: staging-redis-cluster.development.svc.cluster.local
+    REDIS_HOST: 10.128.15.195 # Memstore IP
     REDIS_PORT: '6379'
     GCLOUD_ISSUE_GUIDES_STORAGE_BUCKET: prytaneum-issue-guides
     MODERATION_URL: http://10.112.10.193:5000/

--- a/k8s/server/production/prytaneum-server-configmap.yml
+++ b/k8s/server/production/prytaneum-server-configmap.yml
@@ -11,7 +11,7 @@ data:
     SERVER_PORT: '3002'
     GCP_PROJECT_ID: prytaneum-project
     PUB_SUB_PREFIX: projects/prytaneum-project/topics/
-    REDIS_HOST: prod-redis-cluster.production.svc.cluster.local
+    REDIS_HOST: 10.128.15.195 # Memstore IP
     REDIS_PORT: '6379'
     GCLOUD_ISSUE_GUIDES_STORAGE_BUCKET: prytaneum-issue-guides
     MODERATION_URL: http://10.112.10.190:5000/


### PR DESCRIPTION
- Was using a redis-cluster deployed within the GKE cluster
- Updating to use google cloud's memorystore redis cluster. This should be more robust and possibly less latency as well as being easier to observe and maintain.
- Might help with some of the pub/sub missed messages issue.