### PR TITLE
Migrate from Container Registry to Artifact Registry

### DIFF
--- a/.github/workflows/cc2c-deploy.yml
+++ b/.github/workflows/cc2c-deploy.yml
@@ -30,6 +30,7 @@ env:
     DATABASE_URL: ${{ secrets.DATABASE_URL }} # Used for prisma migration
     REGISTRATION_AUTHORIZATION_CODE: ${{ secrets.REGISTRATION_AUTHORIZATION_CODE }}
     PRYTANEUM_URL: ${{ vars.PRYTANEUM_URL }}
+    GOOGLE_ARTIFACT_REPO: ${{ vars.GOOGLE_ARTIFACT_REPO }}
 
 jobs:
     staging:
@@ -71,7 +72,7 @@ jobs:
               run: |-
                   docker build \
                     -f ./docker/Dockerfile.cc2c \
-                    --tag "gcr.io/$PROJECT_ID/$CC2C_IMAGE:$GITHUB_SHA" \
+                    --tag "$GOOGLE_ARTIFACT_REPO/$CC2C_IMAGE:$GITHUB_SHA" \
                     --build-arg GITHUB_SHA="$GITHUB_SHA" \
                     --build-arg GITHUB_REF="$GITHUB_REF" \
                     --build-arg DEPLOYMENT_ENV="development" \
@@ -84,7 +85,7 @@ jobs:
 
             # Push the App image to Google Container Registry
             - name: Publish App
-              run: docker push "gcr.io/$PROJECT_ID/$CC2C_IMAGE:$GITHUB_SHA"
+              run: docker push "$GOOGLE_ARTIFACT_REPO/$CC2C_IMAGE:$GITHUB_SHA"
 
             # Set up kustomize
             - name: Set up Kustomize
@@ -96,7 +97,7 @@ jobs:
             - name: Kustomize & Deploy App
               run: |-
                   cd ./k8s/cc2c/app/development
-                  kustomize edit set image gcr.io/PROJECT_ID/CC2C_IMAGE:TAG=gcr.io/$PROJECT_ID/$CC2C_IMAGE:$GITHUB_SHA
+                  kustomize edit set image GOOGLE_ARTIFACT_REPO/CC2C_IMAGE:TAG=$GOOGLE_ARTIFACT_REPO/$CC2C_IMAGE:$GITHUB_SHA
                   kustomize edit set namespace $NAMESPACE
                   kustomize build . | kubectl apply -f -
 
@@ -161,7 +162,7 @@ jobs:
               run: |-
                   docker build \
                     -f ./docker/Dockerfile.cc2c \
-                    --tag "gcr.io/$PROJECT_ID/$CC2C_IMAGE:$GITHUB_SHA" \
+                    --tag "$GOOGLE_ARTIFACT_REPO/$CC2C_IMAGE:$GITHUB_SHA" \
                     --build-arg GITHUB_SHA="$GITHUB_SHA" \
                     --build-arg GITHUB_REF="$GITHUB_REF" \
                     --build-arg DEPLOYMENT_ENV="production" \
@@ -174,7 +175,7 @@ jobs:
 
             # Push the App image to Google Container Registry
             - name: Publish App
-              run: docker push "gcr.io/$PROJECT_ID/$CC2C_IMAGE:$GITHUB_SHA"
+              run: docker push "$GOOGLE_ARTIFACT_REPO/$CC2C_IMAGE:$GITHUB_SHA"
 
             # Set up kustomize
             - name: Set up Kustomize
@@ -186,7 +187,7 @@ jobs:
             - name: Kustomize & Deploy App
               run: |-
                   cd ./k8s/cc2c/app/production
-                  kustomize edit set image gcr.io/PROJECT_ID/CC2C_IMAGE:TAG=gcr.io/$PROJECT_ID/$CC2C_IMAGE:$GITHUB_SHA
+                  kustomize edit set image GOOGLE_ARTIFACT_REPO/CC2C_IMAGE:TAG=$GOOGLE_ARTIFACT_REPO/$CC2C_IMAGE:$GITHUB_SHA
                   kustomize edit set namespace $NAMESPACE
                   kustomize build . | kubectl apply -f -
 

--- a/.github/workflows/client-deploy.yml
+++ b/.github/workflows/client-deploy.yml
@@ -31,6 +31,7 @@ env:
     ORIGIN: ${{ vars.ORIGIN }}
     API_URL: ${{ vars.API_URL }}
     GOOGLE_MEET_API_KEY: ${{ vars.GOOGLE_MEET_API_KEY }}
+    $GOOGLE_ARTIFACT_REPO: ${{ vars.GOOGLE_ARTIFACT_REPO }}
 
 jobs:
     staging:
@@ -72,7 +73,7 @@ jobs:
               run: |-
                   docker build \
                     -f ./docker/Dockerfile.client \
-                    --tag "gcr.io/$PROJECT_ID/$CLIENT_IMAGE:$GITHUB_SHA" \
+                    --tag "$GOOGLE_ARTIFACT_REPO/$CLIENT_IMAGE:$GITHUB_SHA" \
                     --build-arg GITHUB_SHA="$GITHUB_SHA" \
                     --build-arg GITHUB_REF="$GITHUB_REF" \
                     --build-arg GRAPHQL_URL="$GRAPHQL_URL" \
@@ -85,7 +86,7 @@ jobs:
 
             # Push the Client image to Google Container Registry
             - name: Publish Client
-              run: docker push "gcr.io/$PROJECT_ID/$CLIENT_IMAGE:$GITHUB_SHA"
+              run: docker push "$GOOGLE_ARTIFACT_REPO/$CLIENT_IMAGE:$GITHUB_SHA"
 
             # Set up kustomize
             - name: Set up Kustomize
@@ -97,7 +98,7 @@ jobs:
             - name: Kustomize & Deploy Client
               run: |-
                   cd ./k8s/client/development
-                  kustomize edit set image gcr.io/PROJECT_ID/CLIENT_IMAGE:TAG=gcr.io/$PROJECT_ID/$CLIENT_IMAGE:$GITHUB_SHA
+                  kustomize edit set image GOOGLE_ARTIFACT_REPO/CLIENT_IMAGE:TAG=$GOOGLE_ARTIFACT_REPO/$CLIENT_IMAGE:$GITHUB_SHA
                   kustomize edit set namespace $NAMESPACE
                   kustomize build . | kubectl apply -f -
 
@@ -150,7 +151,7 @@ jobs:
               run: |-
                   docker build \
                     -f ./docker/Dockerfile.client \
-                    --tag "gcr.io/$PROJECT_ID/$CLIENT_IMAGE:$GITHUB_SHA" \
+                    --tag "$GOOGLE_ARTIFACT_REPO/$CLIENT_IMAGE:$GITHUB_SHA" \
                     --build-arg GITHUB_SHA="$GITHUB_SHA" \
                     --build-arg GITHUB_REF="$GITHUB_REF" \
                     --build-arg DEPLOYMENT_ENV="production" \
@@ -162,7 +163,7 @@ jobs:
 
             # Push the Client image to Google Container Registry
             - name: Publish Client
-              run: docker push "gcr.io/$PROJECT_ID/$CLIENT_IMAGE:$GITHUB_SHA"
+              run: docker push "$GOOGLE_ARTIFACT_REPO/$CLIENT_IMAGE:$GITHUB_SHA"
 
             # Set up kustomize
             - name: Set up Kustomize
@@ -174,7 +175,7 @@ jobs:
             - name: Kustomize & Deploy Client
               run: |-
                   cd ./k8s/client/production
-                  kustomize edit set image gcr.io/PROJECT_ID/CLIENT_IMAGE:TAG=gcr.io/$PROJECT_ID/$CLIENT_IMAGE:$GITHUB_SHA
+                  kustomize edit set image GOOGLE_ARTIFACT_REPO/CLIENT_IMAGE:TAG=$GOOGLE_ARTIFACT_REPO/$CLIENT_IMAGE:$GITHUB_SHA
                   kustomize edit set namespace $NAMESPACE
                   kustomize build . | kubectl apply -f -
 

--- a/.github/workflows/gcp-service-deploy.yml
+++ b/.github/workflows/gcp-service-deploy.yml
@@ -24,6 +24,7 @@ env:
     GKE_ZONE: ${{ vars.GKE_ZONE }}
     GCP_SERVICE_IMAGE: ${{ vars.GCP_SERVICE_IMAGE }}
     NAMESPACE: ${{ vars.NAMESPACE }}
+    GOOGLE_ARTIFACT_REPO: ${{ vars.GOOGLE_ARTIFACT_REPO }}
 
 jobs:
     staging:
@@ -65,7 +66,7 @@ jobs:
               run: |-
                   docker build \
                     -f ./docker/Dockerfile.gcp \
-                    --tag "gcr.io/$PROJECT_ID/$GCP_SERVICE_IMAGE:$GITHUB_SHA" \
+                    --tag "$GOOGLE_ARTIFACT_REPO/$GCP_SERVICE_IMAGE:$GITHUB_SHA" \
                     --build-arg GITHUB_SHA="$GITHUB_SHA" \
                     --build-arg GITHUB_REF="$GITHUB_REF" \
                     --build-arg DEPLOYMENT_ENV="development" \
@@ -73,13 +74,13 @@ jobs:
 
             # Push the App image to Google Container Registry
             - name: Publish GCP Service
-              run: docker push "gcr.io/$PROJECT_ID/$GCP_SERVICE_IMAGE:$GITHUB_SHA"
+              run: docker push "$GOOGLE_ARTIFACT_REPO/$GCP_SERVICE_IMAGE:$GITHUB_SHA"
 
             # Deploy the Docker image to the GKE cluster
             - name: Kustomize & Deploy GCP Service
               run: |-
                   cd ./k8s/cc2c/gcp/development
-                  kustomize edit set image gcr.io/PROJECT_ID/GCP_SERVICE_IMAGE:TAG=gcr.io/$PROJECT_ID/$GCP_SERVICE_IMAGE:$GITHUB_SHA
+                  kustomize edit set image GOOGLE_ARTIFACT_REPO/GCP_SERVICE_IMAGE:TAG=$GOOGLE_ARTIFACT_REPO/$GCP_SERVICE_IMAGE:$GITHUB_SHA
                   kustomize edit set namespace $NAMESPACE
                   kustomize build . | kubectl apply -f -
 
@@ -132,7 +133,7 @@ jobs:
               run: |-
                   docker build \
                     -f ./docker/Dockerfile.gcp \
-                    --tag "gcr.io/$PROJECT_ID/$GCP_SERVICE_IMAGE:$GITHUB_SHA" \
+                    --tag "$GOOGLE_ARTIFACT_REPO/$GCP_SERVICE_IMAGE:$GITHUB_SHA" \
                     --build-arg GITHUB_SHA="$GITHUB_SHA" \
                     --build-arg GITHUB_REF="$GITHUB_REF" \
                     --build-arg DEPLOYMENT_ENV="production" \
@@ -140,13 +141,13 @@ jobs:
 
             # Push the App image to Google Container Registry
             - name: Publish GCP Service
-              run: docker push "gcr.io/$PROJECT_ID/$GCP_SERVICE_IMAGE:$GITHUB_SHA"
+              run: docker push "$GOOGLE_ARTIFACT_REPO/$GCP_SERVICE_IMAGE:$GITHUB_SHA"
 
             # Deploy the Docker image to the GKE cluster
             - name: Kustomize & Deploy GCP Service
               run: |-
                   cd ./k8s/cc2c/gcp/production
-                  kustomize edit set image gcr.io/PROJECT_ID/GCP_SERVICE_IMAGE:TAG=gcr.io/$PROJECT_ID/$GCP_SERVICE_IMAGE:$GITHUB_SHA
+                  kustomize edit set image GOOGLE_ARTIFACT_REPO/GCP_SERVICE_IMAGE:TAG=$GOOGLE_ARTIFACT_REPO/$GCP_SERVICE_IMAGE:$GITHUB_SHA
                   kustomize edit set namespace $NAMESPACE
                   kustomize build . | kubectl apply -f -
 

--- a/.github/workflows/moderation-algo-deploy.yml
+++ b/.github/workflows/moderation-algo-deploy.yml
@@ -25,6 +25,7 @@ env:
     MODERATION_ALGO_IMAGE: ${{ vars.MODERATION_ALGO_IMAGE }}
     NAMESPACE: ${{ vars.NAMESPACE }}
     ORIGIN: ${{ vars.ORIGIN }}
+    GOOGLE_ARTIFACT_REPO: ${{ vars.GOOGLE_ARTIFACT_REPO }}
 
 jobs:
     staging:
@@ -72,14 +73,14 @@ jobs:
               run: |-
                   docker build \
                     -f ./app/moderation-algo/Dockerfile \
-                    --tag "gcr.io/$PROJECT_ID/$MODERATION_ALGO_IMAGE:$GITHUB_SHA" \
+                    --tag "$GOOGLE_ARTIFACT_REPO/$MODERATION_ALGO_IMAGE:$GITHUB_SHA" \
                     --build-arg GITHUB_SHA="$GITHUB_SHA" \
                     --build-arg GITHUB_REF="$GITHUB_REF" \
                     ./app/moderation-algo
 
             # Push the Moderation algo image to Google Container Registry
             - name: Publish Moderation Algorithm
-              run: docker push "gcr.io/$PROJECT_ID/$MODERATION_ALGO_IMAGE:$GITHUB_SHA"
+              run: docker push "$GOOGLE_ARTIFACT_REPO/$MODERATION_ALGO_IMAGE:$GITHUB_SHA"
 
             # Set up kustomize
             - name: Set up Kustomize
@@ -91,7 +92,7 @@ jobs:
             - name: Kustomize & Deploy Moderation Algorithm
               run: |-
                   cd ./k8s/moderation-algo/development
-                  kustomize edit set image gcr.io/PROJECT_ID/MODERATION_ALGO_IMAGE:TAG=gcr.io/$PROJECT_ID/$MODERATION_ALGO_IMAGE:$GITHUB_SHA
+                  kustomize edit set image GOOGLE_ARTIFACT_REPO/MODERATION_ALGO_IMAGE:TAG=$GOOGLE_ARTIFACT_REPO/$MODERATION_ALGO_IMAGE:$GITHUB_SHA
                   kustomize edit set namespace $NAMESPACE
                   kustomize build . | kubectl apply -f -
 
@@ -160,14 +161,14 @@ jobs:
               run: |-
                   docker build \
                     -f ./app/moderation-algo/Dockerfile \
-                    --tag "gcr.io/$PROJECT_ID/$MODERATION_ALGO_IMAGE:$GITHUB_SHA" \
+                    --tag "$GOOGLE_ARTIFACT_REPO/$MODERATION_ALGO_IMAGE:$GITHUB_SHA" \
                     --build-arg GITHUB_SHA="$GITHUB_SHA" \
                     --build-arg GITHUB_REF="$GITHUB_REF" \
                     ./app/moderation-algo
 
             # Push the Moderation algo image to Google Container Registry
             - name: Publish Moderation Algorithm
-              run: docker push "gcr.io/$PROJECT_ID/$MODERATION_ALGO_IMAGE:$GITHUB_SHA"
+              run: docker push "$GOOGLE_ARTIFACT_REPO/$MODERATION_ALGO_IMAGE:$GITHUB_SHA"
 
             # Set up kustomize
             - name: Set up Kustomize
@@ -179,7 +180,7 @@ jobs:
             - name: Kustomize & Deploy Moderation Algorithm
               run: |-
                   cd ./k8s/moderation-algo/production
-                  kustomize edit set image gcr.io/PROJECT_ID/MODERATION_ALGO_IMAGE:TAG=gcr.io/$PROJECT_ID/$MODERATION_ALGO_IMAGE:$GITHUB_SHA
+                  kustomize edit set image GOOGLE_ARTIFACT_REPO/MODERATION_ALGO_IMAGE:TAG=$GOOGLE_ARTIFACT_REPO/$MODERATION_ALGO_IMAGE:$GITHUB_SHA
                   kustomize edit set namespace $NAMESPACE
                   kustomize build . | kubectl apply -f -
 

--- a/.github/workflows/server-deploy.yml
+++ b/.github/workflows/server-deploy.yml
@@ -30,6 +30,7 @@ env:
     GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
     GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
     GOOGLE_REDIRECT_URI: ${{ vars.GOOGLE_REDIRECT_URI }}
+    GOOGLE_ARTIFACT_REPO: ${{ vars.GOOGLE_ARTIFACT_REPO }}
 
 jobs:
     staging:
@@ -59,8 +60,10 @@ jobs:
 
             # Configure Docker to use the gcloud command-line tool as a credential
             # helper for authentication
+            # This is required to push the Docker image to Google Artifact Registry
             - run: |-
-                  gcloud --quiet auth configure-docker
+                  gcloud --quiet auth configure-docker \
+                    us-central1-docker.pkg.dev
             # Get the GKE credentials so we can deploy to the cluster
             - id: 'get-credentials'
               uses: google-github-actions/get-gke-credentials@v0.7.0
@@ -73,7 +76,7 @@ jobs:
               run: |-
                   docker build \
                     -f ./docker/Dockerfile.server \
-                    --tag "gcr.io/$PROJECT_ID/$SERVER_IMAGE:$GITHUB_SHA" \
+                    --tag "$GOOGLE_ARTIFACT_REPO/$SERVER_IMAGE:$GITHUB_SHA" \
                     --build-arg ORIGIN="$ORIGIN" \
                     --build-arg GITHUB_SHA="$GITHUB_SHA" \
                     --build-arg GITHUB_REF="$GITHUB_REF" \
@@ -84,7 +87,7 @@ jobs:
 
             # Push the Server image to Google Container Registry
             - name: Publish Server
-              run: docker push "gcr.io/$PROJECT_ID/$SERVER_IMAGE:$GITHUB_SHA"
+              run: docker push "$GOOGLE_ARTIFACT_REPO/$SERVER_IMAGE:$GITHUB_SHA"
 
             # Set up kustomize
             - name: Set up Kustomize
@@ -96,7 +99,7 @@ jobs:
             - name: Kustomize & Deploy Server
               run: |-
                   cd ./k8s/server/development
-                  kustomize edit set image gcr.io/PROJECT_ID/SERVER_IMAGE:TAG=gcr.io/$PROJECT_ID/$SERVER_IMAGE:$GITHUB_SHA
+                  kustomize edit set image GOOGLE_ARTIFACT_REPO/SERVER_IMAGE:TAG=$GOOGLE_ARTIFACT_REPO/$SERVER_IMAGE:$GITHUB_SHA
                   kustomize edit set namespace $NAMESPACE
                   kustomize build . | kubectl apply -f -
 
@@ -162,7 +165,7 @@ jobs:
               run: |-
                   docker build \
                     -f ./docker/Dockerfile.server \
-                    --tag "gcr.io/$PROJECT_ID/$SERVER_IMAGE:$GITHUB_SHA" \
+                    --tag "$GOOGLE_ARTIFACT_REPO/$SERVER_IMAGE:$GITHUB_SHA" \
                     --build-arg ORIGIN="$ORIGIN" \
                     --build-arg GITHUB_SHA="$GITHUB_SHA" \
                     --build-arg GITHUB_REF="$GITHUB_REF" \
@@ -173,7 +176,7 @@ jobs:
 
             # Push the Server image to Google Container Registry
             - name: Publish Server
-              run: docker push "gcr.io/$PROJECT_ID/$SERVER_IMAGE:$GITHUB_SHA"
+              run: docker push "$GOOGLE_ARTIFACT_REPO/$SERVER_IMAGE:$GITHUB_SHA"
 
             # Set up kustomize
             - name: Set up Kustomize
@@ -185,7 +188,7 @@ jobs:
             - name: Kustomize & Deploy Server
               run: |-
                   cd ./k8s/server/production
-                  kustomize edit set image gcr.io/PROJECT_ID/SERVER_IMAGE:TAG=gcr.io/$PROJECT_ID/$SERVER_IMAGE:$GITHUB_SHA
+                  kustomize edit set image GOOGLE_ARTIFACT_REPO/SERVER_IMAGE:TAG=$GOOGLE_ARTIFACT_REPO/$SERVER_IMAGE:$GITHUB_SHA
                   kustomize edit set namespace $NAMESPACE
                   kustomize build . | kubectl apply -f -
 

--- a/k8s/cc2c/app/development/cc2c-deployment.yml
+++ b/k8s/cc2c/app/development/cc2c-deployment.yml
@@ -27,7 +27,7 @@ spec:
                       secretName: gcp-storage-credentials
             containers:
                 - name: cc2c
-                  image: gcr.io/PROJECT_ID/CC2C_IMAGE:TAG
+                  image: GOOGLE_ARTIFACT_REPO/CC2C_IMAGE:TAG
                   volumeMounts:
                       - name: google-cloud-key
                         mountPath: /var/secrets/google

--- a/k8s/cc2c/app/production/cc2c-deployment.yml
+++ b/k8s/cc2c/app/production/cc2c-deployment.yml
@@ -27,7 +27,7 @@ spec:
                       secretName: gcp-storage-credentials
             containers:
                 - name: cc2c
-                  image: gcr.io/PROJECT_ID/CC2C_IMAGE:TAG
+                  image: GOOGLE_ARTIFACT_REPO/CC2C_IMAGE:TAG
                   volumeMounts:
                       - name: google-cloud-key
                         mountPath: /var/secrets/google

--- a/k8s/cc2c/gcp/development/gcp-deployment.yml
+++ b/k8s/cc2c/gcp/development/gcp-deployment.yml
@@ -27,7 +27,7 @@ spec:
                       secretName: gcp-storage-credentials
             containers:
                 - name: gcp
-                  image: gcr.io/PROJECT_ID/GCP_SERVICE_IMAGE:TAG
+                  image: GOOGLE_ARTIFACT_REPO/GCP_SERVICE_IMAGE:TAG
                   volumeMounts:
                       - name: google-cloud-key
                         mountPath: /var/secrets/google

--- a/k8s/cc2c/gcp/production/gcp-deployment.yml
+++ b/k8s/cc2c/gcp/production/gcp-deployment.yml
@@ -27,7 +27,7 @@ spec:
                       secretName: gcp-storage-credentials
             containers:
                 - name: gcp
-                  image: gcr.io/PROJECT_ID/GCP_SERVICE_IMAGE:TAG
+                  image: GOOGLE_ARTIFACT_REPO/GCP_SERVICE_IMAGE:TAG
                   volumeMounts:
                       - name: google-cloud-key
                         mountPath: /var/secrets/google

--- a/k8s/client/development/prytaneum-client-deployment.yml
+++ b/k8s/client/development/prytaneum-client-deployment.yml
@@ -23,7 +23,7 @@ spec:
         spec:
             containers:
                 - name: prytaneum-client
-                  image: gcr.io/PROJECT_ID/CLIENT_IMAGE:TAG
+                  image: GOOGLE_ARTIFACT_REPO/CLIENT_IMAGE:TAG
                   imagePullPolicy: IfNotPresent
                   resources:
                       limits:

--- a/k8s/client/production/prytaneum-client-deployment.yml
+++ b/k8s/client/production/prytaneum-client-deployment.yml
@@ -23,7 +23,7 @@ spec:
         spec:
             containers:
                 - name: prytaneum-client
-                  image: gcr.io/PROJECT_ID/CLIENT_IMAGE:TAG
+                  image: GOOGLE_ARTIFACT_REPO/CLIENT_IMAGE:TAG
                   imagePullPolicy: IfNotPresent
                   resources:
                       limits:

--- a/k8s/moderation-algo/development/moderation-algo-deployment.yml
+++ b/k8s/moderation-algo/development/moderation-algo-deployment.yml
@@ -23,7 +23,7 @@ spec:
         spec:
             containers:
                 - name: moderation-algo
-                  image: gcr.io/PROJECT_ID/MODERATION_ALGO_IMAGE:TAG
+                  image: GOOGLE_ARTIFACT_REPO/MODERATION_ALGO_IMAGE:TAG
                   imagePullPolicy: IfNotPresent
                   resources:
                       limits:

--- a/k8s/moderation-algo/production/moderation-algo-deployment.yml
+++ b/k8s/moderation-algo/production/moderation-algo-deployment.yml
@@ -23,7 +23,7 @@ spec:
         spec:
             containers:
                 - name: moderation-algo
-                  image: gcr.io/PROJECT_ID/MODERATION_ALGO_IMAGE:TAG
+                  image: GOOGLE_ARTIFACT_REPO/MODERATION_ALGO_IMAGE:TAG
                   imagePullPolicy: IfNotPresent
                   resources:
                       limits:

--- a/k8s/server/development/prytaneum-server-deployment.yml
+++ b/k8s/server/development/prytaneum-server-deployment.yml
@@ -23,7 +23,7 @@ spec:
         spec:
             containers:
                 - name: prytaneum-server
-                  image: gcr.io/PROJECT_ID/SERVER_IMAGE:TAG
+                  image: GOOGLE_ARTIFACT_REPO/SERVER_IMAGE:TAG
                   imagePullPolicy: IfNotPresent
                   resources:
                       limits:

--- a/k8s/server/production/prytaneum-server-deployment.yml
+++ b/k8s/server/production/prytaneum-server-deployment.yml
@@ -23,7 +23,7 @@ spec:
         spec:
             containers:
                 - name: prytaneum-server
-                  image: gcr.io/PROJECT_ID/SERVER_IMAGE:TAG
+                  image: GOOGLE_ARTIFACT_REPO/SERVER_IMAGE:TAG
                   imagePullPolicy: IfNotPresent
                   resources:
                       limits:


### PR DESCRIPTION
The container registry is deprecated and fully shutting down early next year. Migrating to the Artifact Registry as suggested by google.