### PR TITLE
Google OAuth Fix

### DIFF
--- a/.github/workflows/server-deploy.yml
+++ b/.github/workflows/server-deploy.yml
@@ -29,7 +29,6 @@ env:
     DATABASE_URL: ${{ secrets.DATABASE_URL }} # Used for prisma migration
     GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
     GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
-    GOOGLE_REDIRECT_URI: ${{ vars.GOOGLE_REDIRECT_URI }}
     GOOGLE_ARTIFACT_REPO: ${{ vars.GOOGLE_ARTIFACT_REPO }}
 
 jobs:
@@ -39,6 +38,8 @@ jobs:
         environment:
             name: development
             url: ${{ env.ORIGIN }}
+        env:
+            GOOGLE_REDIRECT_URI: ${{ vars.STAGING_GOOGLE_REDIRECT_URI }}
 
         steps:
             - name: Checkout
@@ -129,6 +130,8 @@ jobs:
         environment:
             name: production
             url: ${{ env.ORIGIN }}
+        env:
+            GOOGLE_REDIRECT_URI: ${{ vars.PROD_GOOGLE_REDIRECT_URI }}
         needs: [staging]
 
         steps:

--- a/app/server/src/features/accounts/account.ts
+++ b/app/server/src/features/accounts/account.ts
@@ -85,7 +85,10 @@ server.route({
     handler: async (req, res) => {
         try {
             const { postAuthRedirectUrl } = req.query as { postAuthRedirectUrl: string };
-            console.log('postAuthRedirectUrl', postAuthRedirectUrl);
+            server.log.debug({
+                message: 'Google OAuth aredirect',
+                postAuthRedirectUrl,
+            });
             const googleAuthClient = createAndGetGoogleOAuthClient();
             const authorizationUri = googleAuthClient.generateAuthUrl({
                 access_type: 'offline',
@@ -110,8 +113,11 @@ server.route({
     url: '/api/auth/callback/google',
     handler: async (req, res) => {
         try {
-            server.log.info('Google OAuth callback received');
-            server.log.info(`Google OAuth Query parameters: ${JSON.stringify(req.query)}`);
+            server.log.debug('Google OAuth callback received');
+            server.log.debug({
+                message: 'Google OAuth callback query',
+                query: req.query,
+            });
             const {
                 error,
                 state: reqState,
@@ -131,13 +137,20 @@ server.route({
 
             const oauth2 = google.oauth2('v2');
             const userInfoResponse = await oauth2.userinfo.get({ auth: googleAuthClient });
+            server.log.debug({
+                message: 'Google OAuth callback userInfoResponse',
+                userInfoResponse: userInfoResponse.data,
+            });
             const userProfile = userInfoResponse.data;
 
             // Check if the user exists in your database; if not, register a new user.
             let user = await prisma.user.findUnique({ where: { email: userProfile.email! } });
             let token;
             if (!user) {
-                server.log.info(`New user detected, registering new user with oauth email: ${userProfile.email}`);
+                server.log.debug({
+                    message: 'User not found, registering new user',
+                    userProfile,
+                });
                 const result = await registerWithGoogleOAuth(prisma, {
                     email: userProfile.email!,
                     firstName: userProfile.given_name || 'First',
@@ -147,7 +160,10 @@ server.route({
                 token = result.token;
                 user = result.user;
             } else {
-                server.log.info(`Existing user detected, logging in with oauth email: ${userProfile.email}`);
+                server.log.debug({
+                    message: 'User already exists, updating user with new refresh token',
+                    user,
+                });
                 token = await jwt.sign({ id: toUserId(user).id });
                 if (tokens.refresh_token) {
                     await prisma.user.update({
@@ -173,7 +189,7 @@ server.route({
                 path: '/', // Cookie is valid for the entire site
                 maxAge: 60 * 60 * 24 * 30, // 30 days expiration
             });
-            server.log.info(`JWT cookie set: ${token}`);
+            server.log.debug(`JWT cookie set: ${token}`);
 
             let redirectUrl = process.env.ORIGIN || 'http://localhost:8080';
             try {


### PR DESCRIPTION
- The redirect URI was sending production requests to the dev server, causing the token to be set in the wrong sub domain and thus not allowing oauth login in production. Attempting to fix by moving the env declarations within the relevant jobs themselves as well as giving each var a unique name to ensure that it is not being set wrong at build time.
- Improved logging some more, updated from info to debug to make it easier to search for and am now using structured logging instead of a string.