### PR TITLE
Prytaneum broadcast msg improvement

### DIFF
--- a/app/client/src/__generated__/useBroadcastMessageCreatedSubscription.graphql.ts
+++ b/app/client/src/__generated__/useBroadcastMessageCreatedSubscription.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<88d7ebc54484770934cc6918f9478b58>>
+ * @generated SignedSource<<5d9ef99aff32a422e6c7d7b1d5ca49e8>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -23,6 +23,7 @@ export type useBroadcastMessageCreatedSubscription$data = {
         readonly broadcastMessage: string;
         readonly createdBy: {
           readonly firstName: string | null;
+          readonly id: string;
         } | null;
         readonly id: string;
         readonly isVisible: boolean | null;
@@ -157,6 +158,7 @@ return {
                     "name": "createdBy",
                     "plural": false,
                     "selections": [
+                      (v5/*: any*/),
                       (v9/*: any*/)
                     ],
                     "storageKey": null
@@ -236,8 +238,8 @@ return {
                     "name": "createdBy",
                     "plural": false,
                     "selections": [
-                      (v9/*: any*/),
                       (v5/*: any*/),
+                      (v9/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -304,16 +306,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "c6d1043261ee8b5b5f172e489b4abf0f",
+    "cacheID": "1611ad2a6ca58a36a3d209497142c2df",
     "id": null,
     "metadata": {},
     "name": "useBroadcastMessageCreatedSubscription",
     "operationKind": "subscription",
-    "text": "subscription useBroadcastMessageCreatedSubscription(\n  $eventId: ID!\n  $lang: String!\n) {\n  broadcastMessageCreated(eventId: $eventId) {\n    edge {\n      cursor\n      node {\n        id\n        broadcastMessage\n        position\n        isVisible\n        createdBy {\n          firstName\n          id\n        }\n        ...BroadcastMessageActionsFragment\n        ...BroadcastMessageAuthorFragment\n        ...BroadcastMessageContentFragment_3iqx2P\n      }\n    }\n  }\n}\n\nfragment BroadcastMessageActionsFragment on EventBroadcastMessage {\n  id\n  ...DeleteBroadcastMessageButtonFragment\n  ...EditBroadcastMessageButtonFragment\n}\n\nfragment BroadcastMessageAuthorFragment on EventBroadcastMessage {\n  createdBy {\n    id\n    firstName\n    lastName\n    avatar\n  }\n  createdAt\n}\n\nfragment BroadcastMessageContentFragment_3iqx2P on EventBroadcastMessage {\n  broadcastMessage\n  lang\n  translatedBroadcastMessage(lang: $lang)\n}\n\nfragment DeleteBroadcastMessageButtonFragment on EventBroadcastMessage {\n  id\n  position\n}\n\nfragment EditBroadcastMessageButtonFragment on EventBroadcastMessage {\n  id\n}\n"
+    "text": "subscription useBroadcastMessageCreatedSubscription(\n  $eventId: ID!\n  $lang: String!\n) {\n  broadcastMessageCreated(eventId: $eventId) {\n    edge {\n      cursor\n      node {\n        id\n        broadcastMessage\n        position\n        isVisible\n        createdBy {\n          id\n          firstName\n        }\n        ...BroadcastMessageActionsFragment\n        ...BroadcastMessageAuthorFragment\n        ...BroadcastMessageContentFragment_3iqx2P\n      }\n    }\n  }\n}\n\nfragment BroadcastMessageActionsFragment on EventBroadcastMessage {\n  id\n  ...DeleteBroadcastMessageButtonFragment\n  ...EditBroadcastMessageButtonFragment\n}\n\nfragment BroadcastMessageAuthorFragment on EventBroadcastMessage {\n  createdBy {\n    id\n    firstName\n    lastName\n    avatar\n  }\n  createdAt\n}\n\nfragment BroadcastMessageContentFragment_3iqx2P on EventBroadcastMessage {\n  broadcastMessage\n  lang\n  translatedBroadcastMessage(lang: $lang)\n}\n\nfragment DeleteBroadcastMessageButtonFragment on EventBroadcastMessage {\n  id\n  position\n}\n\nfragment EditBroadcastMessageButtonFragment on EventBroadcastMessage {\n  id\n}\n"
   }
 };
 })();
 
-(node as any).hash = "c0da6dc48eee99a0a2ad77c935494b45";
+(node as any).hash = "702477e84febb7e0fe5cf931d293dc8a";
 
 export default node;

--- a/app/client/src/__generated__/useBroadcastMessageSnackSubscription.graphql.ts
+++ b/app/client/src/__generated__/useBroadcastMessageSnackSubscription.graphql.ts
@@ -1,0 +1,123 @@
+/**
+ * @generated SignedSource<<d72add0b4b6e14b7ff3289adcb0411f4>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest, GraphQLSubscription } from 'relay-runtime';
+export type useBroadcastMessageSnackSubscription$variables = {
+  eventId: string;
+};
+export type useBroadcastMessageSnackSubscription$data = {
+  readonly broadcastMessageCreated: {
+    readonly edge: {
+      readonly node: {
+        readonly broadcastMessage: string;
+        readonly id: string;
+      };
+    };
+  };
+};
+export type useBroadcastMessageSnackSubscription = {
+  response: useBroadcastMessageSnackSubscription$data;
+  variables: useBroadcastMessageSnackSubscription$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "eventId"
+  }
+],
+v1 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "eventId",
+        "variableName": "eventId"
+      }
+    ],
+    "concreteType": "EventBroadcastMessageEdgeContainer",
+    "kind": "LinkedField",
+    "name": "broadcastMessageCreated",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "EventBroadcastMessageEdge",
+        "kind": "LinkedField",
+        "name": "edge",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "EventBroadcastMessage",
+            "kind": "LinkedField",
+            "name": "node",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "id",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "broadcastMessage",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "useBroadcastMessageSnackSubscription",
+    "selections": (v1/*: any*/),
+    "type": "Subscription",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "useBroadcastMessageSnackSubscription",
+    "selections": (v1/*: any*/)
+  },
+  "params": {
+    "cacheID": "ec1333fe62efd766bc19de46d289b817",
+    "id": null,
+    "metadata": {},
+    "name": "useBroadcastMessageSnackSubscription",
+    "operationKind": "subscription",
+    "text": "subscription useBroadcastMessageSnackSubscription(\n  $eventId: ID!\n) {\n  broadcastMessageCreated(eventId: $eventId) {\n    edge {\n      node {\n        id\n        broadcastMessage\n      }\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "12fe548773bfa32374edbfc33b78af9e";
+
+export default node;

--- a/app/client/src/features/events/BroadcastMessages/BroadcastMessageList/useBroadcastMessageList.tsx
+++ b/app/client/src/features/events/BroadcastMessages/BroadcastMessageList/useBroadcastMessageList.tsx
@@ -50,15 +50,12 @@ export function useBroadcastMessageList({ fragmentRef }: useBroadcastMessageList
     const MAX_MESSAGES_DISPLAYED = 50;
     const [isRefreshing, setIsRefreshing] = React.useState(false);
 
-    const broadcastMessageList = React.useMemo(
-        () =>
-            broadcastMessages?.edges
-                ? broadcastMessages.edges.map(({ node, cursor }) => {
-                      return { ...node, cursor };
-                  })
-                : [],
-        [broadcastMessages]
-    );
+    const broadcastMessageList = React.useMemo(() => {
+        if (!broadcastMessages?.edges) return [];
+        return broadcastMessages.edges.map(({ node, cursor }) => {
+            return { ...node, cursor };
+        });
+    }, [broadcastMessages]);
 
     const refresh = React.useCallback(() => {
         if (isRefreshing) return;

--- a/app/client/src/features/events/BroadcastMessages/useBroadcastMessageSnack.ts
+++ b/app/client/src/features/events/BroadcastMessages/useBroadcastMessageSnack.ts
@@ -1,0 +1,43 @@
+import { useSnack } from '@local/core';
+import { useBroadcastMessageSnackSubscription } from '@local/__generated__/useBroadcastMessageSnackSubscription.graphql';
+import { useMemo } from 'react';
+import { useSubscription, graphql } from 'react-relay';
+import { GraphQLSubscriptionConfig } from 'relay-runtime';
+import { useEvent } from '../useEvent';
+
+export const USE_BROADCAST_MESSAGE_SNACK_SUBSCRIPTION = graphql`
+    subscription useBroadcastMessageSnackSubscription($eventId: ID!) {
+        broadcastMessageCreated(eventId: $eventId) {
+            edge {
+                node {
+                    id
+                    broadcastMessage
+                }
+            }
+        }
+    }
+`;
+
+export function useBroadcastMessageSnack() {
+    const { displaySnack } = useSnack();
+    const { eventId } = useEvent();
+
+    const snackConfig = useMemo<GraphQLSubscriptionConfig<useBroadcastMessageSnackSubscription>>(
+        () => ({
+            variables: { eventId },
+            subscription: USE_BROADCAST_MESSAGE_SNACK_SUBSCRIPTION,
+            onNext: (data) => {
+                const broadcastMessage = data?.broadcastMessageCreated?.edge?.node?.broadcastMessage;
+                if (broadcastMessage) {
+                    displaySnack(broadcastMessage, {
+                        variant: 'info',
+                        anchorOrigin: { vertical: 'top', horizontal: 'center' },
+                    });
+                }
+            },
+        }),
+        [displaySnack, eventId]
+    );
+
+    useSubscription(snackConfig);
+}

--- a/app/client/src/features/events/EventSidebar/EventSidebar.tsx
+++ b/app/client/src/features/events/EventSidebar/EventSidebar.tsx
@@ -25,6 +25,7 @@ import {
 } from '@local/components/EventInfoPoppers';
 import { Participant } from '../Participants/useParticipantList';
 import ParticipantList from '../Participants/ParticipantList';
+import { useBroadcastMessageSnack } from '../BroadcastMessages/useBroadcastMessageSnack';
 
 export const EVENT_SIDEBAR_FRAGMENT = graphql`
     fragment EventSidebarFragment on Event {
@@ -62,6 +63,7 @@ export const EventSidebar = ({ fragmentRef, participants }: EventSidebarProps) =
         useResponsiveDialog();
     const [isFeedbackPromptResultsOpen, openFeedbackPromptResults, closeFeedbackPromptResults] = useResponsiveDialog();
     const eventId = data.id;
+    useBroadcastMessageSnack();
 
     // Subscribe to live feedback prompts
     const { feedbackPromptRef } = useLiveFeedbackPrompt({ openFeedbackPromptResponse });

--- a/app/server/src/features/events/methods.ts
+++ b/app/server/src/features/events/methods.ts
@@ -14,7 +14,7 @@ const toEventId = toGlobalId('Event');
 export async function findBroadcastMessagesByEventId(eventId: string, prisma: PrismaClient) {
     return prisma.eventBroadcastMessage.findMany({
         where: { eventId, isVisible: true },
-        orderBy: { createdAt: 'asc' },
+        orderBy: { createdAt: 'desc' },
     });
 }
 


### PR DESCRIPTION
- When broadcasting a message during an event, it will pop up as a snackbar at the top, sharing the message with all participants and moderators except the creator (since you know what it is already and can see it in the list).
- Fixed list order (newest should be at the top since new ones are being appended to the top of the list)