### PR TITLE
Redis cluster to instance migration

### DIFF
--- a/app/moderation-algo/main.py
+++ b/app/moderation-algo/main.py
@@ -70,9 +70,7 @@ def ConnectToRedis() -> redis.Redis:
     REDIS_PASSWORD = os.environ.get('REDIS_PASSWORD', None)
     NODE_ENV = os.environ.get('NODE_ENV')
     if NODE_ENV == 'production':
-        startup_nodes = [ClusterNode(host=REDIS_HOST, port=REDIS_PORT)]
-        return RedisCluster(startup_nodes=startup_nodes, skip_full_coverage_check=True, decode_responses=True, 
-                            socket_timeout=5, socket_connect_timeout=5)
+        return redis.StrictRedis(host=REDIS_HOST, port=REDIS_PORT, charset='utf-8', decode_responses=True)
     return redis.StrictRedis(host=REDIS_HOST, port=REDIS_PORT, username=REDIS_USERNAME, password=REDIS_PASSWORD,
                             charset='utf-8', decode_responses=True)
 

--- a/k8s/moderation-algo/development/moderation-algo-configmap.yml
+++ b/k8s/moderation-algo/development/moderation-algo-configmap.yml
@@ -9,6 +9,6 @@ data:
     HOST: 0.0.0.0
     NODE_ENV: production
     GCP_PROJECT_ID: prytaneum-project
-    REDIS_HOST: 10.128.15.195 # Memstore IP
+    REDIS_HOST: 10.169.113.211 # GCloud Memorystore Redis Instance IP
     REDIS_PORT: '6379'
     REDIS_USERNAME: default

--- a/k8s/moderation-algo/production/moderation-algo-configmap.yml
+++ b/k8s/moderation-algo/production/moderation-algo-configmap.yml
@@ -9,6 +9,6 @@ data:
     HOST: 0.0.0.0
     NODE_ENV: production
     GCP_PROJECT_ID: prytaneum-project
-    REDIS_HOST: 10.128.15.195 # Memstore IP
+    REDIS_HOST: 10.169.113.211 # GCloud Memorystore Redis Instance IP
     REDIS_PORT: '6379'
     REDIS_USERNAME: default

--- a/k8s/server/development/prytaneum-server-configmap.yml
+++ b/k8s/server/development/prytaneum-server-configmap.yml
@@ -11,7 +11,7 @@ data:
     SERVER_PORT: '3002'
     GCP_PROJECT_ID: prytaneum-project
     PUB_SUB_PREFIX: projects/prytaneum-project/topics/
-    REDIS_HOST: 10.128.15.195 # Memstore IP
+    REDIS_HOST: 10.169.113.211 # GCloud Memorystore Redis Instance IP
     REDIS_PORT: '6379'
     GCLOUD_ISSUE_GUIDES_STORAGE_BUCKET: prytaneum-issue-guides
     MODERATION_URL: http://10.112.10.193:5000/

--- a/k8s/server/production/prytaneum-server-configmap.yml
+++ b/k8s/server/production/prytaneum-server-configmap.yml
@@ -11,7 +11,7 @@ data:
     SERVER_PORT: '3002'
     GCP_PROJECT_ID: prytaneum-project
     PUB_SUB_PREFIX: projects/prytaneum-project/topics/
-    REDIS_HOST: 10.128.15.195 # Memstore IP
+    REDIS_HOST: 10.169.113.211 # GCloud Memorystore Redis Instance IP
     REDIS_PORT: '6379'
     GCLOUD_ISSUE_GUIDES_STORAGE_BUCKET: prytaneum-issue-guides
     MODERATION_URL: http://10.112.10.190:5000/


### PR DESCRIPTION
- Limitations with redis cluster causing issues with pub/sub horizontal scalability (messages not propagated if connections made to different node/shard)
- Since redis is being used as a pub/sub by the server we need to use an instance rather than a cluster
- Eventually want to migrate to using gcloud pub/sub rather than redis, but for current implementation this migration should provide improved message consistency. 