### PR TITLE
Viewpoint generation dialog improvements

### DIFF
--- a/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackPrompt/FeedbackResponsesDialog.tsx
+++ b/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackPrompt/FeedbackResponsesDialog.tsx
@@ -84,7 +84,6 @@ export default function FeedbackResponsesDialog({
                                 <ShareFeedbackPromptResults prompt={promptRef.current} />
                             </React.Fragment>
                         ) : null}
-                        {/* <ShareFeedbackResultsButton /> */}
                     </Stack>
                     {!selectedPrompt?.isOpenEnded ? (
                         <FormControl sx={{ m: 1, minWidth: 120 }}>

--- a/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackPrompt/GenerateViewpoints.tsx
+++ b/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackPrompt/GenerateViewpoints.tsx
@@ -9,6 +9,7 @@ import { ResponsiveDialog, useResponsiveDialog } from '@local/components';
 import { useEvent } from '@local/features/events';
 import { Prompt } from './LiveFeedbackPromptList';
 import { useSnack } from '@local/core';
+import { LoadingButton } from '@local/components/LoadingButton';
 
 export const GENERATE_VIEWPOINTS_MUTATION = graphql`
     mutation GenerateViewpointsMutation($input: GenerateViewpointsInput!) {
@@ -38,12 +39,14 @@ export default function GenerateViewpoints({ promptId, setSelectedPrompt }: Prop
     const { eventId } = useEvent();
     const { displaySnack } = useSnack();
     const [checked, setChecked] = React.useState(false);
+    const [isLoading, setIsLoading] = React.useState(false);
 
     const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
         setChecked(event.target.checked);
     };
 
     const handleSubmit = () => {
+        setIsLoading(true);
         commit({
             variables: {
                 input: {
@@ -54,6 +57,7 @@ export default function GenerateViewpoints({ promptId, setSelectedPrompt }: Prop
             },
             onCompleted: () => {
                 displaySnack('Successfully generated viewpoints.', { variant: 'success' });
+                setIsLoading(false);
                 close();
             },
             updater: (store) => {
@@ -81,11 +85,13 @@ export default function GenerateViewpoints({ promptId, setSelectedPrompt }: Prop
                     let errorMessage = 'Error generating viewpoints';
                     if (error instanceof Error) errorMessage += `: ${error.message}`;
                     displaySnack(errorMessage, { variant: 'error' });
+                    setIsLoading(false);
                 }
             },
             onError: (error) => {
                 console.error(error);
                 displaySnack(`Error generating viewpoints: ${error.message}`, { variant: 'error' });
+                setIsLoading(false);
             },
         });
     };
@@ -120,9 +126,9 @@ export default function GenerateViewpoints({ promptId, setSelectedPrompt }: Prop
                                 Cancel
                             </Button>
                             <div style={{ width: '0.5rem' }} />
-                            <Button variant='contained' onClick={handleSubmit}>
+                            <LoadingButton loading={isLoading} variant='contained' onClick={handleSubmit}>
                                 Generate
-                            </Button>
+                            </LoadingButton>
                         </Grid>
                     </Grid>
                 </DialogContent>

--- a/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackPrompt/GenerateViewpoints.tsx
+++ b/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackPrompt/GenerateViewpoints.tsx
@@ -53,6 +53,7 @@ export default function GenerateViewpoints({ promptId, setSelectedPrompt }: Prop
                 },
             },
             onCompleted: () => {
+                displaySnack('Successfully generated viewpoints.', { variant: 'success' });
                 close();
             },
             updater: (store) => {

--- a/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackPromptResponses/ShareFeedbackPromptResults.tsx
+++ b/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackPromptResponses/ShareFeedbackPromptResults.tsx
@@ -7,6 +7,7 @@ import Button from '@mui/material/Button';
 import { ResponsiveDialog, useResponsiveDialog } from '@local/components';
 import { Grid, Typography, DialogContent } from '@mui/material';
 import { useEvent } from '../../useEvent';
+import { useSnack } from '@local/core';
 
 export const SHARE_FEEDBACK_PROMPT_RESULTS_MUTATION = graphql`
     mutation ShareFeedbackPromptResultsMutation($eventId: ID!, $promptId: ID!) {
@@ -32,11 +33,15 @@ export function ShareFeedbackPromptResults({ prompt }: ShareFeedbackResultsProps
     const [isOpen, open, close] = useResponsiveDialog();
     const [commit] = useMutation(SHARE_FEEDBACK_PROMPT_RESULTS_MUTATION);
     const { eventId } = useEvent();
+    const { displaySnack } = useSnack();
 
     const handleSubmit = () => {
         commit({
             variables: { eventId, promptId: prompt.id },
-            onCompleted: close,
+            onCompleted: () => {
+                displaySnack('Successfully shared feedback prompt results.', { variant: 'success' });
+                close();
+            },
         });
     };
 

--- a/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackPromptResponses/ShareFeedbackPromptResults.tsx
+++ b/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackPromptResponses/ShareFeedbackPromptResults.tsx
@@ -8,6 +8,7 @@ import { ResponsiveDialog, useResponsiveDialog } from '@local/components';
 import { Grid, Typography, DialogContent } from '@mui/material';
 import { useEvent } from '../../useEvent';
 import { useSnack } from '@local/core';
+import { LoadingButton } from '@local/components/LoadingButton';
 
 export const SHARE_FEEDBACK_PROMPT_RESULTS_MUTATION = graphql`
     mutation ShareFeedbackPromptResultsMutation($eventId: ID!, $promptId: ID!) {
@@ -34,13 +35,20 @@ export function ShareFeedbackPromptResults({ prompt }: ShareFeedbackResultsProps
     const [commit] = useMutation(SHARE_FEEDBACK_PROMPT_RESULTS_MUTATION);
     const { eventId } = useEvent();
     const { displaySnack } = useSnack();
+    const [isLoading, setIsLoading] = React.useState(false);
 
     const handleSubmit = () => {
+        setIsLoading(true);
         commit({
             variables: { eventId, promptId: prompt.id },
             onCompleted: () => {
                 displaySnack('Successfully shared feedback prompt results.', { variant: 'success' });
+                setIsLoading(false);
                 close();
+            },
+            onError: (error) => {
+                displaySnack(error.message, { variant: 'error' });
+                setIsLoading(false);
             },
         });
     };
@@ -60,9 +68,9 @@ export function ShareFeedbackPromptResults({ prompt }: ShareFeedbackResultsProps
                                 Cancel
                             </Button>
                             <div style={{ width: '0.5rem' }} />
-                            <Button variant='contained' onClick={handleSubmit}>
+                            <LoadingButton loading={isLoading} variant='contained' onClick={handleSubmit}>
                                 Share
-                            </Button>
+                            </LoadingButton>
                         </Grid>
                     </Grid>
                 </DialogContent>


### PR DESCRIPTION
- Added a loading button for both actions since they can take time and we want to give the user better feedback + stop them from submitting multiple times.
- Added success snacks to give better feedback to the moderator when performing the actions. (since often regenerating doesn't provide different results it can appear like nothing happened when regenerating, the snack will notify the moderator that the action was successful even if there is no update to the data.)