### PR TITLE
Prytaneum Improvements

### DIFF
--- a/app/client/schema.graphql
+++ b/app/client/schema.graphql
@@ -743,6 +743,7 @@ type Mutation {
   returns false if an account with the provided email cannot be found
   """
   resetPasswordRequest(input: ResetPasswordRequestForm!): ResetPasswordRequestMutationResponse!
+  reshareFeedbackPrompt(promptId: ID!): EventFeedbackPromptMutationResponse!
   shareFeedbackPromptDraft(promptId: ID!): EventFeedbackPromptMutationResponse!
   shareFeedbackPromptResults(eventId: ID!, promptId: ID!): EventFeedbackPromptMutationResponse!
 
@@ -956,7 +957,7 @@ type Subscription {
   eventUpdates(userId: ID!): Event!
   feedbackCRUD(eventId: ID!): FeedbackOperation!
   feedbackPromptResultsShared(eventId: ID!): EventLiveFeedbackPrompt!
-  feedbackPrompted(eventId: ID!): EventLiveFeedbackPrompt!
+  feedbackPrompted(eventId: ID!): EventLiveFeedbackPromptEdge!
 
   """subscription for whenever a new org is added"""
   orgUpdated: OrganizationSubscription!

--- a/app/client/src/__generated__/EventSettingsQuery.graphql.ts
+++ b/app/client/src/__generated__/EventSettingsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<5718739fdb98a6127d07ddea18f96b1f>>
+ * @generated SignedSource<<e3a5476e33e7806b3a4ee4b9f38c611f>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -17,7 +17,7 @@ export type EventSettingsQuery$data = {
   readonly node: {
     readonly id: string;
     readonly isViewerModerator?: boolean | null;
-    readonly " $fragmentSpreads": FragmentRefs<"EventDetailsFragment" | "EventIssueGuideSettingsFragment" | "GenericSettingsFragment" | "ModeratorEventSettingsFragment" | "SpeakerEventSettingsFragment" | "VideoEventSettingsFragment" | "useInvitedUsersListFragment">;
+    readonly " $fragmentSpreads": FragmentRefs<"EventDetailsFragment" | "EventIssueGuideSettingsFragment" | "GenericSettingsFragment" | "ModeratorEventSettingsFragment" | "SpeakerEventSettingsFragment" | "VideoEventSettingsFragment" | "useEventDetailsFragment" | "useInvitedUsersListFragment">;
   } | null;
 };
 export type EventSettingsQuery = {
@@ -79,10 +79,17 @@ v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
+  "name": "topic",
+  "storageKey": null
+},
+v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
   "name": "description",
   "storageKey": null
 },
-v8 = [
+v9 = [
   {
     "kind": "Literal",
     "name": "after",
@@ -94,35 +101,35 @@ v8 = [
     "value": 10
   }
 ],
-v9 = {
+v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "email",
   "storageKey": null
 },
-v10 = {
+v11 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "cursor",
   "storageKey": null
 },
-v11 = {
+v12 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endCursor",
   "storageKey": null
 },
-v12 = {
+v13 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "hasNextPage",
   "storageKey": null
 },
-v13 = {
+v14 = {
   "alias": null,
   "args": null,
   "concreteType": "PageInfo",
@@ -130,12 +137,12 @@ v13 = {
   "name": "pageInfo",
   "plural": false,
   "selections": [
-    (v11/*: any*/),
-    (v12/*: any*/)
+    (v12/*: any*/),
+    (v13/*: any*/)
   ],
   "storageKey": null
 },
-v14 = {
+v15 = {
   "kind": "ClientExtension",
   "selections": [
     {
@@ -147,21 +154,21 @@ v14 = {
     }
   ]
 },
-v15 = {
+v16 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "firstName",
   "storageKey": null
 },
-v16 = {
+v17 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "lastName",
   "storageKey": null
 },
-v17 = {
+v18 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -222,6 +229,11 @@ return {
                 "args": null,
                 "kind": "FragmentSpread",
                 "name": "EventIssueGuideSettingsFragment"
+              },
+              {
+                "args": null,
+                "kind": "FragmentSpread",
+                "name": "useEventDetailsFragment"
               }
             ],
             "type": "Event",
@@ -255,14 +267,8 @@ return {
             "selections": [
               (v3/*: any*/),
               (v6/*: any*/),
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "topic",
-                "storageKey": null
-              },
               (v7/*: any*/),
+              (v8/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -279,7 +285,7 @@ return {
               },
               {
                 "alias": null,
-                "args": (v8/*: any*/),
+                "args": (v9/*: any*/),
                 "concreteType": "EventSpeakerConnection",
                 "kind": "LinkedField",
                 "name": "speakers",
@@ -317,7 +323,7 @@ return {
                             "storageKey": null
                           },
                           (v6/*: any*/),
-                          (v7/*: any*/),
+                          (v8/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -325,23 +331,23 @@ return {
                             "name": "pictureUrl",
                             "storageKey": null
                           },
-                          (v9/*: any*/),
+                          (v10/*: any*/),
                           (v5/*: any*/)
                         ],
                         "storageKey": null
                       },
-                      (v10/*: any*/)
+                      (v11/*: any*/)
                     ],
                     "storageKey": null
                   },
-                  (v13/*: any*/),
-                  (v14/*: any*/)
+                  (v14/*: any*/),
+                  (v15/*: any*/)
                 ],
                 "storageKey": "speakers(after:\"\",first:10)"
               },
               {
                 "alias": null,
-                "args": (v8/*: any*/),
+                "args": (v9/*: any*/),
                 "filters": null,
                 "handle": "connection",
                 "key": "SpeakerEventSettingsFragment_speakers",
@@ -357,7 +363,7 @@ return {
               },
               {
                 "alias": null,
-                "args": (v8/*: any*/),
+                "args": (v9/*: any*/),
                 "concreteType": "EventVideoConnection",
                 "kind": "LinkedField",
                 "name": "videos",
@@ -398,18 +404,18 @@ return {
                         ],
                         "storageKey": null
                       },
-                      (v10/*: any*/)
+                      (v11/*: any*/)
                     ],
                     "storageKey": null
                   },
-                  (v13/*: any*/),
-                  (v14/*: any*/)
+                  (v14/*: any*/),
+                  (v15/*: any*/)
                 ],
                 "storageKey": "videos(after:\"\",first:10)"
               },
               {
                 "alias": null,
-                "args": (v8/*: any*/),
+                "args": (v9/*: any*/),
                 "filters": null,
                 "handle": "connection",
                 "key": "YoutubeSettingsFragment_videos",
@@ -460,7 +466,7 @@ return {
               },
               {
                 "alias": null,
-                "args": (v8/*: any*/),
+                "args": (v9/*: any*/),
                 "concreteType": "UserConnection",
                 "kind": "LinkedField",
                 "name": "moderators",
@@ -474,7 +480,7 @@ return {
                     "name": "edges",
                     "plural": true,
                     "selections": [
-                      (v10/*: any*/),
+                      (v11/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -484,10 +490,10 @@ return {
                         "plural": false,
                         "selections": [
                           (v2/*: any*/),
-                          (v15/*: any*/),
                           (v16/*: any*/),
                           (v17/*: any*/),
-                          (v9/*: any*/),
+                          (v18/*: any*/),
+                          (v10/*: any*/),
                           (v5/*: any*/)
                         ],
                         "storageKey": null
@@ -495,14 +501,14 @@ return {
                     ],
                     "storageKey": null
                   },
-                  (v13/*: any*/),
-                  (v14/*: any*/)
+                  (v14/*: any*/),
+                  (v15/*: any*/)
                 ],
                 "storageKey": "moderators(after:\"\",first:10)"
               },
               {
                 "alias": null,
-                "args": (v8/*: any*/),
+                "args": (v9/*: any*/),
                 "filters": null,
                 "handle": "connection",
                 "key": "ModeratorEventSettingsFragment_moderators",
@@ -511,7 +517,7 @@ return {
               },
               {
                 "alias": null,
-                "args": (v8/*: any*/),
+                "args": (v9/*: any*/),
                 "concreteType": "UserConnection",
                 "kind": "LinkedField",
                 "name": "invited",
@@ -534,9 +540,9 @@ return {
                         "plural": false,
                         "selections": [
                           (v2/*: any*/),
-                          (v15/*: any*/),
                           (v16/*: any*/),
                           (v17/*: any*/),
+                          (v18/*: any*/),
                           {
                             "alias": null,
                             "args": (v4/*: any*/),
@@ -558,14 +564,42 @@ return {
                     "name": "pageInfo",
                     "plural": false,
                     "selections": [
-                      (v12/*: any*/),
-                      (v11/*: any*/)
+                      (v13/*: any*/),
+                      (v12/*: any*/)
                     ],
                     "storageKey": null
                   },
-                  (v14/*: any*/)
+                  (v15/*: any*/)
                 ],
                 "storageKey": "invited(after:\"\",first:10)"
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "isActive",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "isViewerInvited",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "EventTopic",
+                "kind": "LinkedField",
+                "name": "topics",
+                "plural": true,
+                "selections": [
+                  (v2/*: any*/),
+                  (v7/*: any*/),
+                  (v8/*: any*/)
+                ],
+                "storageKey": null
               }
             ],
             "type": "Event",
@@ -577,16 +611,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "e907372ec3920fdc3706b623295c3a5b",
+    "cacheID": "292c88447da476b1563a8b532b331eab",
     "id": null,
     "metadata": {},
     "name": "EventSettingsQuery",
     "operationKind": "query",
-    "text": "query EventSettingsQuery(\n  $eventId: ID!\n) {\n  node(id: $eventId) {\n    __typename\n    id\n    ... on Event {\n      isViewerModerator\n      ...EventDetailsFragment\n      ...SpeakerEventSettingsFragment\n      ...VideoEventSettingsFragment\n      ...GenericSettingsFragment\n      ...ModeratorEventSettingsFragment\n      ...useInvitedUsersListFragment_32qNee\n      ...EventIssueGuideSettingsFragment\n    }\n  }\n}\n\nfragment EventDetailsFragment on Event {\n  id\n  title\n  topic\n  description\n  startDateTime\n  endDateTime\n}\n\nfragment EventIssueGuideSettingsFragment on Event {\n  id\n  title\n  issueGuideUrl\n}\n\nfragment GenericSettingsFragment on Event {\n  id\n  isQuestionFeedVisible\n  isCollectRatingsEnabled\n  isForumEnabled\n  isPrivate\n  issueGuideUrl\n}\n\nfragment GoogleMeetSettingsFragment on Event {\n  googleMeetUrl\n  id\n}\n\nfragment ModeratorEventSettingsFragment on Event {\n  id\n  moderators(first: 10, after: \"\") {\n    edges {\n      cursor\n      node {\n        id\n        firstName\n        lastName\n        avatar\n        email\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment SpeakerEventSettingsFragment on Event {\n  id\n  speakers(first: 10, after: \"\") {\n    edges {\n      node {\n        id\n        eventId\n        name\n        title\n        description\n        pictureUrl\n        email\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment VideoEventSettingsFragment on Event {\n  eventType\n  ...YoutubeSettingsFragment\n  ...GoogleMeetSettingsFragment\n  id\n}\n\nfragment YoutubeSettingsFragment on Event {\n  id\n  videos(first: 10, after: \"\") {\n    edges {\n      node {\n        id\n        url\n        lang\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment useInvitedUsersListFragment_32qNee on Event {\n  invited(first: 10, after: \"\") {\n    edges {\n      node {\n        id\n        firstName\n        lastName\n        avatar\n        moderatorOf(eventId: $eventId)\n      }\n    }\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n  }\n  id\n}\n"
+    "text": "query EventSettingsQuery(\n  $eventId: ID!\n) {\n  node(id: $eventId) {\n    __typename\n    id\n    ... on Event {\n      isViewerModerator\n      ...EventDetailsFragment\n      ...SpeakerEventSettingsFragment\n      ...VideoEventSettingsFragment\n      ...GenericSettingsFragment\n      ...ModeratorEventSettingsFragment\n      ...useInvitedUsersListFragment_32qNee\n      ...EventIssueGuideSettingsFragment\n      ...useEventDetailsFragment\n    }\n  }\n}\n\nfragment EventDetailsFragment on Event {\n  id\n  title\n  topic\n  description\n  startDateTime\n  endDateTime\n}\n\nfragment EventIssueGuideSettingsFragment on Event {\n  id\n  title\n  issueGuideUrl\n}\n\nfragment GenericSettingsFragment on Event {\n  id\n  isQuestionFeedVisible\n  isCollectRatingsEnabled\n  isForumEnabled\n  isPrivate\n  issueGuideUrl\n}\n\nfragment GoogleMeetSettingsFragment on Event {\n  googleMeetUrl\n  id\n}\n\nfragment ModeratorEventSettingsFragment on Event {\n  id\n  moderators(first: 10, after: \"\") {\n    edges {\n      cursor\n      node {\n        id\n        firstName\n        lastName\n        avatar\n        email\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment SpeakerEventSettingsFragment on Event {\n  id\n  speakers(first: 10, after: \"\") {\n    edges {\n      node {\n        id\n        eventId\n        name\n        title\n        description\n        pictureUrl\n        email\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment VideoEventSettingsFragment on Event {\n  eventType\n  ...YoutubeSettingsFragment\n  ...GoogleMeetSettingsFragment\n  id\n}\n\nfragment YoutubeSettingsFragment on Event {\n  id\n  videos(first: 10, after: \"\") {\n    edges {\n      node {\n        id\n        url\n        lang\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment useEventDetailsFragment on Event {\n  id\n  title\n  topic\n  description\n  startDateTime\n  endDateTime\n  isActive\n  isViewerModerator\n  isPrivate\n  isViewerInvited\n  issueGuideUrl\n  topics {\n    id\n    topic\n    description\n  }\n  eventType\n}\n\nfragment useInvitedUsersListFragment_32qNee on Event {\n  invited(first: 10, after: \"\") {\n    edges {\n      node {\n        id\n        firstName\n        lastName\n        avatar\n        moderatorOf(eventId: $eventId)\n      }\n    }\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n  }\n  id\n}\n"
   }
 };
 })();
 
-(node as any).hash = "678b5ebdc371349238206163d8609626";
+(node as any).hash = "cafed250469a666dd14f9e222175d52b";
 
 export default node;

--- a/app/client/src/__generated__/ShareFeedbackPromptMutation.graphql.ts
+++ b/app/client/src/__generated__/ShareFeedbackPromptMutation.graphql.ts
@@ -1,0 +1,139 @@
+/**
+ * @generated SignedSource<<8da5890edd22bbdc0b363ea5c63ab58b>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest, Mutation } from 'relay-runtime';
+export type ShareFeedbackPromptMutation$variables = {
+  promptId: string;
+};
+export type ShareFeedbackPromptMutation$data = {
+  readonly reshareFeedbackPrompt: {
+    readonly body: {
+      readonly cursor: string;
+      readonly node: {
+        readonly id: string;
+      };
+    } | null;
+    readonly isError: boolean;
+    readonly message: string;
+  };
+};
+export type ShareFeedbackPromptMutation = {
+  response: ShareFeedbackPromptMutation$data;
+  variables: ShareFeedbackPromptMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "promptId"
+  }
+],
+v1 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "promptId",
+        "variableName": "promptId"
+      }
+    ],
+    "concreteType": "EventFeedbackPromptMutationResponse",
+    "kind": "LinkedField",
+    "name": "reshareFeedbackPrompt",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "isError",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "message",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "EventLiveFeedbackPromptEdge",
+        "kind": "LinkedField",
+        "name": "body",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "cursor",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "EventLiveFeedbackPrompt",
+            "kind": "LinkedField",
+            "name": "node",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "id",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ShareFeedbackPromptMutation",
+    "selections": (v1/*: any*/),
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "ShareFeedbackPromptMutation",
+    "selections": (v1/*: any*/)
+  },
+  "params": {
+    "cacheID": "964511c1baf025a3381554b61f8e7f04",
+    "id": null,
+    "metadata": {},
+    "name": "ShareFeedbackPromptMutation",
+    "operationKind": "mutation",
+    "text": "mutation ShareFeedbackPromptMutation(\n  $promptId: ID!\n) {\n  reshareFeedbackPrompt(promptId: $promptId) {\n    isError\n    message\n    body {\n      cursor\n      node {\n        id\n      }\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "0345fab8a625a9d3f8a1ff29f9297bf5";
+
+export default node;

--- a/app/client/src/__generated__/useLiveFeedbackPromptSubscription.graphql.ts
+++ b/app/client/src/__generated__/useLiveFeedbackPromptSubscription.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<f03c568493d8733a94f5ba6381b05dcd>>
+ * @generated SignedSource<<f7afa589034b18876582b9372e7a8ebf>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -14,13 +14,15 @@ export type useLiveFeedbackPromptSubscription$variables = {
 };
 export type useLiveFeedbackPromptSubscription$data = {
   readonly feedbackPrompted: {
-    readonly id: string;
-    readonly isDraft: boolean | null;
-    readonly isMultipleChoice: boolean | null;
-    readonly isOpenEnded: boolean | null;
-    readonly isVote: boolean | null;
-    readonly multipleChoiceOptions: ReadonlyArray<string> | null;
-    readonly prompt: string;
+    readonly node: {
+      readonly id: string;
+      readonly isDraft: boolean | null;
+      readonly isMultipleChoice: boolean | null;
+      readonly isOpenEnded: boolean | null;
+      readonly isVote: boolean | null;
+      readonly multipleChoiceOptions: ReadonlyArray<string> | null;
+      readonly prompt: string;
+    };
   };
 };
 export type useLiveFeedbackPromptSubscription = {
@@ -46,7 +48,7 @@ v1 = [
         "variableName": "eventId"
       }
     ],
-    "concreteType": "EventLiveFeedbackPrompt",
+    "concreteType": "EventLiveFeedbackPromptEdge",
     "kind": "LinkedField",
     "name": "feedbackPrompted",
     "plural": false,
@@ -54,50 +56,61 @@ v1 = [
       {
         "alias": null,
         "args": null,
-        "kind": "ScalarField",
-        "name": "id",
-        "storageKey": null
-      },
-      {
-        "alias": null,
-        "args": null,
-        "kind": "ScalarField",
-        "name": "prompt",
-        "storageKey": null
-      },
-      {
-        "alias": null,
-        "args": null,
-        "kind": "ScalarField",
-        "name": "isVote",
-        "storageKey": null
-      },
-      {
-        "alias": null,
-        "args": null,
-        "kind": "ScalarField",
-        "name": "isDraft",
-        "storageKey": null
-      },
-      {
-        "alias": null,
-        "args": null,
-        "kind": "ScalarField",
-        "name": "isOpenEnded",
-        "storageKey": null
-      },
-      {
-        "alias": null,
-        "args": null,
-        "kind": "ScalarField",
-        "name": "isMultipleChoice",
-        "storageKey": null
-      },
-      {
-        "alias": null,
-        "args": null,
-        "kind": "ScalarField",
-        "name": "multipleChoiceOptions",
+        "concreteType": "EventLiveFeedbackPrompt",
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "prompt",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "isVote",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "isDraft",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "isOpenEnded",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "isMultipleChoice",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "multipleChoiceOptions",
+            "storageKey": null
+          }
+        ],
         "storageKey": null
       }
     ],
@@ -122,16 +135,16 @@ return {
     "selections": (v1/*: any*/)
   },
   "params": {
-    "cacheID": "d252d6ad06a7bbf09e1a22d19d75cd87",
+    "cacheID": "8a67d4ead30d9e680f812ec39555c066",
     "id": null,
     "metadata": {},
     "name": "useLiveFeedbackPromptSubscription",
     "operationKind": "subscription",
-    "text": "subscription useLiveFeedbackPromptSubscription(\n  $eventId: ID!\n) {\n  feedbackPrompted(eventId: $eventId) {\n    id\n    prompt\n    isVote\n    isDraft\n    isOpenEnded\n    isMultipleChoice\n    multipleChoiceOptions\n  }\n}\n"
+    "text": "subscription useLiveFeedbackPromptSubscription(\n  $eventId: ID!\n) {\n  feedbackPrompted(eventId: $eventId) {\n    node {\n      id\n      prompt\n      isVote\n      isDraft\n      isOpenEnded\n      isMultipleChoice\n      multipleChoiceOptions\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "734052273232777e5039afae3dbdc9cb";
+(node as any).hash = "35f418331281c37477421497ffc1a59a";
 
 export default node;

--- a/app/client/src/__generated__/useLiveFeedbackPromptedSubscription.graphql.ts
+++ b/app/client/src/__generated__/useLiveFeedbackPromptedSubscription.graphql.ts
@@ -1,0 +1,195 @@
+/**
+ * @generated SignedSource<<81a36a07554daf55a2bef26b21a0539b>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest, GraphQLSubscription } from 'relay-runtime';
+export type useLiveFeedbackPromptedSubscription$variables = {
+  connections: ReadonlyArray<string>;
+  eventId: string;
+};
+export type useLiveFeedbackPromptedSubscription$data = {
+  readonly feedbackPrompted: {
+    readonly node: {
+      readonly id: string;
+      readonly isDraft: boolean | null;
+      readonly isMultipleChoice: boolean | null;
+      readonly isOpenEnded: boolean | null;
+      readonly isVote: boolean | null;
+      readonly multipleChoiceOptions: ReadonlyArray<string> | null;
+      readonly prompt: string;
+    };
+  };
+};
+export type useLiveFeedbackPromptedSubscription = {
+  response: useLiveFeedbackPromptedSubscription$data;
+  variables: useLiveFeedbackPromptedSubscription$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "connections"
+},
+v1 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "eventId"
+},
+v2 = [
+  {
+    "kind": "Variable",
+    "name": "eventId",
+    "variableName": "eventId"
+  }
+],
+v3 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "EventLiveFeedbackPrompt",
+  "kind": "LinkedField",
+  "name": "node",
+  "plural": false,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "id",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "prompt",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "isVote",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "isDraft",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "isOpenEnded",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "isMultipleChoice",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "multipleChoiceOptions",
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v1/*: any*/)
+    ],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "useLiveFeedbackPromptedSubscription",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v2/*: any*/),
+        "concreteType": "EventLiveFeedbackPromptEdge",
+        "kind": "LinkedField",
+        "name": "feedbackPrompted",
+        "plural": false,
+        "selections": [
+          (v3/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Subscription",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [
+      (v1/*: any*/),
+      (v0/*: any*/)
+    ],
+    "kind": "Operation",
+    "name": "useLiveFeedbackPromptedSubscription",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v2/*: any*/),
+        "concreteType": "EventLiveFeedbackPromptEdge",
+        "kind": "LinkedField",
+        "name": "feedbackPrompted",
+        "plural": false,
+        "selections": [
+          (v3/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "filters": null,
+            "handle": "appendNode",
+            "key": "",
+            "kind": "LinkedHandle",
+            "name": "node",
+            "handleArgs": [
+              {
+                "kind": "Variable",
+                "name": "connections",
+                "variableName": "connections"
+              },
+              {
+                "kind": "Literal",
+                "name": "edgeTypeName",
+                "value": "EventLiveFeedbackPromptEdge"
+              }
+            ]
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "e2703f8cb4ffaaf505f3f488ac518a87",
+    "id": null,
+    "metadata": {},
+    "name": "useLiveFeedbackPromptedSubscription",
+    "operationKind": "subscription",
+    "text": "subscription useLiveFeedbackPromptedSubscription(\n  $eventId: ID!\n) {\n  feedbackPrompted(eventId: $eventId) {\n    node {\n      id\n      prompt\n      isVote\n      isDraft\n      isOpenEnded\n      isMultipleChoice\n      multipleChoiceOptions\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "1d2796acdd5eeb8da02c0504fe76d400";
+
+export default node;

--- a/app/client/src/components/SettingsMenu/SettingsMenu.tsx
+++ b/app/client/src/components/SettingsMenu/SettingsMenu.tsx
@@ -20,12 +20,23 @@ interface Props {
  * @param {AccordionData[]} config of the content
  */
 export function SettingsMenu({ config }: Props) {
+    const [expanded, setExpanded] = React.useState<string | false>(false);
+
+    const handleChange = (panel: string) => (e: React.SyntheticEvent, newExpanded: boolean) => {
+        e.preventDefault();
+        setExpanded(newExpanded ? panel : false);
+    };
+
     return (
-        <div style={{ height: '100%', width: '100%' }}>
+        <React.Fragment>
             {config.map(
                 ({ title: sectionTitle, description, component }, idx) =>
                     component && (
-                        <Accordion key={idx}>
+                        <Accordion
+                            key={idx}
+                            expanded={expanded === `panel-${sectionTitle}`}
+                            onChange={handleChange(`panel-${sectionTitle}`)}
+                        >
                             <AccordionSummary expandIcon={<ExpandMoreIcon />} aria-controls={`panel-${sectionTitle}`}>
                                 <Typography variant='h5'>{sectionTitle}</Typography>
                             </AccordionSummary>
@@ -44,6 +55,6 @@ export function SettingsMenu({ config }: Props) {
                         </Accordion>
                     )
             )}
-        </div>
+        </React.Fragment>
     );
 }

--- a/app/client/src/features/events/BroadcastMessages/BroadcastMessageInput.tsx
+++ b/app/client/src/features/events/BroadcastMessages/BroadcastMessageInput.tsx
@@ -50,7 +50,10 @@ export function BroadcastMessageInput() {
         [form]
     );
 
-    const handleClose = () => setState({ message: '' });
+    const handleClose = () => {
+        close();
+        setState({ message: '' });
+    };
 
     const handleOpen = () => {
         setState({ message: '' });

--- a/app/client/src/features/events/EventContext.ts
+++ b/app/client/src/features/events/EventContext.ts
@@ -16,8 +16,8 @@ interface TEventContext {
      * is the current user a moderator
      */
     isModerator: boolean;
-    pauseParentRefreshing: () => void;
-    resumeParentRefreshing: () => void;
+    pauseParentRefreshing?: () => void;
+    resumeParentRefreshing?: () => void;
     eventData: useEventDetailsFragment$data;
 }
 

--- a/app/client/src/features/events/EventContext.ts
+++ b/app/client/src/features/events/EventContext.ts
@@ -1,3 +1,4 @@
+import { useEventDetailsFragment$data } from '@local/__generated__/useEventDetailsFragment.graphql';
 import { createContext } from 'react';
 
 /**
@@ -17,6 +18,7 @@ interface TEventContext {
     isModerator: boolean;
     pauseParentRefreshing: () => void;
     resumeParentRefreshing: () => void;
+    eventData: useEventDetailsFragment$data;
 }
 
 // if value is null, then there is no context within the parent tree

--- a/app/client/src/features/events/EventLive.tsx
+++ b/app/client/src/features/events/EventLive.tsx
@@ -193,6 +193,7 @@ function EventLive({ node, validateInvite, tokenProvided }: EventLiveProps) {
                 isModerator: Boolean(node.isViewerModerator),
                 pauseParentRefreshing,
                 resumeParentRefreshing,
+                eventData,
             }}
         >
             <EventTopicContext.Provider value={{ topic: 'default', topics: [] }}>

--- a/app/client/src/features/events/EventLiveModeratorView.tsx
+++ b/app/client/src/features/events/EventLiveModeratorView.tsx
@@ -56,29 +56,18 @@ interface EventLiveProps {
 }
 
 function EventLiveModeratorView({ node }: EventLiveProps) {
-    const { pauseEventDetailsRefresh, resumeEventDetailsRefresh } = useEventDetails({
+    const { eventData } = useEventDetails({
         fragmentRef: node,
     });
     const { id: eventId } = node;
-    const { pausePingEvent, resumePingEvent } = usePingEvent(eventId);
-
-    const pauseParentRefreshing = React.useCallback(() => {
-        pauseEventDetailsRefresh();
-        pausePingEvent();
-    }, [pauseEventDetailsRefresh, pausePingEvent]);
-
-    const resumeParentRefreshing = React.useCallback(() => {
-        resumeEventDetailsRefresh();
-        resumePingEvent();
-    }, [resumeEventDetailsRefresh, resumePingEvent]);
+    usePingEvent(eventId);
 
     return (
         <EventContext.Provider
             value={{
                 eventId: node.id,
                 isModerator: Boolean(node.isViewerModerator),
-                pauseParentRefreshing,
-                resumeParentRefreshing,
+                eventData,
             }}
         >
             <EventTopicContext.Provider value={{ topic: 'default', topics: [] }}>

--- a/app/client/src/features/events/EventPost.tsx
+++ b/app/client/src/features/events/EventPost.tsx
@@ -83,6 +83,7 @@ export function EventPost({ node }: EventPostProps) {
                 isModerator: Boolean(eventData.isViewerModerator),
                 pauseParentRefreshing: () => {},
                 resumeParentRefreshing: () => {},
+                eventData,
             }}
         >
             <Grid container spacing={2} columns={16} height='100%'>

--- a/app/client/src/features/events/EventPre.tsx
+++ b/app/client/src/features/events/EventPre.tsx
@@ -78,6 +78,7 @@ export function EventPre({ fragmentRef }: EventPreProps) {
                 isModerator: Boolean(eventData.isViewerModerator),
                 pauseParentRefreshing: () => {},
                 resumeParentRefreshing: () => {},
+                eventData,
             }}
         >
             <Grid container spacing={2} columns={16} height='100%'>

--- a/app/client/src/features/events/LiveFeedbackPrompts/FeedbackDashboard.tsx
+++ b/app/client/src/features/events/LiveFeedbackPrompts/FeedbackDashboard.tsx
@@ -4,25 +4,29 @@ import DashboardIcon from '@mui/icons-material/Dashboard';
 import { useTheme } from '@mui/material/styles';
 import useMediaQuery from '@mui/material/useMediaQuery';
 
-import { StyledDialogTitle, StyledDialog } from '@local/components';
+import { StyledDialogTitle, StyledDialog, Loader } from '@local/components';
 import { useLiveFeedbackPromptsFragment$key } from '@local/__generated__/useLiveFeedbackPromptsFragment.graphql';
 import { LiveFeedbackPromptsList } from './LiveFeedbackPrompt/LiveFeedbackPromptList';
 
-interface ShareFeedbackResultsProps {
+interface FeedbackDashboardProps {
     fragmentRef: useLiveFeedbackPromptsFragment$key;
 }
 
 /**
- * A modal that opens when moderators click on the "Share Feedback Results" button
+ * A modal that opens when moderators click on the "Feedback Dashboard" button
  * A list of previous feedback prompts are displayed, and moderators can click on each one to see the responses
  * A button can be pressed to share the results card for one of the prompts with the audience
  */
-export function ShareFeedbackResults({ fragmentRef }: ShareFeedbackResultsProps) {
+export function FeedbackDashboard({ fragmentRef }: FeedbackDashboardProps) {
     const theme = useTheme();
     const fullscreen = useMediaQuery(theme.breakpoints.down('md'));
     const [open, setOpen] = React.useState(false);
-    const handleOpen = () => setOpen(true);
-    const handleClose = () => setOpen(false);
+    const handleOpen = () => {
+        setOpen(true);
+    };
+    const handleClose = () => {
+        setOpen(false);
+    };
 
     return (
         <React.Fragment>
@@ -43,7 +47,9 @@ export function ShareFeedbackResults({ fragmentRef }: ShareFeedbackResultsProps)
                 </StyledDialogTitle>
                 <DialogContent dividers>
                     <Grid container direction='column' alignItems='center'>
-                        <LiveFeedbackPromptsList fragmentRef={fragmentRef} isShareResultsOpen={open} />
+                        <React.Suspense fallback={<Loader />}>
+                            <LiveFeedbackPromptsList fragmentRef={fragmentRef} />
+                        </React.Suspense>
                     </Grid>
                 </DialogContent>
             </StyledDialog>

--- a/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackPrompt/LiveFeedbackPromptList.tsx
+++ b/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackPrompt/LiveFeedbackPromptList.tsx
@@ -14,7 +14,6 @@ import {
 import DescriptionIcon from '@mui/icons-material/Description';
 import { OpenInNew as OpenInNewIcon } from '@mui/icons-material';
 import { useTheme, alpha } from '@mui/material/styles';
-import { useEvent } from '@local/features/events/useEvent';
 import { ShareFeedbackPromptDraft } from './ShareFeedbackPromptDraft';
 import { SubmitLiveFeedbackPrompt } from './SubmitLiveFeedbackPrompt';
 import { useLiveFeedbackPrompts } from './useLiveFeedbackPrompts';
@@ -189,32 +188,22 @@ function PromptList({ prompts: readonlyPrompts, handleClick, selectedTab, setSel
 
 interface LiveFeedbackPromptsListProps {
     fragmentRef: useLiveFeedbackPromptsFragment$key;
-    isShareResultsOpen: boolean;
 }
 
 /**
  * This component is responsible for loading the query and passing the fragment ref to the PromptList component
  */
-export function LiveFeedbackPromptsList({ fragmentRef, isShareResultsOpen }: LiveFeedbackPromptsListProps) {
+export function LiveFeedbackPromptsList({ fragmentRef }: LiveFeedbackPromptsListProps) {
     const [open, setOpen] = React.useState(false);
     const { prompts, connections, refresh } = useLiveFeedbackPrompts({
         fragmentRef,
-        isModalOpen: open,
-        isShareResultsOpen,
     });
     const [selectedTab, setSelectedTab] = React.useState<FeedbackDashboardTab>('open-ended');
     const [selectedPrompt, setSelectedPrompt] = React.useState<Prompt | null>(null);
     const selectedPromptRef = React.useRef<Prompt | null>(null);
-    const { pauseParentRefreshing, resumeParentRefreshing, eventId } = useEvent();
 
-    const handleOpen = () => {
-        setOpen(true);
-        pauseParentRefreshing();
-    };
-    const handleClose = () => {
-        setOpen(false);
-        resumeParentRefreshing();
-    };
+    const handleOpen = () => setOpen(true);
+    const handleClose = () => setOpen(false);
 
     const handlePromptClick = (prompt: Prompt) => {
         // Update the selected prompt ref
@@ -231,7 +220,7 @@ export function LiveFeedbackPromptsList({ fragmentRef, isShareResultsOpen }: Liv
 
     return (
         <React.Fragment>
-            <SubmitLiveFeedbackPrompt eventId={eventId} connections={connections} selectedTab={selectedTab} />
+            <SubmitLiveFeedbackPrompt connections={connections} selectedTab={selectedTab} />
             <Typography variant='h6'>Select view on a prompt to see its responses</Typography>
             <PromptList
                 prompts={prompts}

--- a/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackPrompt/LiveFeedbackPromptList.tsx
+++ b/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackPrompt/LiveFeedbackPromptList.tsx
@@ -10,6 +10,8 @@ import {
     Tab,
     CardActions,
     CardHeader,
+    Stack,
+    Tooltip,
 } from '@mui/material';
 import DescriptionIcon from '@mui/icons-material/Description';
 import { OpenInNew as OpenInNewIcon } from '@mui/icons-material';
@@ -19,6 +21,8 @@ import { SubmitLiveFeedbackPrompt } from './SubmitLiveFeedbackPrompt';
 import { useLiveFeedbackPrompts } from './useLiveFeedbackPrompts';
 import { useLiveFeedbackPromptsFragment$key } from '@local/__generated__/useLiveFeedbackPromptsFragment.graphql';
 import FeedbackResponsesDialog from './FeedbackResponsesDialog';
+import { useLiveFeedbackPrompted } from '../useLiveFeedbackPrompted';
+import { ShareFeedbackPrompt } from './ShareFeedbackPrompt';
 
 export type FeedbackDashboardTab = 'open-ended' | 'vote' | 'multiple-choice';
 
@@ -66,10 +70,15 @@ function PromptItem({ prompt, handleClick }: PromptItemProps) {
                 {prompt.isDraft ? (
                     <ShareFeedbackPromptDraft prompt={prompt} />
                 ) : (
-                    <IconButton onClick={() => handleClick(prompt)}>
-                        <OpenInNewIcon />
-                        <Typography variant='subtitle1'>View</Typography>
-                    </IconButton>
+                    <Stack direction='row' spacing={1}>
+                        <Tooltip title='View Responses' placement='top'>
+                            <IconButton onClick={() => handleClick(prompt)}>
+                                <OpenInNewIcon />
+                                <Typography variant='subtitle1'>View Responses</Typography>
+                            </IconButton>
+                        </Tooltip>
+                        <ShareFeedbackPrompt prompt={prompt} />
+                    </Stack>
                 )}
             </CardActions>
         </Card>
@@ -198,6 +207,7 @@ export function LiveFeedbackPromptsList({ fragmentRef }: LiveFeedbackPromptsList
     const { prompts, connections, refresh } = useLiveFeedbackPrompts({
         fragmentRef,
     });
+    useLiveFeedbackPrompted({ connections });
     const [selectedTab, setSelectedTab] = React.useState<FeedbackDashboardTab>('open-ended');
     const [selectedPrompt, setSelectedPrompt] = React.useState<Prompt | null>(null);
     const selectedPromptRef = React.useRef<Prompt | null>(null);

--- a/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackPrompt/ShareFeedbackPrompt.tsx
+++ b/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackPrompt/ShareFeedbackPrompt.tsx
@@ -1,0 +1,84 @@
+import * as React from 'react';
+import { Button, DialogContent, Grid, IconButton, Tooltip, Typography } from '@mui/material';
+import SendIcon from '@mui/icons-material/Send';
+import { useMutation, graphql } from 'react-relay';
+
+import type { ShareFeedbackPromptMutation } from '@local/__generated__/ShareFeedbackPromptMutation.graphql';
+import { ResponsiveDialog, useResponsiveDialog } from '@local/components/ResponsiveDialog';
+import { useSnack } from '@local/core';
+import { Prompt } from './LiveFeedbackPromptList';
+
+interface Props {
+    prompt: Prompt;
+}
+
+export const SHARE_FEEDBACK_PROMPT_MUTATION = graphql`
+    mutation ShareFeedbackPromptMutation($promptId: ID!) {
+        reshareFeedbackPrompt(promptId: $promptId) {
+            isError
+            message
+            body {
+                cursor
+                node {
+                    id
+                }
+            }
+        }
+    }
+`;
+
+export function ShareFeedbackPrompt({ prompt }: Props) {
+    const [isOpen, open, close] = useResponsiveDialog();
+    const { displaySnack } = useSnack();
+    const [commit] = useMutation<ShareFeedbackPromptMutation>(SHARE_FEEDBACK_PROMPT_MUTATION);
+
+    function handleSubmit() {
+        try {
+            commit({
+                variables: { promptId: prompt.id },
+                onCompleted(payload) {
+                    try {
+                        if (payload.reshareFeedbackPrompt.isError)
+                            throw new Error(payload.reshareFeedbackPrompt.message);
+                        close();
+                        displaySnack('Prompt re-shared successfully!', { variant: 'success' });
+                    } catch (err) {
+                        if (err instanceof Error) displaySnack(err.message, { variant: 'error' });
+                        else displaySnack('Something went wrong!');
+                    }
+                },
+            });
+        } catch (err) {
+            if (err instanceof Error) displaySnack(err.message, { variant: 'error' });
+            else displaySnack('Something went wrong!');
+        }
+    }
+
+    return (
+        <React.Fragment>
+            <ResponsiveDialog open={isOpen} onClose={close}>
+                <DialogContent>
+                    <Typography variant='h6'>Are you sure you want to re-share this prompt?</Typography>
+                    <Typography variant='subtitle2'>
+                        NOTE: Only shares with participants that have not yet responded to the prompt.
+                    </Typography>
+                    <Typography variant='body1'>
+                        <b>Prompt: {prompt.prompt}</b>
+                    </Typography>
+                    <Grid container justifyContent='end'>
+                        <Button onClick={close}>Cancel</Button>
+                        <Button variant='contained' color='primary' onClick={handleSubmit}>
+                            Share
+                        </Button>
+                    </Grid>
+                </DialogContent>
+            </ResponsiveDialog>
+            <Tooltip title='Share Prompt' placement='top'>
+                <IconButton onClick={open}>
+                    <SendIcon />
+                    <Typography variant='subtitle1'>Re-Share Prompt</Typography>
+                </IconButton>
+            </Tooltip>
+        </React.Fragment>
+    );
+}

--- a/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackPrompt/SubmitLiveFeedbackPrompt.tsx
+++ b/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackPrompt/SubmitLiveFeedbackPrompt.tsx
@@ -12,6 +12,7 @@ import { useSnack } from '@local/core';
 import { FEEDBACK_PROMPT_MAX_LENGTH } from '@local/utils/rules';
 import { isURL } from '@local/utils';
 import type { FeedbackDashboardTab } from './LiveFeedbackPromptList';
+import { useEvent } from '@local/features/events';
 
 export const SUBMIT_LIVE_FEEDBACK_PROMPT_MUTATION = graphql`
     mutation SubmitLiveFeedbackPromptMutation($input: CreateFeedbackPrompt!, $connections: [ID!]!) {
@@ -38,14 +39,14 @@ export const SUBMIT_LIVE_FEEDBACK_PROMPT_MUTATION = graphql`
 
 interface Props {
     className?: string;
-    eventId: string;
     connections: string[];
     selectedTab: FeedbackDashboardTab;
 }
 
-export function SubmitLiveFeedbackPrompt({ className, eventId, connections, selectedTab }: Props) {
+export function SubmitLiveFeedbackPrompt({ className, connections, selectedTab }: Props) {
     const [isOpen, open, close] = useResponsiveDialog();
     const { user } = useUser();
+    const { eventId } = useEvent();
     const { displaySnack } = useSnack();
     const [commit] = useMutation<SubmitLiveFeedbackPromptMutation>(SUBMIT_LIVE_FEEDBACK_PROMPT_MUTATION);
 

--- a/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackPrompt/useLiveFeedbackPrompts.tsx
+++ b/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackPrompt/useLiveFeedbackPrompts.tsx
@@ -65,7 +65,7 @@ export function useLiveFeedbackPrompts({ fragmentRef }: Props) {
             liveFeedbackPrompts?.edges
                 ? liveFeedbackPrompts.edges.map(({ node, cursor }) => ({ ...node, cursor }))
                 : [],
-        [liveFeedbackPrompts]
+        [liveFeedbackPrompts?.edges]
     );
 
     const connections = React.useMemo(

--- a/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackPrompt/useLiveFeedbackPrompts.tsx
+++ b/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackPrompt/useLiveFeedbackPrompts.tsx
@@ -36,19 +36,14 @@ const USE_LIVE_FEEDBACK_PROMPTS = graphql`
 
 export interface Props {
     fragmentRef: useLiveFeedbackPromptsFragment$key;
-    isModalOpen: boolean;
-    isShareResultsOpen: boolean;
 }
 
-export function useLiveFeedbackPrompts({ fragmentRef, isModalOpen, isShareResultsOpen }: Props) {
+export function useLiveFeedbackPrompts({ fragmentRef }: Props) {
     const [data, refetch] = useRefetchableFragment(USE_LIVE_FEEDBACK_PROMPTS, fragmentRef);
     const { liveFeedbackPrompts } = data;
 
     const REFETCH_INTERVAL = 20000; // 20 seconds
     const refresh = React.useCallback(() => {
-        // if the modal is open, don't refetch (Ensures secondary modal doesn't flash)
-        if (isModalOpen) return;
-
         const endCursor = data.liveFeedbackPrompts?.pageInfo?.endCursor;
 
         // Prepare variables conditionally
@@ -62,16 +57,8 @@ export function useLiveFeedbackPrompts({ fragmentRef, isModalOpen, isShareResult
         }
 
         refetch(variables, { fetchPolicy: 'store-and-network' });
-    }, [isModalOpen, refetch, data.liveFeedbackPrompts?.pageInfo?.endCursor]);
-    const { pauseRefresh, resumeRefresh } = useRefresh({ refreshInterval: REFETCH_INTERVAL, callback: refresh });
-
-    React.useEffect(() => {
-        if (isModalOpen || !isShareResultsOpen) {
-            pauseRefresh();
-        } else {
-            resumeRefresh();
-        }
-    }, [isModalOpen, isShareResultsOpen, pauseRefresh, resumeRefresh]);
+    }, [refetch, data.liveFeedbackPrompts?.pageInfo?.endCursor]);
+    useRefresh({ refreshInterval: REFETCH_INTERVAL, callback: refresh });
 
     const promptsList = React.useMemo(
         () =>
@@ -86,5 +73,5 @@ export function useLiveFeedbackPrompts({ fragmentRef, isModalOpen, isShareResult
         [data.liveFeedbackPrompts?.__id]
     );
 
-    return { prompts: promptsList, connections, pauseRefresh, resumeRefresh, refresh };
+    return { prompts: promptsList, connections, refresh };
 }

--- a/app/client/src/features/events/LiveFeedbackPrompts/index.ts
+++ b/app/client/src/features/events/LiveFeedbackPrompts/index.ts
@@ -1,2 +1,2 @@
-export * from './ShareFeedbackResults';
 export * from './useLiveFeedbackPrompt';
+export * from './FeedbackDashboard';

--- a/app/client/src/features/events/LiveFeedbackPrompts/useLiveFeedbackPrompt.tsx
+++ b/app/client/src/features/events/LiveFeedbackPrompts/useLiveFeedbackPrompt.tsx
@@ -8,13 +8,15 @@ import { useLiveFeedbackPromptResponseSnack } from './LiveFeedbackPromptResponse
 export const USE_LIVE_FEEDBACK_PROMPT_SUBSCRIPTION = graphql`
     subscription useLiveFeedbackPromptSubscription($eventId: ID!) {
         feedbackPrompted(eventId: $eventId) {
-            id
-            prompt
-            isVote
-            isDraft
-            isOpenEnded
-            isMultipleChoice
-            multipleChoiceOptions
+            node {
+                id
+                prompt
+                isVote
+                isDraft
+                isOpenEnded
+                isMultipleChoice
+                multipleChoiceOptions
+            }
         }
     }
 `;
@@ -86,7 +88,7 @@ export function useLiveFeedbackPrompt({ openFeedbackPromptResponse }: Props) {
             subscription: USE_LIVE_FEEDBACK_PROMPT_SUBSCRIPTION,
             onNext: (data) => {
                 if (!data) return;
-                const { feedbackPrompted } = data;
+                const { node: feedbackPrompted } = data.feedbackPrompted;
                 const {
                     id: promptId,
                     prompt,
@@ -95,6 +97,8 @@ export function useLiveFeedbackPrompt({ openFeedbackPromptResponse }: Props) {
                     isMultipleChoice,
                     multipleChoiceOptions,
                 } = feedbackPrompted;
+                // Check if prompt is already enqueued to avoid duplicates
+                if (enqueuedPrompts.some((_prompt) => _prompt.id === promptId)) return;
                 enqueuedPrompts.push({
                     id: promptId,
                     prompt,

--- a/app/client/src/features/events/LiveFeedbackPrompts/useLiveFeedbackPrompted.ts
+++ b/app/client/src/features/events/LiveFeedbackPrompts/useLiveFeedbackPrompted.ts
@@ -1,0 +1,42 @@
+import * as React from 'react';
+import { graphql, useSubscription } from 'react-relay';
+import { useLiveFeedbackPromptedSubscription } from '@local/__generated__/useLiveFeedbackPromptedSubscription.graphql';
+import { useEvent } from '@local/features/events/useEvent';
+import { GraphQLSubscriptionConfig } from 'relay-runtime';
+
+export const USE_LIVE_FEEDBACK_PROMPTED_SUBSCRIPTION = graphql`
+    subscription useLiveFeedbackPromptedSubscription($eventId: ID!, $connections: [ID!]!) {
+        feedbackPrompted(eventId: $eventId) {
+            node @appendNode(connections: $connections, edgeTypeName: "EventLiveFeedbackPromptEdge") {
+                id
+                prompt
+                isVote
+                isDraft
+                isOpenEnded
+                isMultipleChoice
+                multipleChoiceOptions
+            }
+        }
+    }
+`;
+
+interface Props {
+    connections: string[];
+}
+
+export function useLiveFeedbackPrompted({ connections }: Props) {
+    const { eventId } = useEvent();
+
+    const config = React.useMemo<GraphQLSubscriptionConfig<useLiveFeedbackPromptedSubscription>>(
+        () => ({
+            variables: {
+                eventId: eventId,
+                connections,
+            },
+            subscription: USE_LIVE_FEEDBACK_PROMPTED_SUBSCRIPTION,
+        }),
+        [connections, eventId]
+    );
+
+    useSubscription<useLiveFeedbackPromptedSubscription>(config);
+}

--- a/app/client/src/features/events/Moderation/ModeratorActions.tsx
+++ b/app/client/src/features/events/Moderation/ModeratorActions.tsx
@@ -1,13 +1,14 @@
 import React from 'react';
 import { graphql, useMutation } from 'react-relay';
-import { Button, Stack } from '@mui/material';
+import { Button, Stack, useMediaQuery } from '@mui/material';
+import { useTheme } from '@mui/material/styles';
 
 import type { ModeratorActionsStartEventMutation } from '@local/__generated__/ModeratorActionsStartEventMutation.graphql';
 import type { ModeratorActionsEndEventMutation } from '@local/__generated__/ModeratorActionsEndEventMutation.graphql';
 import { useSnack } from '@local/core';
 import { ConfirmationDialog } from '@local/components/ConfirmationDialog';
-import { ShareFeedbackResults } from '../LiveFeedbackPrompts';
 import { useLiveFeedbackPromptsFragment$key } from '@local/__generated__/useLiveFeedbackPromptsFragment.graphql';
+import { FeedbackDashboard } from '../LiveFeedbackPrompts';
 
 export const START_EVENT_MUTATION = graphql`
     mutation ModeratorActionsStartEventMutation($eventId: String!) {
@@ -24,6 +25,17 @@ export const END_EVENT_MUTATION = graphql`
         }
     }
 `;
+
+const ResponsiveStack = ({ children }: { children: React.ReactNode }) => {
+    const theme = useTheme();
+    const mdDownBreakpoint = useMediaQuery(theme.breakpoints.down('md'));
+
+    return (
+        <Stack direction={mdDownBreakpoint ? 'column' : 'row'} justifyContent='center' alignItems='center' spacing={2}>
+            {children}
+        </Stack>
+    );
+};
 
 export interface ModeratorActionsProps {
     isLive: Boolean;
@@ -81,17 +93,15 @@ export function ModeratorActions({ isLive, setIsLive, eventId, fragmentRef }: Mo
 
     return (
         <Stack direction='column' paddingTop='1rem'>
-            <Stack direction='row' justifyContent='center' alignItems='center' spacing={2}>
+            <ResponsiveStack>
                 {/* <Button variant='contained' onClick={() => console.log('TODO')}>
                     Intermission
                 </Button> */}
                 <Button variant='contained' color={isLive ? 'error' : 'success'} onClick={openConfirmationDialog}>
                     {isLive ? 'End Event' : 'Start Event'}
                 </Button>
-                <React.Suspense fallback={<ShareFeedbackResults fragmentRef={fragmentRef} />}>
-                    <ShareFeedbackResults fragmentRef={fragmentRef} />
-                </React.Suspense>
-            </Stack>
+                <FeedbackDashboard fragmentRef={fragmentRef} />
+            </ResponsiveStack>
             <ConfirmationDialog
                 title='Update Event Status'
                 open={isConfirmationDialogOpen}

--- a/app/client/src/features/events/ModeratorView/EventLiveNewModeratorView.tsx
+++ b/app/client/src/features/events/ModeratorView/EventLiveNewModeratorView.tsx
@@ -59,22 +59,12 @@ interface EventLiveProps {
 function EventLiveNewModeratorView({ node, refresh }: EventLiveProps) {
     const theme = useTheme();
     const isXlDownBreakpoint = useMediaQuery(theme.breakpoints.down('xl')); // Below 1080p (likely 720p)
-    const { eventData, pauseEventDetailsRefresh, resumeEventDetailsRefresh } = useEventDetails({
+    const { eventData } = useEventDetails({
         fragmentRef: node,
     });
     const { id: eventId } = node;
 
-    const { pausePingEvent, resumePingEvent } = usePingEvent(eventId);
-
-    const pauseParentRefreshing = React.useCallback(() => {
-        pauseEventDetailsRefresh();
-        pausePingEvent();
-    }, [pauseEventDetailsRefresh, pausePingEvent]);
-
-    const resumeParentRefreshing = React.useCallback(() => {
-        resumeEventDetailsRefresh();
-        resumePingEvent();
-    }, [resumeEventDetailsRefresh, resumePingEvent]);
+    usePingEvent(eventId);
 
     // TODO: Improve suspense loading with skeletons that match the panel sizes
     return (
@@ -82,8 +72,6 @@ function EventLiveNewModeratorView({ node, refresh }: EventLiveProps) {
             value={{
                 eventId: node.id,
                 isModerator: Boolean(node.isViewerModerator),
-                pauseParentRefreshing,
-                resumeParentRefreshing,
                 eventData,
             }}
         >

--- a/app/client/src/features/events/ModeratorView/EventLiveNewModeratorView.tsx
+++ b/app/client/src/features/events/ModeratorView/EventLiveNewModeratorView.tsx
@@ -84,6 +84,7 @@ function EventLiveNewModeratorView({ node, refresh }: EventLiveProps) {
                 isModerator: Boolean(node.isViewerModerator),
                 pauseParentRefreshing,
                 resumeParentRefreshing,
+                eventData,
             }}
         >
             <PanelGroup direction='horizontal'>

--- a/app/client/src/graphql-types.ts
+++ b/app/client/src/graphql-types.ts
@@ -839,6 +839,7 @@ export type Mutation = {
    * returns false if an account with the provided email cannot be found
    */
   resetPasswordRequest: ResetPasswordRequestMutationResponse;
+  reshareFeedbackPrompt: EventFeedbackPromptMutationResponse;
   shareFeedbackPromptDraft: EventFeedbackPromptMutationResponse;
   shareFeedbackPromptResults: EventFeedbackPromptMutationResponse;
   /** Start the event so that it is "live" */
@@ -1134,6 +1135,11 @@ export type MutationResetPasswordArgs = {
 
 export type MutationResetPasswordRequestArgs = {
   input: ResetPasswordRequestForm;
+};
+
+
+export type MutationReshareFeedbackPromptArgs = {
+  promptId: Scalars['ID'];
 };
 
 
@@ -1523,7 +1529,7 @@ export type Subscription = {
   eventUpdates: Event;
   feedbackCRUD: FeedbackOperation;
   feedbackPromptResultsShared: EventLiveFeedbackPrompt;
-  feedbackPrompted: EventLiveFeedbackPrompt;
+  feedbackPrompted: EventLiveFeedbackPromptEdge;
   /** subscription for whenever a new org is added */
   orgUpdated: OrganizationSubscription;
   participantMuted?: Maybe<Scalars['Boolean']>;

--- a/app/client/src/pages/events/[id]/settings.tsx
+++ b/app/client/src/pages/events/[id]/settings.tsx
@@ -4,7 +4,7 @@ import { useRouter } from 'next/router';
 import { useQueryLoader } from 'react-relay';
 
 import { EventSettingsQuery } from '@local/__generated__/EventSettingsQuery.graphql';
-import { EventSettings, EVENT_SETTINGS_QUERY } from '@local/features/events';
+import { EventSettingsContainer, EVENT_SETTINGS_QUERY } from '@local/features/events';
 import { Loader } from '@local/components/Loader';
 import { useUser } from '@local/features/accounts';
 
@@ -26,7 +26,7 @@ const Page: NextPage = () => {
 
     return (
         <React.Suspense fallback={<Loader />}>
-            <EventSettings queryRef={queryRef} />
+            <EventSettingsContainer queryRef={queryRef} />
         </React.Suspense>
     );
 };

--- a/app/server/src/core/plugins/mercurius.ts
+++ b/app/server/src/core/plugins/mercurius.ts
@@ -90,6 +90,9 @@ export function attachMercuriusTo(server: FastifyInstance) {
     mercuriusCodgen(server, {
         // Should be src/graphql-types.ts
         targetPath: join(__dirname, '../../graphql-types.ts'),
+        watchOptions: {
+            enabled: process.env.NODE_ENV === 'development',
+        },
         codegenConfig: {
             internalResolversPrefix: '__',
             // For some reason, mercurius changes this from the default.

--- a/app/server/src/core/server.ts
+++ b/app/server/src/core/server.ts
@@ -66,7 +66,13 @@ const makeServer =
         : makeDevelopmentServer;
 
 export function getOrCreateServer() {
-    const server = _server ?? makeServer();
-    if (!_server) _server = server;
-    return server;
+    try {
+        const server = _server ?? makeServer();
+        if (!_server) _server = server;
+        return server;
+    } catch (error) {
+        console.error('Failed to create server.');
+        console.error(error);
+        process.exit(1);
+    }
 }

--- a/app/server/src/core/startup.ts
+++ b/app/server/src/core/startup.ts
@@ -11,7 +11,7 @@ export function startup() {
     server.log.info('Performing setup checks...');
     checkEnv();
     server.log.info('Setting up graceful shutdown...');
-    initGracefulShutdown(server);
+    initGracefulShutdown();
 
     server.log.info('Creating clients...');
     try {

--- a/app/server/src/core/startup.ts
+++ b/app/server/src/core/startup.ts
@@ -10,32 +10,50 @@ export function startup() {
     const server = getOrCreateServer();
     server.log.info('Performing setup checks...');
     checkEnv();
-    initGracefulShutdown();
-    setupMetaRoutes(server);
-    // Init prisma client
-    getPrismaClient(server.log);
-    // Intit redis client
-    getRedisClient(server.log);
+    server.log.info('Setting up graceful shutdown...');
+    initGracefulShutdown(server);
 
-    getTranslationClient();
+    server.log.info('Creating clients...');
+    try {
+        getPrismaClient();
+        getRedisClient(server.log);
+        getTranslationClient();
+    } catch (error) {
+        server.log.error(error);
+        server.log.fatal('Failed to create clients, exiting.');
+        process.exit(1);
+    }
 
     server.log.info('Attaching plugins...');
-    plugins.attachAltairTo(server);
-    plugins.attachCookieTo(server);
-    plugins.attachCorsTo(server);
-    plugins.attachMercuriusTo(server);
-    plugins.attachMulterTo(server);
+    try {
+        plugins.attachAltairTo(server);
+        plugins.attachCookieTo(server);
+        plugins.attachCorsTo(server);
+        plugins.attachMercuriusTo(server);
+        plugins.attachMulterTo(server);
+    } catch (error) {
+        server.log.error(error);
+        server.log.fatal('Failed to attach plugins, exiting.');
+        process.exit(1);
+    }
 
     server.log.info('Attaching hooks...');
-    hooks.attachPreHandlerTo(server);
+    try {
+        hooks.attachPreHandlerTo(server);
+    } catch (error) {
+        server.log.error(error);
+        server.log.fatal('Failed to attach hooks, exiting.');
+        process.exit(1);
+    }
 
     server.log.info('Attaching routes...');
     try {
+        setupMetaRoutes(server);
         require('@local/features/accounts/account');
         require('@local/features/events/moderation/issue-guide');
         require('@local/features/google/google-meet');
     } catch (error) {
-        server.log.error('Failed to attach routes:', error);
+        server.log.error(error);
         server.log.fatal('Failed to attach routes, exiting.');
         process.exit(1);
     }

--- a/app/server/src/features/events/feedback/schema.graphql
+++ b/app/server/src/features/events/feedback/schema.graphql
@@ -147,6 +147,7 @@ type Mutation {
     createFeedbackDM(input: CreateFeedbackDM!): EventFeedbackMutationResponse!
     createFeedbackPrompt(input: CreateFeedbackPrompt!): EventFeedbackPromptMutationResponse!
     shareFeedbackPromptDraft(promptId: ID!): EventFeedbackPromptMutationResponse!
+    reshareFeedbackPrompt(promptId: ID!): EventFeedbackPromptMutationResponse!
     createFeedbackPromptResponse(input: CreateFeedbackPromptResponse!): EventFeedbackPromptResponseMutationResponse!
     shareFeedbackPromptResults(eventId: ID!, promptId: ID!): EventFeedbackPromptMutationResponse!
     submitPostEventFeedback(feedback: String!, eventId: ID!): PostEventFeedbackMutationResponse!
@@ -164,6 +165,6 @@ type Query {
 
 type Subscription {
     feedbackCRUD(eventId: ID!): FeedbackOperation!
-    feedbackPrompted(eventId: ID!): EventLiveFeedbackPrompt!
+    feedbackPrompted(eventId: ID!): EventLiveFeedbackPromptEdge!
     feedbackPromptResultsShared(eventId: ID!): EventLiveFeedbackPrompt!
 }

--- a/app/server/src/graphql-types.ts
+++ b/app/server/src/graphql-types.ts
@@ -359,6 +359,7 @@ export type Mutation = {
     createFeedbackDM: EventFeedbackMutationResponse;
     createFeedbackPrompt: EventFeedbackPromptMutationResponse;
     shareFeedbackPromptDraft: EventFeedbackPromptMutationResponse;
+    reshareFeedbackPrompt: EventFeedbackPromptMutationResponse;
     createFeedbackPromptResponse: EventFeedbackPromptResponseMutationResponse;
     shareFeedbackPromptResults: EventFeedbackPromptMutationResponse;
     submitPostEventFeedback: PostEventFeedbackMutationResponse;
@@ -532,6 +533,10 @@ export type MutationcreateFeedbackPromptArgs = {
 };
 
 export type MutationshareFeedbackPromptDraftArgs = {
+    promptId: Scalars['ID'];
+};
+
+export type MutationreshareFeedbackPromptArgs = {
     promptId: Scalars['ID'];
 };
 
@@ -946,7 +951,7 @@ export type Subscription = {
     broadcastMessageCreated: EventBroadcastMessageEdgeContainer;
     broadcastMessageDeleted: EventBroadcastMessageEdgeContainer;
     feedbackCRUD: FeedbackOperation;
-    feedbackPrompted: EventLiveFeedbackPrompt;
+    feedbackPrompted: EventLiveFeedbackPromptEdge;
     feedbackPromptResultsShared: EventLiveFeedbackPrompt;
     /** Subscribes to the creation of invites for a given event. */
     userInvited: UserEdgeContainer;
@@ -2722,6 +2727,12 @@ export type MutationResolvers<
         ContextType,
         RequireFields<MutationshareFeedbackPromptDraftArgs, 'promptId'>
     >;
+    reshareFeedbackPrompt?: Resolver<
+        ResolversTypes['EventFeedbackPromptMutationResponse'],
+        ParentType,
+        ContextType,
+        RequireFields<MutationreshareFeedbackPromptArgs, 'promptId'>
+    >;
     createFeedbackPromptResponse?: Resolver<
         ResolversTypes['EventFeedbackPromptResponseMutationResponse'],
         ParentType,
@@ -3189,7 +3200,7 @@ export type SubscriptionResolvers<
         RequireFields<SubscriptionfeedbackCRUDArgs, 'eventId'>
     >;
     feedbackPrompted?: SubscriptionResolver<
-        ResolversTypes['EventLiveFeedbackPrompt'],
+        ResolversTypes['EventLiveFeedbackPromptEdge'],
         'feedbackPrompted',
         ParentType,
         ContextType,


### PR DESCRIPTION
Various improvements including:
- Mod view improvements to fragment refreshing. Seems to be working now so that there is no flashing even when refreshing parent component fragments.
- Data for Feedback Dashboard refresh whenever it is opened as well as on an interval (while the window is open).
- Server logging improvements in settup
- Settings accordions now only have one open at a time (looks cleaner and takes up less space when going between sections.)
- Can now re-share prompts (shouldn't be any duplicates and does checks to ensure only participants that haven't responded yet would see a re-prompt notification).
- Creating/Sharing prompts are subscription based now so should update live if two moderators are looking at the dashboard at the same time