### PR TITLE
Viewpoint Summarization Improvments

### DIFF
--- a/app/client/schema.graphql
+++ b/app/client/schema.graphql
@@ -611,6 +611,12 @@ type FeedbackOperation {
   operationType: Operation!
 }
 
+input GenerateViewpointsInput {
+  eventId: ID!
+  isForcedRegenerate: Boolean
+  promptId: ID!
+}
+
 type GeneratedTopic {
   description: String!
   locked: Boolean
@@ -701,7 +707,7 @@ type Mutation {
   Material limited to ~120k characters
   """
   generateEventTopics(eventId: String!, material: String!): TopicGenerationMutationResponse
-  generateViewpoints(eventId: ID!, promptId: ID!): EventFeedbackPromptMutationResponse!
+  generateViewpoints(input: GenerateViewpointsInput!): EventFeedbackPromptMutationResponse!
   hideQuestion(input: HideQuestion!): EventQuestion
   lockTopic(eventId: String!, topic: String!): TopicLockToggleMutationResponse
   lockTopics(eventId: String!, topics: [String!]!): MutationResponse

--- a/app/client/src/__generated__/GenerateViewpointsMutation.graphql.ts
+++ b/app/client/src/__generated__/GenerateViewpointsMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<9c61f1eaeb363806f7d6113fa7083e21>>
+ * @generated SignedSource<<9c11b6aa61d136f2fdb6f0c20dde1f49>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,9 +9,13 @@
 // @ts-nocheck
 
 import { ConcreteRequest, Mutation } from 'relay-runtime';
-export type GenerateViewpointsMutation$variables = {
+export type GenerateViewpointsInput = {
   eventId: string;
+  isForcedRegenerate?: boolean | null;
   promptId: string;
+};
+export type GenerateViewpointsMutation$variables = {
+  input: GenerateViewpointsInput;
 };
 export type GenerateViewpointsMutation$data = {
   readonly generateViewpoints: {
@@ -37,12 +41,7 @@ var v0 = [
   {
     "defaultValue": null,
     "kind": "LocalArgument",
-    "name": "eventId"
-  },
-  {
-    "defaultValue": null,
-    "kind": "LocalArgument",
-    "name": "promptId"
+    "name": "input"
   }
 ],
 v1 = [
@@ -51,13 +50,8 @@ v1 = [
     "args": [
       {
         "kind": "Variable",
-        "name": "eventId",
-        "variableName": "eventId"
-      },
-      {
-        "kind": "Variable",
-        "name": "promptId",
-        "variableName": "promptId"
+        "name": "input",
+        "variableName": "input"
       }
     ],
     "concreteType": "EventFeedbackPromptMutationResponse",
@@ -151,16 +145,16 @@ return {
     "selections": (v1/*: any*/)
   },
   "params": {
-    "cacheID": "55957d2a7f9961a532cccf203f1ffd54",
+    "cacheID": "8741c137667be86ea906e0129ec57f61",
     "id": null,
     "metadata": {},
     "name": "GenerateViewpointsMutation",
     "operationKind": "mutation",
-    "text": "mutation GenerateViewpointsMutation(\n  $eventId: ID!\n  $promptId: ID!\n) {\n  generateViewpoints(eventId: $eventId, promptId: $promptId) {\n    isError\n    message\n    body {\n      cursor\n      node {\n        id\n        viewpoints\n        voteViewpoints\n      }\n    }\n  }\n}\n"
+    "text": "mutation GenerateViewpointsMutation(\n  $input: GenerateViewpointsInput!\n) {\n  generateViewpoints(input: $input) {\n    isError\n    message\n    body {\n      cursor\n      node {\n        id\n        viewpoints\n        voteViewpoints\n      }\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "d7273e1d4da70155aea5937e5caabedc";
+(node as any).hash = "aa89d219734805e1938400df4d0d6d2a";
 
 export default node;

--- a/app/client/src/core/ThemeContext.tsx
+++ b/app/client/src/core/ThemeContext.tsx
@@ -15,7 +15,7 @@ interface Props {
 export const ThemeSelector = React.createContext<(() => void)[]>([() => {}]);
 
 export function ThemeProvider({ children }: Props) {
-    const [state, setState] = React.useState<keyof TThemes>('dark');
+    const [state, setState] = React.useState<keyof TThemes>('light');
     return (
         <ThemeSelector.Provider value={[() => setState(state === 'light' ? 'dark' : 'light')]}>
             <MUIThemeProvider theme={themes[state]}>{children}</MUIThemeProvider>

--- a/app/client/src/core/theme.tsx
+++ b/app/client/src/core/theme.tsx
@@ -140,17 +140,16 @@ export const themes: TThemes = {
         ...base,
         palette: {
             ...base.palette,
-            primary: { main: '#4056a1' },
-            secondary: { main: '#f13c20' },
+            primary: { main: '#f3f1ee' },
+            secondary: { main: '#171818' },
         },
     }),
     light: createTheme({
         ...base,
         palette: {
             ...base.palette,
-            primary: { main: '#f3f1ee' },
-            // primary: { main: '#fef7ec' },
-            secondary: { main: '#171818' },
+            primary: { main: '#4056a1' },
+            secondary: { main: '#f13c20' },
         },
     }),
 };

--- a/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackPrompt/FeedbackResponsesDialog.tsx
+++ b/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackPrompt/FeedbackResponsesDialog.tsx
@@ -58,16 +58,6 @@ export default function FeedbackResponsesDialog({
         return <React.Fragment />;
     }, [selectedPrompt]);
 
-    const ShareFeedbackResultsButton = () => {
-        if (selectedPrompt)
-            return (
-                <Grid item paddingBottom='1rem'>
-                    <ShareFeedbackPromptResults prompt={selectedPrompt} />
-                </Grid>
-            );
-        return <React.Fragment />;
-    };
-
     return (
         <StyledDialog
             fullScreen={fullscreen}
@@ -86,9 +76,15 @@ export default function FeedbackResponsesDialog({
                     <PromptText />
                     <Stack direction='row' spacing={2}>
                         {promptRef.current ? (
-                            <GenerateViewpoints promptId={promptRef.current.id} setSelectedPrompt={setSelectedPrompt} />
+                            <React.Fragment>
+                                <GenerateViewpoints
+                                    promptId={promptRef.current.id}
+                                    setSelectedPrompt={setSelectedPrompt}
+                                />
+                                <ShareFeedbackPromptResults prompt={promptRef.current} />
+                            </React.Fragment>
                         ) : null}
-                        <ShareFeedbackResultsButton />
+                        {/* <ShareFeedbackResultsButton /> */}
                     </Stack>
                     {!selectedPrompt?.isOpenEnded ? (
                         <FormControl sx={{ m: 1, minWidth: 120 }}>

--- a/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackPrompt/ViewpointsList.tsx
+++ b/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackPrompt/ViewpointsList.tsx
@@ -2,12 +2,28 @@ import { Chip, Divider, Tooltip, Typography } from '@mui/material';
 import React from 'react';
 import { Prompt } from './LiveFeedbackPromptList';
 
-interface Props {
+const StyledViewpoint = ({ viewpoint }: { viewpoint: string }) => {
+    // Gradient from purple to blue
+    const gradient = 'linear-gradient(to right bottom, #9c27b0, #2979ff)';
+    return (
+        <Chip
+            variant='outlined'
+            label={viewpoint}
+            sx={{
+                marginBottom: '0.25rem',
+                color: 'white',
+                backgroundImage: gradient,
+            }}
+        />
+    );
+};
+
+interface ViewpointListProps {
     prompt: Prompt;
     vote: string;
 }
 
-export default function ViewpointsList({ prompt, vote }: Props) {
+export default function ViewpointsList({ prompt, vote }: ViewpointListProps) {
     const { viewpoints, voteViewpoints, isOpenEnded } = prompt;
 
     const viewpointsGenerated = React.useMemo(() => {
@@ -38,8 +54,8 @@ export default function ViewpointsList({ prompt, vote }: Props) {
                     <React.Fragment key={index}>
                         <Typography variant='h6'>{_vote}</Typography>
                         {voteViewpoints[_vote].map((viewpoint, _index) => (
-                            <div key={_index}>
-                                <Chip label={viewpoint} sx={{ marginBottom: '0.25rem' }} />
+                            <div key={`${_vote}:${_index}`}>
+                                <StyledViewpoint viewpoint={viewpoint} />
                             </div>
                         ))}
                     </React.Fragment>
@@ -52,7 +68,7 @@ export default function ViewpointsList({ prompt, vote }: Props) {
                     <Typography variant='h6'>{vote}</Typography>
                     {voteViewpoints[vote].map((viewpoint, index) => (
                         <div key={index}>
-                            <Chip label={viewpoint} sx={{ marginBottom: '0.25rem' }} />
+                            <StyledViewpoint viewpoint={viewpoint} />
                         </div>
                     ))}
                 </React.Fragment>
@@ -62,7 +78,7 @@ export default function ViewpointsList({ prompt, vote }: Props) {
             {isOpenEnded ? (
                 viewpoints.map((viewpoint, index) => (
                     <div key={index}>
-                        <Chip label={viewpoint} sx={{ marginBottom: '0.25rem' }} />
+                        <StyledViewpoint viewpoint={viewpoint} />
                     </div>
                 ))
             ) : (

--- a/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackPromptResponses/ShareFeedbackPromptResults.tsx
+++ b/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackPromptResponses/ShareFeedbackPromptResults.tsx
@@ -51,15 +51,22 @@ export function ShareFeedbackPromptResults({ prompt }: ShareFeedbackResultsProps
                             </Typography>
                         </Grid>
                         <Grid container item justifyContent='center'>
-                            <Button onClick={close}>Cancel</Button>
-                            <Button onClick={handleSubmit}>Share</Button>
+                            <Button variant='outlined' onClick={close}>
+                                Cancel
+                            </Button>
+                            <div style={{ width: '0.5rem' }} />
+                            <Button variant='contained' onClick={handleSubmit}>
+                                Share
+                            </Button>
                         </Grid>
                     </Grid>
                 </DialogContent>
             </ResponsiveDialog>
-            <Button variant='contained' color='primary' onClick={open}>
-                Share Results
-            </Button>
+            <Grid item paddingBottom='1rem'>
+                <Button variant='contained' color='primary' onClick={open}>
+                    Share Results
+                </Button>
+            </Grid>
         </React.Fragment>
     );
 }

--- a/app/client/src/graphql-types.ts
+++ b/app/client/src/graphql-types.ts
@@ -721,6 +721,12 @@ export type FeedbackOperation = {
   operationType: Operation;
 };
 
+export type GenerateViewpointsInput = {
+  eventId: Scalars['ID'];
+  isForcedRegenerate?: InputMaybe<Scalars['Boolean']>;
+  promptId: Scalars['ID'];
+};
+
 export type GeneratedTopic = {
   __typename?: 'GeneratedTopic';
   description: Scalars['String'];
@@ -1033,8 +1039,7 @@ export type MutationGenerateEventTopicsArgs = {
 
 
 export type MutationGenerateViewpointsArgs = {
-  eventId: Scalars['ID'];
-  promptId: Scalars['ID'];
+  input: GenerateViewpointsInput;
 };
 
 

--- a/app/server/src/features/events/feedback/schema.graphql
+++ b/app/server/src/features/events/feedback/schema.graphql
@@ -142,6 +142,12 @@ type Votes {
     conflicted: Int!
 }
 
+input GenerateViewpointsInput {
+    eventId: ID!
+    promptId: ID!
+    isForcedRegenerate: Boolean
+}
+
 type Mutation {
     createFeedback(input: CreateFeedback!): EventFeedbackMutationResponse!
     createFeedbackDM(input: CreateFeedbackDM!): EventFeedbackMutationResponse!
@@ -151,7 +157,7 @@ type Mutation {
     createFeedbackPromptResponse(input: CreateFeedbackPromptResponse!): EventFeedbackPromptResponseMutationResponse!
     shareFeedbackPromptResults(eventId: ID!, promptId: ID!): EventFeedbackPromptMutationResponse!
     submitPostEventFeedback(feedback: String!, eventId: ID!): PostEventFeedbackMutationResponse!
-    generateViewpoints(eventId: ID!, promptId: ID!): EventFeedbackPromptMutationResponse!
+    generateViewpoints(input: GenerateViewpointsInput!): EventFeedbackPromptMutationResponse!
 }
 
 type Query {

--- a/app/server/src/graphql-types.ts
+++ b/app/server/src/graphql-types.ts
@@ -555,8 +555,7 @@ export type MutationsubmitPostEventFeedbackArgs = {
 };
 
 export type MutationgenerateViewpointsArgs = {
-    eventId: Scalars['ID'];
-    promptId: Scalars['ID'];
+    input: GenerateViewpointsInput;
 };
 
 export type MutationcreateInviteArgs = {
@@ -1395,6 +1394,12 @@ export type Votes = {
     conflicted: Scalars['Int'];
 };
 
+export type GenerateViewpointsInput = {
+    eventId: Scalars['ID'];
+    promptId: Scalars['ID'];
+    isForcedRegenerate?: InputMaybe<Scalars['Boolean']>;
+};
+
 export type CreateInvite = {
     email: Scalars['String'];
     eventId: Scalars['ID'];
@@ -2031,6 +2036,7 @@ export type ResolversTypes = {
     CreateFeedbackPrompt: CreateFeedbackPrompt;
     CreateFeedbackPromptResponse: CreateFeedbackPromptResponse;
     Votes: ResolverTypeWrapper<Votes>;
+    GenerateViewpointsInput: GenerateViewpointsInput;
     CreateInvite: CreateInvite;
     ValidateInvite: ValidateInvite;
     InviteMutationResponse: ResolverTypeWrapper<InviteMutationResponse>;
@@ -2211,6 +2217,7 @@ export type ResolversParentTypes = {
     CreateFeedbackPrompt: CreateFeedbackPrompt;
     CreateFeedbackPromptResponse: CreateFeedbackPromptResponse;
     Votes: Votes;
+    GenerateViewpointsInput: GenerateViewpointsInput;
     CreateInvite: CreateInvite;
     ValidateInvite: ValidateInvite;
     InviteMutationResponse: InviteMutationResponse;
@@ -2755,7 +2762,7 @@ export type MutationResolvers<
         ResolversTypes['EventFeedbackPromptMutationResponse'],
         ParentType,
         ContextType,
-        RequireFields<MutationgenerateViewpointsArgs, 'eventId' | 'promptId'>
+        RequireFields<MutationgenerateViewpointsArgs, 'input'>
     >;
     createInvite?: Resolver<
         ResolversTypes['InviteMutationResponse'],


### PR DESCRIPTION
- Added option to force the viewpoints to regenerate (since they will use the cache by default unless the responses change.)
- The share results dialog should no longer close when there is a parent refresh.
- Fixed issue with the theme default. (Palette was set up wrong, light and dark were switched and dark was set to default when the existing theme was light).
- Added visual flair to summaries by giving the background a gradient (should be more appealing to look at and more clear to read)