### PR TITLE
Prompt response summarization caching

### DIFF
--- a/app/server/src/core/utils/prisma.ts
+++ b/app/server/src/core/utils/prisma.ts
@@ -1,11 +1,14 @@
 import type { FastifyBaseLogger } from 'fastify';
 
 import { PrismaClient } from '@local/__generated__/prisma';
+import { getOrCreateServer } from '../server';
+
+const server = getOrCreateServer();
 
 // Prisma client must be a singleton
 let _prisma: PrismaClient | null = null;
 
-export function getPrismaClient(logger: FastifyBaseLogger) {
+export function getPrismaClient(logger: FastifyBaseLogger = server.log): PrismaClient {
     const prisma = _prisma ?? new PrismaClient();
     if (!_prisma) {
         logger.debug('Instantiating new prisma client.');

--- a/app/server/src/core/utils/redis.ts
+++ b/app/server/src/core/utils/redis.ts
@@ -1,12 +1,15 @@
 import type { FastifyBaseLogger } from 'fastify';
-import { Redis, Cluster } from 'ioredis';
+import { Redis } from 'ioredis';
 // @ts-ignore - MockRedis is not typed
 import MockRedis from 'ioredis-mock';
+import { getOrCreateServer } from '../server';
+
+const server = getOrCreateServer();
 
 // Redis client must be a singleton
-let _redis: Redis | Cluster | null = null;
+let _redis: Redis | null = null;
 
-function generateNewRedisClient(logger: FastifyBaseLogger) {
+function generateNewRedisClient(logger: FastifyBaseLogger = server.log): Redis {
     if (process.env.NODE_ENV === 'test') {
         logger.info('Using mock redis client.');
         return new MockRedis() as Redis;
@@ -58,8 +61,8 @@ function generateNewRedisClient(logger: FastifyBaseLogger) {
     });
 }
 
-export function getRedisClient(logger: FastifyBaseLogger) {
-    const redis = _redis ?? generateNewRedisClient(logger);
+export function getRedisClient(logger: FastifyBaseLogger = server.log): Redis {
+    const redis = _redis ?? generateNewRedisClient();
 
     if (!_redis) {
         logger.info('Instantiating new redis client.');

--- a/app/server/src/features/events/feedback/methods.ts
+++ b/app/server/src/features/events/feedback/methods.ts
@@ -10,6 +10,43 @@ import { fromGlobalId } from 'graphql-relay';
 import { isModerator } from '../moderation/methods';
 import { ProtectedError } from '../../../lib/ProtectedError';
 import { Vote } from '@local/graphql-types';
+import { hashString } from '@local/lib/utilities';
+import { getRedisClient } from '@local/core/utils';
+import { getOrCreateServer } from '@local/core/server';
+
+const redis = getRedisClient();
+const server = getOrCreateServer();
+
+async function checkViewpointsCache(promptId: string, responses: string[]): Promise<string[] | null> {
+    try {
+        server.log.debug(`Checking cache for viewpoints for prompt ${promptId}`);
+        server.log.debug(`Responses: ${JSON.stringify(responses)}`);
+        const responsesHash = hashString(JSON.stringify(responses));
+        const cachedViewpoints = await redis.get(`viewpoints:${promptId}:${responsesHash}`);
+        if (cachedViewpoints) {
+            server.log.debug(`Found cached viewpoints for prompt ${promptId}: ${cachedViewpoints}`);
+            return JSON.parse(cachedViewpoints) as string[];
+        }
+        server.log.debug(`No cached viewpoints found for prompt ${promptId}`);
+        return null;
+    } catch (error) {
+        server.log.error(`Error checking cache for viewpoints for prompt ${promptId}: ${error}`);
+        return null;
+    }
+}
+
+async function cacheViewpoints(promptId: string, responses: string[], viewpoints: string[]) {
+    try {
+        server.log.debug(`Caching viewpoints for prompt ${promptId}`);
+        server.log.debug(`Responses: ${JSON.stringify(responses)}`);
+        server.log.debug(`Viewpoints: ${JSON.stringify(viewpoints)}`);
+        const responsesHash = hashString(JSON.stringify(responses));
+        const CACHE_EXPIRATION = 60 * 60 * 12; // 12 hours in seconds
+        await redis.set(`viewpoints:${promptId}:${responsesHash}`, JSON.stringify(viewpoints), 'EX', CACHE_EXPIRATION);
+    } catch (error) {
+        server.log.error(`Error caching viewpoints for prompt ${promptId}: ${error}`);
+    }
+}
 
 export async function myFeedback(userId: string, eventId: string, prisma: PrismaClient) {
     const result = await prisma.eventLiveFeedback.findMany({
@@ -31,6 +68,10 @@ async function generateViewpoints(promptId: string, issue: string, eventId: stri
 
     const responses = _responses.map((response) => response.response);
 
+    const cachedViewpoints = await checkViewpointsCache(promptId, responses);
+
+    if (cachedViewpoints) return cachedViewpoints;
+
     let response: AxiosResponse<string[]> | null = null;
     try {
         const url = process.env.MODERATION_URL + 'promptsummary';
@@ -50,6 +91,7 @@ async function generateViewpoints(promptId: string, issue: string, eventId: stri
         console.error(error);
     }
     const viewpoints = response?.data || [];
+    await cacheViewpoints(promptId, responses, viewpoints);
     return viewpoints;
 }
 
@@ -63,6 +105,12 @@ async function generateViewpointsByVote(promptId: string, issue: string, eventId
 
         const responses = _responses.map((response) => response.response);
         if (responses.length === 0) continue;
+
+        const cachedViewpoints = await checkViewpointsCache(promptId, responses);
+        if (cachedViewpoints) {
+            viewpointsByVote[vote] = cachedViewpoints;
+            continue;
+        }
 
         let response: AxiosResponse<string[]> | null = null;
         try {
@@ -83,6 +131,7 @@ async function generateViewpointsByVote(promptId: string, issue: string, eventId
             console.error(error);
         }
         const viewpoints = response?.data || [];
+        await cacheViewpoints(promptId, responses, viewpoints);
         viewpointsByVote[vote] = viewpoints;
     }
     return viewpointsByVote;
@@ -104,6 +153,12 @@ async function generateViewpointsByMultipleChoice(
         const responses = _responses.map((response) => response.response);
         if (responses.length === 0) continue;
 
+        const cachedViewpoints = await checkViewpointsCache(promptId, responses);
+        if (cachedViewpoints) {
+            viewpointsByChoice[choice] = cachedViewpoints;
+            continue;
+        }
+
         let response: AxiosResponse<string[]> | null = null;
         try {
             const url = process.env.MODERATION_URL + 'promptsummary';
@@ -123,6 +178,7 @@ async function generateViewpointsByMultipleChoice(
             console.error(error);
         }
         const viewpoints = response?.data || [];
+        await cacheViewpoints(promptId, responses, viewpoints);
         viewpointsByChoice[choice] = viewpoints;
     }
     return viewpointsByChoice;

--- a/app/server/src/features/events/feedback/methods.ts
+++ b/app/server/src/features/events/feedback/methods.ts
@@ -8,8 +8,8 @@ import type {
 } from '@local/graphql-types';
 import { fromGlobalId } from 'graphql-relay';
 import { isModerator } from '../moderation/methods';
-import { ProtectedError } from '../../../lib/ProtectedError';
 import { Vote } from '@local/graphql-types';
+import { ProtectedError } from '@local/lib/ProtectedError';
 import { hashString } from '@local/lib/utilities';
 import { getRedisClient } from '@local/core/utils';
 import { getOrCreateServer } from '@local/core/server';

--- a/app/server/src/features/events/feedback/methods.ts
+++ b/app/server/src/features/events/feedback/methods.ts
@@ -43,6 +43,7 @@ async function cacheViewpoints(promptId: string, responses: string[], viewpoints
         const responsesHash = hashString(JSON.stringify(responses));
         const CACHE_EXPIRATION = 60 * 60 * 12; // 12 hours in seconds
         await redis.set(`viewpoints:${promptId}:${responsesHash}`, JSON.stringify(viewpoints), 'EX', CACHE_EXPIRATION);
+        server.log.debug(`Cached viewpoints for prompt ${promptId}`);
     } catch (error) {
         server.log.error(`Error caching viewpoints for prompt ${promptId}: ${error}`);
     }

--- a/app/server/src/lib/utilities.ts
+++ b/app/server/src/lib/utilities.ts
@@ -1,0 +1,7 @@
+import { createHash } from 'crypto';
+
+export function hashString(input: string): string {
+    const hash = createHash('sha256');
+    hash.update(input);
+    return hash.digest('hex');
+}


### PR DESCRIPTION
Re-generating the viewpoints when the responses have not changed is wasted resources and was causing some discontinuity in the mod view vs the shared results to the participants.

The viewpoints are cached in redis based on the promptId and a hash of the responses. If the responses change then it should re-generate the viewpoints still, but otherwise it should just returned the cached result.