### PR TITLE
fix(workflows): updated version for google actions

### DIFF
--- a/.github/workflows/cc2c-deploy.yml
+++ b/.github/workflows/cc2c-deploy.yml
@@ -45,13 +45,13 @@ jobs:
               uses: actions/checkout@v3
 
             - id: 'auth'
-              uses: 'google-github-actions/auth@v1'
+              uses: 'google-github-actions/auth@v2'
               with:
                   credentials_json: '${{ secrets.GKE_SA_KEY }}'
 
             # Setup gcloud CLI
             - name: 'Set up Cloud SDK'
-              uses: google-github-actions/setup-gcloud@v1
+              uses: google-github-actions/setup-gcloud@v2
               with:
                   version: '400.0.0'
                   project_id: ${{ secrets.GKE_PROJECT_ID }}
@@ -136,13 +136,13 @@ jobs:
               uses: actions/checkout@v3
 
             - id: 'auth'
-              uses: 'google-github-actions/auth@v1'
+              uses: 'google-github-actions/auth@v2'
               with:
                   credentials_json: '${{ secrets.GKE_SA_KEY }}'
 
             # Setup gcloud CLI
             - name: 'Set up Cloud SDK'
-              uses: google-github-actions/setup-gcloud@v1
+              uses: google-github-actions/setup-gcloud@v2
               with:
                   version: '400.0.0'
                   project_id: ${{ secrets.GKE_PROJECT_ID }}

--- a/.github/workflows/cc2c-ingress-deploy.yml
+++ b/.github/workflows/cc2c-ingress-deploy.yml
@@ -34,13 +34,13 @@ jobs:
               uses: actions/checkout@v3
 
             - id: 'auth'
-              uses: 'google-github-actions/auth@v1'
+              uses: 'google-github-actions/auth@v2'
               with:
                   credentials_json: '${{ secrets.GKE_SA_KEY }}'
 
             # Setup gcloud CLI
             - name: 'Set up Cloud SDK'
-              uses: google-github-actions/setup-gcloud@v1
+              uses: google-github-actions/setup-gcloud@v2
               with:
                   version: '400.0.0'
                   project_id: ${{ secrets.GKE_PROJECT_ID }}
@@ -85,13 +85,13 @@ jobs:
               uses: actions/checkout@v3
 
             - id: 'auth'
-              uses: 'google-github-actions/auth@v1'
+              uses: 'google-github-actions/auth@v2'
               with:
                   credentials_json: '${{ secrets.GKE_SA_KEY }}'
 
             # Setup gcloud CLI
             - name: 'Set up Cloud SDK'
-              uses: google-github-actions/setup-gcloud@v1
+              uses: google-github-actions/setup-gcloud@v2
               with:
                   version: '400.0.0'
                   project_id: ${{ secrets.GKE_PROJECT_ID }}

--- a/.github/workflows/client-deploy.yml
+++ b/.github/workflows/client-deploy.yml
@@ -46,13 +46,13 @@ jobs:
               uses: actions/checkout@v3
 
             - id: 'auth'
-              uses: 'google-github-actions/auth@v1'
+              uses: 'google-github-actions/auth@v2'
               with:
                   credentials_json: '${{ secrets.GKE_SA_KEY }}'
 
             # Setup gcloud CLI
             - name: 'Set up Cloud SDK'
-              uses: google-github-actions/setup-gcloud@v1
+              uses: google-github-actions/setup-gcloud@v2
               with:
                   version: '400.0.0'
                   project_id: ${{ secrets.GKE_PROJECT_ID }}
@@ -125,13 +125,13 @@ jobs:
               uses: actions/checkout@v3
 
             - id: 'auth'
-              uses: 'google-github-actions/auth@v1'
+              uses: 'google-github-actions/auth@v2'
               with:
                   credentials_json: '${{ secrets.GKE_SA_KEY }}'
 
             # Setup gcloud CLI
             - name: 'Set up Cloud SDK'
-              uses: google-github-actions/setup-gcloud@v1
+              uses: google-github-actions/setup-gcloud@v2
               with:
                   version: '400.0.0'
                   project_id: ${{ secrets.GKE_PROJECT_ID }}

--- a/.github/workflows/gcp-service-deploy.yml
+++ b/.github/workflows/gcp-service-deploy.yml
@@ -39,13 +39,13 @@ jobs:
               uses: actions/checkout@v3
 
             - id: 'auth'
-              uses: 'google-github-actions/auth@v1'
+              uses: 'google-github-actions/auth@v2'
               with:
                   credentials_json: '${{ secrets.GKE_SA_KEY }}'
 
             # Setup gcloud CLI
             - name: 'Set up Cloud SDK'
-              uses: google-github-actions/setup-gcloud@v1
+              uses: google-github-actions/setup-gcloud@v2
               with:
                   version: '400.0.0'
                   project_id: ${{ secrets.GKE_PROJECT_ID }}
@@ -107,13 +107,13 @@ jobs:
               uses: actions/checkout@v3
 
             - id: 'auth'
-              uses: 'google-github-actions/auth@v1'
+              uses: 'google-github-actions/auth@v2'
               with:
                   credentials_json: '${{ secrets.GKE_SA_KEY }}'
 
             # Setup gcloud CLI
             - name: 'Set up Cloud SDK'
-              uses: google-github-actions/setup-gcloud@v1
+              uses: google-github-actions/setup-gcloud@v2
               with:
                   version: '400.0.0'
                   project_id: ${{ secrets.GKE_PROJECT_ID }}

--- a/.github/workflows/ingress-deploy.yml
+++ b/.github/workflows/ingress-deploy.yml
@@ -34,13 +34,13 @@ jobs:
               uses: actions/checkout@v3
 
             - id: 'auth'
-              uses: 'google-github-actions/auth@v1'
+              uses: 'google-github-actions/auth@v2'
               with:
                   credentials_json: '${{ secrets.GKE_SA_KEY }}'
 
             # Setup gcloud CLI
             - name: 'Set up Cloud SDK'
-              uses: google-github-actions/setup-gcloud@v1
+              uses: google-github-actions/setup-gcloud@v2
               with:
                   version: '400.0.0'
                   project_id: ${{ secrets.GKE_PROJECT_ID }}
@@ -85,13 +85,13 @@ jobs:
               uses: actions/checkout@v3
 
             - id: 'auth'
-              uses: 'google-github-actions/auth@v1'
+              uses: 'google-github-actions/auth@v2'
               with:
                   credentials_json: '${{ secrets.GKE_SA_KEY }}'
 
             # Setup gcloud CLI
             - name: 'Set up Cloud SDK'
-              uses: google-github-actions/setup-gcloud@v1
+              uses: google-github-actions/setup-gcloud@v2
               with:
                   version: '400.0.0'
                   project_id: ${{ secrets.GKE_PROJECT_ID }}

--- a/.github/workflows/moderation-algo-deploy.yml
+++ b/.github/workflows/moderation-algo-deploy.yml
@@ -42,13 +42,13 @@ jobs:
             - run: env
 
             - id: 'auth'
-              uses: 'google-github-actions/auth@v1'
+              uses: 'google-github-actions/auth@v2'
               with:
                   credentials_json: '${{ secrets.GKE_SA_KEY }}'
 
             # Setup gcloud CLI
             - name: 'Set up Cloud SDK'
-              uses: google-github-actions/setup-gcloud@v1
+              uses: google-github-actions/setup-gcloud@v2
               with:
                   version: '400.0.0'
                   project_id: ${{ secrets.GKE_PROJECT_ID }}
@@ -121,13 +121,13 @@ jobs:
             - run: env
 
             - id: 'auth'
-              uses: 'google-github-actions/auth@v1'
+              uses: 'google-github-actions/auth@v2'
               with:
                   credentials_json: '${{ secrets.GKE_SA_KEY }}'
 
             # Setup gcloud CLI
             - name: 'Set up Cloud SDK'
-              uses: google-github-actions/setup-gcloud@v1
+              uses: google-github-actions/setup-gcloud@v2
               with:
                   version: '400.0.0'
                   project_id: ${{ secrets.GKE_PROJECT_ID }}

--- a/.github/workflows/server-deploy.yml
+++ b/.github/workflows/server-deploy.yml
@@ -47,13 +47,13 @@ jobs:
             - run: env
 
             - id: 'auth'
-              uses: 'google-github-actions/auth@v1'
+              uses: 'google-github-actions/auth@v2'
               with:
                   credentials_json: '${{ secrets.GKE_SA_KEY }}'
 
             # Setup gcloud CLI
             - name: 'Set up Cloud SDK'
-              uses: google-github-actions/setup-gcloud@v1
+              uses: google-github-actions/setup-gcloud@v2
               with:
                   version: '400.0.0'
                   project_id: ${{ secrets.GKE_PROJECT_ID }}
@@ -138,13 +138,13 @@ jobs:
             - run: env
 
             - id: 'auth'
-              uses: 'google-github-actions/auth@v1'
+              uses: 'google-github-actions/auth@v2'
               with:
                   credentials_json: '${{ secrets.GKE_SA_KEY }}'
 
             # Setup gcloud CLI
             - name: 'Set up Cloud SDK'
-              uses: google-github-actions/setup-gcloud@v1
+              uses: google-github-actions/setup-gcloud@v2
               with:
                   version: '400.0.0'
                   project_id: ${{ secrets.GKE_PROJECT_ID }}


### PR DESCRIPTION
It seems that the version 1 of google github actions we were using is deprecated now, switching to version 2.