### PR TITLE
OAuth Env Config Fix

### DIFF
--- a/k8s/server/development/prytaneum-server-configmap.yml
+++ b/k8s/server/development/prytaneum-server-configmap.yml
@@ -15,3 +15,4 @@ data:
     REDIS_PORT: '6379'
     GCLOUD_ISSUE_GUIDES_STORAGE_BUCKET: prytaneum-issue-guides
     MODERATION_URL: http://10.112.10.193:5000/
+    GOOGLE_REDIRECT_URI: https://dev.prytaneum.io/api/auth/callback/google

--- a/k8s/server/development/prytaneum-server-deployment.yml
+++ b/k8s/server/development/prytaneum-server-deployment.yml
@@ -58,6 +58,11 @@ spec:
                             configMapKeyRef:
                                 name: prytaneum-server-config
                                 key: REDIS_PORT
+                      - name: GOOGLE_REDIRECT_URI
+                        valueFrom:
+                            configMapKeyRef:
+                                key: GOOGLE_REDIRECT_URI
+                                name: prytaneum-server-config
                       - name: GCP_PROJECT_ID
                         valueFrom:
                             configMapKeyRef:
@@ -117,6 +122,16 @@ spec:
                             secretKeyRef:
                                 key: jwt
                                 name: prytaneum-client-secrets
+                      - name: GOOGLE_CLIENT_ID
+                        valueFrom:
+                            secretKeyRef:
+                                key: GOOGLE_CLIENT_ID
+                                name: prytaneum-oauth-secrets
+                      - name: GOOGLE_CLIENT_SECRET
+                        valueFrom:
+                            secretKeyRef:
+                                key: GOOGLE_CLIENT_SECRET
+                                name: prytaneum-oauth-secrets
                       - name: 'GOOGLE_APPLICATION_CREDENTIALS'
                         value: '/var/secrets/google/key.json'
                   volumeMounts:

--- a/k8s/server/production/prytaneum-server-configmap.yml
+++ b/k8s/server/production/prytaneum-server-configmap.yml
@@ -15,3 +15,4 @@ data:
     REDIS_PORT: '6379'
     GCLOUD_ISSUE_GUIDES_STORAGE_BUCKET: prytaneum-issue-guides
     MODERATION_URL: http://10.112.10.190:5000/
+    GOOGLE_REDIRECT_URI: https://prytaneum.io/api/auth/callback/google

--- a/k8s/server/production/prytaneum-server-deployment.yml
+++ b/k8s/server/production/prytaneum-server-deployment.yml
@@ -58,6 +58,11 @@ spec:
                             configMapKeyRef:
                                 name: prytaneum-server-config
                                 key: REDIS_PORT
+                      - name: GOOGLE_REDIRECT_URI
+                        valueFrom:
+                            configMapKeyRef:
+                                key: GOOGLE_REDIRECT_URI
+                                name: prytaneum-server-config
                       - name: GCP_PROJECT_ID
                         valueFrom:
                             configMapKeyRef:
@@ -117,6 +122,16 @@ spec:
                             secretKeyRef:
                                 key: jwt
                                 name: prytaneum-client-secrets
+                      - name: GOOGLE_CLIENT_ID
+                        valueFrom:
+                            secretKeyRef:
+                                key: GOOGLE_CLIENT_ID
+                                name: prytaneum-oauth-secrets
+                      - name: GOOGLE_CLIENT_SECRET
+                        valueFrom:
+                            secretKeyRef:
+                                key: GOOGLE_CLIENT_SECRET
+                                name: prytaneum-oauth-secrets
                       - name: 'GOOGLE_APPLICATION_CREDENTIALS'
                         value: '/var/secrets/google/key.json'
                   volumeMounts:


### PR DESCRIPTION
For some reason the github actions env namespaces config is not being set correctly when deploying causing the production version to try and use the dev version's oauth client (thus causing a mismatch error). Attempting to fix this issue by having these env vars set within gke instead, which should ensure isolation based on the namespace.