### PR TITLE
Offensive question filtering

### DIFF
--- a/app/server/src/features/events/methods.ts
+++ b/app/server/src/features/events/methods.ts
@@ -247,7 +247,7 @@ export async function findQuestionsByEventId({ eventId, first, after, prisma }: 
     const hasAfterCursor = after !== '' && !!after;
 
     const result = await prisma.eventQuestion.findMany({
-        where: { eventId, isVisible: true },
+        where: { eventId, isVisible: true, offensive: false },
         orderBy: { createdAt: 'desc' },
         take: first ? first + 1 : undefined,
         cursor: hasAfterCursor

--- a/app/server/src/features/events/questions/methods.ts
+++ b/app/server/src/features/events/questions/methods.ts
@@ -208,7 +208,7 @@ export async function createQuestion(
             refQuestion: true,
         },
     });
-    return { question: newQuestion, topics };
+    return { question: newQuestion, topics, offensive };
 }
 /**
  *  Remove a question from an event

--- a/app/server/src/features/events/questions/resolvers.ts
+++ b/app/server/src/features/events/questions/resolvers.ts
@@ -21,10 +21,19 @@ export const resolvers: Resolvers = {
             return runMutation(async () => {
                 if (!ctx.viewer.id) throw new ProtectedError({ userMessage: errors.noLogin });
                 const { id: eventId } = fromGlobalId(args.input.eventId);
-                const { question, topics } = await Question.createQuestion(ctx.viewer.id, ctx.prisma, ctx.redis, {
+                const { question, offensive } = await Question.createQuestion(ctx.viewer.id, ctx.prisma, ctx.redis, {
                     ...args.input,
                     eventId,
                 });
+
+                if (offensive) {
+                    throw new ProtectedError({
+                        userMessage:
+                            'Your question has been flagged as potentially offensive and will not be displayed',
+                        internalMessage: `Question flagged as offensive: ${question.id}`,
+                    });
+                }
+
                 const formattedQuestion = toQuestionId(question);
                 if (formattedQuestion.refQuestion)
                     formattedQuestion.refQuestion = toQuestionId(formattedQuestion.refQuestion);


### PR DESCRIPTION
Offensive questions should no longer display (assuming the mod-algo detects them properly). 
Anyone who submits offensive questions should see a message letting them know that it was flagged and will not show up.
TODO:
- [ ] Grey out question for the user, maybe with a banner on it so it's clear that it's flagged.
- [ ] Add a section for moderators to view these questions and either allow them or permanently hide them (would still retain in the database but be hidden from everyone)
- [ ] Keep track of how many offensive questions a user in an event has asked and possibly auto-mute them if they meet a threshold. Would help dissuade users from attempts to bypass filter/test its limits.