### PR TITLE
Feedback flows (Surveys) fixes

### DIFF
--- a/app/client/src/__generated__/ShareFeedbackPromptFlowDraftMutation.graphql.ts
+++ b/app/client/src/__generated__/ShareFeedbackPromptFlowDraftMutation.graphql.ts
@@ -1,0 +1,147 @@
+/**
+ * @generated SignedSource<<d7dc8f6cc8fa54b67b50de1e4cc5346f>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest, Mutation } from 'relay-runtime';
+export type ShareFeedbackPromptFlowDraftMutation$variables = {
+  flowId: string;
+};
+export type ShareFeedbackPromptFlowDraftMutation$data = {
+  readonly shareFeedbackFlowDraft: {
+    readonly body: {
+      readonly cursor: string;
+      readonly node: {
+        readonly id: string;
+        readonly isDraft: boolean;
+      };
+    } | null;
+    readonly isError: boolean;
+    readonly message: string;
+  };
+};
+export type ShareFeedbackPromptFlowDraftMutation = {
+  response: ShareFeedbackPromptFlowDraftMutation$data;
+  variables: ShareFeedbackPromptFlowDraftMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "flowId"
+  }
+],
+v1 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "flowId",
+        "variableName": "flowId"
+      }
+    ],
+    "concreteType": "FeedbackFlowMutationResponse",
+    "kind": "LinkedField",
+    "name": "shareFeedbackFlowDraft",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "isError",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "message",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "FeedbackFlowEdge",
+        "kind": "LinkedField",
+        "name": "body",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "cursor",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "FeedbackFlow",
+            "kind": "LinkedField",
+            "name": "node",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "id",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "isDraft",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ShareFeedbackPromptFlowDraftMutation",
+    "selections": (v1/*: any*/),
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "ShareFeedbackPromptFlowDraftMutation",
+    "selections": (v1/*: any*/)
+  },
+  "params": {
+    "cacheID": "c453f2e07325312101a5ed5f1a4b22ba",
+    "id": null,
+    "metadata": {},
+    "name": "ShareFeedbackPromptFlowDraftMutation",
+    "operationKind": "mutation",
+    "text": "mutation ShareFeedbackPromptFlowDraftMutation(\n  $flowId: ID!\n) {\n  shareFeedbackFlowDraft(flowId: $flowId) {\n    isError\n    message\n    body {\n      cursor\n      node {\n        id\n        isDraft\n      }\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "416c188b09e99ec64e75fc1309a0f047";
+
+export default node;

--- a/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackFlow/LiveFeedbackFlowForm.tsx
+++ b/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackFlow/LiveFeedbackFlowForm.tsx
@@ -120,7 +120,7 @@ export function LiveFeedbackFlowForm({ onSubmit, onCancel, onSaveDraft, initialS
     return (
         <Box component='form' onSubmit={handleSubmit} sx={{ width: '100%' }}>
             <Typography variant='h5' gutterBottom sx={{ textAlign: 'center', mb: 3 }}>
-                Create Feedback Flow
+                Create Survey
             </Typography>
 
             {/* Flow Name and Description Fields */}
@@ -128,7 +128,7 @@ export function LiveFeedbackFlowForm({ onSubmit, onCancel, onSaveDraft, initialS
                 <Grid item xs={12}>
                     <TextField
                         id='flow-name'
-                        label='Flow Name'
+                        label='Survey Name'
                         value={flowName}
                         onChange={handleFlowNameChange}
                         fullWidth
@@ -139,7 +139,7 @@ export function LiveFeedbackFlowForm({ onSubmit, onCancel, onSaveDraft, initialS
                 <Grid item xs={12}>
                     <TextField
                         id='flow-description'
-                        label='Flow Description'
+                        label='Survey Description'
                         value={flowDescription}
                         onChange={handleFlowDescriptionChange}
                         fullWidth
@@ -172,11 +172,11 @@ export function LiveFeedbackFlowForm({ onSubmit, onCancel, onSaveDraft, initialS
                                         promptState.prompt.length > 30 ? '...' : ''
                                     }`}
                                 </Typography>
-                                {prompts.length > 1 && ( // Only show delete if more than one prompt exists
+                                {prompts.length > 1 && (
                                     <IconButton
                                         aria-label='delete prompt'
                                         onClick={(e) => {
-                                            e.stopPropagation(); // Prevent accordion toggle
+                                            e.stopPropagation();
                                             handleRemovePrompt(index)();
                                         }}
                                         size='small'
@@ -218,18 +218,18 @@ export function LiveFeedbackFlowForm({ onSubmit, onCancel, onSaveDraft, initialS
                     color='primary'
                     onClick={handleSaveDraft}
                     startIcon={<SaveIcon />}
-                    disabled={!isFlowInfoValid} // Can save draft even if prompts aren't perfect
+                    disabled={!isFlowInfoValid}
                 >
                     Save as Draft
                 </Button>
                 <Button
-                    type='submit' // Triggers the form's onSubmit
+                    type='submit'
                     variant='contained'
                     color='primary'
                     startIcon={<SendIcon />}
-                    disabled={!canSubmit} // Enable only when basic validation passes
+                    disabled={!canSubmit}
                 >
-                    Prompt Flow
+                    Prompt Survey
                 </Button>
             </Box>
         </Box>

--- a/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackFlow/ShareFeedbackPromptFlowDraft.tsx
+++ b/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackFlow/ShareFeedbackPromptFlowDraft.tsx
@@ -34,30 +34,28 @@ export function ShareFeedbackPromptFlowDraft({ flow }: Props) {
     const [commit] = useMutation<ShareFeedbackPromptFlowDraftMutation>(SHARE_PROMPT_DRAFT_MUTATION);
 
     function handleSubmit() {
-        try {
-            commit({
-                variables: { flowId: flow.id },
-                onCompleted(payload) {
-                    try {
-                        if (payload.shareFeedbackFlowDraft.isError)
-                            throw new Error(payload.shareFeedbackFlowDraft.message);
-                        close();
-                        displaySnack('Prompt submitted successfully!', { variant: 'success' });
-                    } catch (err) {
-                        if (err instanceof Error) displaySnack(err.message, { variant: 'error' });
-                        else displaySnack('Something went wrong!');
-                    }
-                },
-                updater(store) {
-                    const promptRecord = store.get(flow.id);
-                    if (!promptRecord) return console.error('Prompt not found in store');
-                    promptRecord.setValue(false, 'isDraft');
-                },
-            });
-        } catch (err) {
-            if (err instanceof Error) displaySnack(err.message, { variant: 'error' });
-            else displaySnack('Something went wrong!');
-        }
+        commit({
+            variables: { flowId: flow.id },
+            onCompleted(payload) {
+                try {
+                    if (payload.shareFeedbackFlowDraft.isError) throw new Error(payload.shareFeedbackFlowDraft.message);
+                    close();
+                    displaySnack('Prompt submitted successfully!', { variant: 'success' });
+                } catch (err) {
+                    if (err instanceof Error) displaySnack(err.message, { variant: 'error' });
+                    else displaySnack('Something went wrong!');
+                }
+            },
+            updater(store) {
+                const promptRecord = store.get(flow.id);
+                if (!promptRecord) return console.error('Prompt not found in store');
+                promptRecord.setValue(false, 'isDraft');
+            },
+            onError(err) {
+                if (err instanceof Error) displaySnack(err.message, { variant: 'error' });
+                else displaySnack('Something went wrong!');
+            },
+        });
     }
 
     return (

--- a/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackFlow/ShareFeedbackPromptFlowDraft.tsx
+++ b/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackFlow/ShareFeedbackPromptFlowDraft.tsx
@@ -1,0 +1,82 @@
+import * as React from 'react';
+import { Button, DialogContent, Grid, Typography } from '@mui/material';
+import SendIcon from '@mui/icons-material/Send';
+import { useMutation, graphql } from 'react-relay';
+
+import type { ShareFeedbackPromptFlowDraftMutation } from '@local/__generated__/ShareFeedbackPromptFlowDraftMutation.graphql';
+import { ResponsiveDialog, useResponsiveDialog } from '@local/components/ResponsiveDialog';
+import { useSnack } from '@local/core';
+import { Flow } from '../LiveFeedbackPrompt/LiveFeedbackPromptList';
+
+interface Props {
+    flow: Flow;
+}
+
+export const SHARE_PROMPT_DRAFT_MUTATION = graphql`
+    mutation ShareFeedbackPromptFlowDraftMutation($flowId: ID!) {
+        shareFeedbackFlowDraft(flowId: $flowId) {
+            isError
+            message
+            body {
+                cursor
+                node {
+                    id
+                    isDraft
+                }
+            }
+        }
+    }
+`;
+
+export function ShareFeedbackPromptFlowDraft({ flow }: Props) {
+    const [isOpen, open, close] = useResponsiveDialog();
+    const { displaySnack } = useSnack();
+    const [commit] = useMutation<ShareFeedbackPromptFlowDraftMutation>(SHARE_PROMPT_DRAFT_MUTATION);
+
+    function handleSubmit() {
+        try {
+            commit({
+                variables: { flowId: flow.id },
+                onCompleted(payload) {
+                    try {
+                        if (payload.shareFeedbackFlowDraft.isError)
+                            throw new Error(payload.shareFeedbackFlowDraft.message);
+                        close();
+                        displaySnack('Prompt submitted successfully!', { variant: 'success' });
+                    } catch (err) {
+                        if (err instanceof Error) displaySnack(err.message, { variant: 'error' });
+                        else displaySnack('Something went wrong!');
+                    }
+                },
+                updater(store) {
+                    const promptRecord = store.get(flow.id);
+                    if (!promptRecord) return console.error('Prompt not found in store');
+                    promptRecord.setValue(false, 'isDraft');
+                },
+            });
+        } catch (err) {
+            if (err instanceof Error) displaySnack(err.message, { variant: 'error' });
+            else displaySnack('Something went wrong!');
+        }
+    }
+
+    return (
+        <React.Fragment>
+            <ResponsiveDialog open={isOpen} onClose={close}>
+                <DialogContent>
+                    <Typography variant='h6'>Are you sure you want to share this survey?</Typography>
+                    <Typography variant='body1'>Survey: {flow.flowName}</Typography>
+                    <Grid container justifyContent='end'>
+                        <Button onClick={close}>Cancel</Button>
+                        <Button variant='contained' color='primary' onClick={handleSubmit}>
+                            Share
+                        </Button>
+                    </Grid>
+                </DialogContent>
+            </ResponsiveDialog>
+            <Button variant='contained' startIcon={<SendIcon />} onClick={open}>
+                Share Draft
+            </Button>
+        </React.Fragment>
+    );
+}

--- a/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackFlow/SubmitLiveFeedbackFlow.tsx
+++ b/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackFlow/SubmitLiveFeedbackFlow.tsx
@@ -105,11 +105,11 @@ export function SubmitLiveFeedbackFlow({ className, connections = [] }: Props) {
                     return;
                 }
                 if (response.createFeedbackFlow?.isError) {
-                    displaySnack(response.createFeedbackFlow.message || 'Failed to create feedback flow.', {
+                    displaySnack(response.createFeedbackFlow.message || 'Failed to create survey.', {
                         variant: 'error',
                     });
                 } else {
-                    displaySnack('Feedback flow created successfully!', { variant: 'success' });
+                    displaySnack('Survey created successfully!', { variant: 'success' });
                     closeDialog();
                 }
             },
@@ -180,7 +180,7 @@ export function SubmitLiveFeedbackFlow({ className, connections = [] }: Props) {
                 <DialogTitle
                     sx={{ m: 0, p: 2, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}
                 >
-                    Create New Feedback Flow
+                    Create New Survey
                     <IconButton
                         aria-label='close'
                         onClick={handleCancel}
@@ -207,7 +207,7 @@ export function SubmitLiveFeedbackFlow({ className, connections = [] }: Props) {
                 onClick={openDialog}
                 startIcon={user ? <PlaylistAddIcon /> : <LockIcon />}
             >
-                Create Feedback Flow
+                Create Survey
             </Button>
         </React.Fragment>
     );

--- a/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackFlowResponse/SubmitLiveFeedbackFlowResponse.tsx
+++ b/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackFlowResponse/SubmitLiveFeedbackFlowResponse.tsx
@@ -101,7 +101,7 @@ export function SubmitLiveFeedbackFlowResponse({}: SubmitLiveFeedbackFlowRespons
         if (currentFlow && currentPromptIndex < currentFlow.prompts.length - 1) {
             setCurrentPromptIndex(currentPromptIndex + 1);
         } else {
-            displaySnack('All prompts answered. Ready to submit flow.', { variant: 'info' });
+            displaySnack('All prompts answered. Ready to submit the survey.', { variant: 'info' });
         }
     }, [currentFlow, currentPromptIndex, displaySnack]);
 
@@ -125,7 +125,7 @@ export function SubmitLiveFeedbackFlowResponse({}: SubmitLiveFeedbackFlowRespons
 
     const handleSubmitEntireFlow = () => {
         if (!currentFlow || collectedResponses.some((r) => r === null)) {
-            displaySnack('Please answer all prompts before submitting the flow.', { variant: 'error' });
+            displaySnack('Please answer all prompts before submitting the survey.', { variant: 'error' });
             return;
         }
 
@@ -152,7 +152,7 @@ export function SubmitLiveFeedbackFlowResponse({}: SubmitLiveFeedbackFlowRespons
             },
             onCompleted: (response, errors) => {
                 if (errors) {
-                    displaySnack(`Error submitting flow responses: ${errors[0].message}`, { variant: 'error' });
+                    displaySnack(`Error submitting survey responses: ${errors[0].message}`, { variant: 'error' });
                     return;
                 }
                 const hasErrors = response.createFeedbackPromptFlowResponse.isError;
@@ -160,7 +160,7 @@ export function SubmitLiveFeedbackFlowResponse({}: SubmitLiveFeedbackFlowRespons
                 if (hasErrors) {
                     displaySnack(errorMessage, { variant: 'error' });
                 } else {
-                    displaySnack('Feedback flow responses submitted successfully!', { variant: 'success' });
+                    displaySnack('Survey responses submitted successfully!', { variant: 'success' });
                 }
                 handleCloseDialog();
             },
@@ -186,7 +186,7 @@ export function SubmitLiveFeedbackFlowResponse({}: SubmitLiveFeedbackFlowRespons
             PaperProps={{ sx: { height: '100%' } }}
         >
             <DialogTitle sx={{ m: 0, p: 2, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-                {currentFlow.flowName || 'Feedback Flow'}
+                {currentFlow.flowName || 'Feedback Survey'}
                 <IconButton aria-label='close' onClick={handleCloseDialog} sx={{ color: theme.palette.grey[500] }}>
                     <CloseIcon />
                 </IconButton>
@@ -194,7 +194,7 @@ export function SubmitLiveFeedbackFlowResponse({}: SubmitLiveFeedbackFlowRespons
             <DialogContent dividers>
                 <Box>
                     <Typography variant='caption' color='textSecondary'>
-                        {currentFlow.flowDescription || 'No description provided for this flow.'}
+                        {currentFlow.flowDescription || 'No description provided for this survey.'}
                     </Typography>
                 </Box>
                 <Stepper activeStep={currentPromptIndex} alternativeLabel={!isMobile} sx={{ mb: 3 }}>
@@ -218,8 +218,8 @@ export function SubmitLiveFeedbackFlowResponse({}: SubmitLiveFeedbackFlowRespons
                                 onSubmit={handleIndividualPromptSubmit}
                                 isFlow={true}
                                 isLastFlowPrompt={index === currentFlow.prompts.length - 1}
-                                initialState={collectedResponses[currentPromptIndex] || undefined}
-                                promptIndex={currentPromptIndex}
+                                initialState={collectedResponses[index] || undefined}
+                                promptIndex={index}
                                 onFormUpdate={handleFormUpdate}
                                 onValidityChange={(isValid) => {
                                     setIsPromptFormValid(isValid);
@@ -244,7 +244,7 @@ export function SubmitLiveFeedbackFlowResponse({}: SubmitLiveFeedbackFlowRespons
                                     onClick={handleSubmitEntireFlow}
                                     disabled={isSubmittingFlow || !collectedResponses[currentPromptIndex]}
                                 >
-                                    Submit Flow
+                                    Submit Survey
                                     {isSubmittingFlow && <CircularProgress size={18} sx={{ ml: 1 }} />}
                                 </Button>
                             ) : (

--- a/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackFlowResponse/SubmitLiveFeedbackFlowResponse.tsx
+++ b/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackFlowResponse/SubmitLiveFeedbackFlowResponse.tsx
@@ -22,7 +22,7 @@ import useMediaQuery from '@mui/material/useMediaQuery';
 import { useMutation, graphql } from 'react-relay';
 
 import {
-    LiveFeedbackPromptResponseForm,
+    MemoizedLiveFeedbackPromptResponseForm,
     TLiveFeedbackPromptResponseFormState,
 } from '../LiveFeedbackPromptResponse/LiveFeedbackPromptResponseForm';
 import type { Prompt as SinglePromptType } from '../useLiveFeedbackPrompt';
@@ -57,17 +57,23 @@ export function SubmitLiveFeedbackFlowResponse({}: SubmitLiveFeedbackFlowRespons
     const [currentPromptIndex, setCurrentPromptIndex] = React.useState(0);
     const [collectedResponses, setCollectedResponses] = React.useState<TLiveFeedbackPromptResponseFormState[]>([]);
     const [isPromptFormValid, setIsPromptFormValid] = React.useState<boolean>(false); // Track form validity
+    const [isLoading, setIsLoading] = React.useState<boolean>(false);
 
     const [commitFlowResponses, isSubmittingFlow] = useMutation<SubmitLiveFeedbackFlowResponseMutation>(
         SUBMIT_FEEDBACK_FLOW_RESPONSES_MUTATION
     );
 
     const handlePresentFlow = React.useCallback((flow: ActiveFlow) => {
+        setIsLoading(true);
         setCurrentFlow(flow);
         setCurrentPromptIndex(0);
         setCollectedResponses(new Array(flow.prompts.length).fill(null)); // Initialize responses array
         setIsOpen(true);
     }, []);
+
+    React.useEffect(() => {
+        if (isOpen) setIsLoading(false);
+    }, [isOpen]);
 
     useActiveFeedbackFlow({ onFlowPrompted: handlePresentFlow });
 
@@ -192,42 +198,50 @@ export function SubmitLiveFeedbackFlowResponse({}: SubmitLiveFeedbackFlowRespons
                 </IconButton>
             </DialogTitle>
             <DialogContent dividers>
-                <Box>
-                    <Typography variant='caption' color='textSecondary'>
-                        {currentFlow.flowDescription || 'No description provided for this survey.'}
-                    </Typography>
-                </Box>
-                <Stepper activeStep={currentPromptIndex} alternativeLabel={!isMobile} sx={{ mb: 3 }}>
-                    {currentFlow.prompts.map((prompt, index) => (
-                        <Step key={prompt.id}>
-                            <StepLabel>
-                                {isMobile ? `Prompt ${index + 1}` : prompt.prompt.substring(0, 20) + '...'}
-                            </StepLabel>
-                        </Step>
-                    ))}
-                </Stepper>
-
-                <Box sx={{ minHeight: '300px' }}>
-                    {currentFlow.prompts.map((prompt, index) => (
-                        <Box
-                            key={prompt.id} // Key for the wrapper div
-                            style={{ display: index === currentPromptIndex ? 'block' : 'none' }}
-                        >
-                            <LiveFeedbackPromptResponseForm
-                                prompt={prompt}
-                                onSubmit={handleIndividualPromptSubmit}
-                                isFlow={true}
-                                isLastFlowPrompt={index === currentFlow.prompts.length - 1}
-                                initialState={collectedResponses[index] || undefined}
-                                promptIndex={index}
-                                onFormUpdate={handleFormUpdate}
-                                onValidityChange={(isValid) => {
-                                    setIsPromptFormValid(isValid);
-                                }}
-                            />
+                {isLoading ? (
+                    <Box display='flex' justifyContent='center' alignItems='center' sx={{ minHeight: '300px' }}>
+                        <CircularProgress />
+                    </Box>
+                ) : (
+                    <React.Fragment>
+                        <Box>
+                            <Typography variant='caption' color='textSecondary'>
+                                {currentFlow.flowDescription || 'No description provided for this survey.'}
+                            </Typography>
                         </Box>
-                    ))}
-                </Box>
+                        <Stepper activeStep={currentPromptIndex} alternativeLabel={!isMobile} sx={{ mb: 3 }}>
+                            {currentFlow.prompts.map((prompt, index) => (
+                                <Step key={prompt.id}>
+                                    <StepLabel>
+                                        {isMobile ? `Prompt ${index + 1}` : prompt.prompt.substring(0, 20) + '...'}
+                                    </StepLabel>
+                                </Step>
+                            ))}
+                        </Stepper>
+
+                        <Box sx={{ minHeight: '300px' }}>
+                            {currentFlow.prompts.map((prompt, index) => (
+                                <Box
+                                    key={prompt.id} // Key for the wrapper div
+                                    style={{ display: index === currentPromptIndex ? 'block' : 'none' }}
+                                >
+                                    <MemoizedLiveFeedbackPromptResponseForm
+                                        prompt={prompt}
+                                        onSubmit={handleIndividualPromptSubmit}
+                                        isFlow={true}
+                                        isLastFlowPrompt={index === currentFlow.prompts.length - 1}
+                                        initialState={collectedResponses[index] || undefined}
+                                        promptIndex={index}
+                                        onFormUpdate={handleFormUpdate}
+                                        onValidityChange={(isValid) => {
+                                            setIsPromptFormValid(isValid);
+                                        }}
+                                    />
+                                </Box>
+                            ))}
+                        </Box>
+                    </React.Fragment>
+                )}
             </DialogContent>
             <Box sx={{ p: 2, borderTop: '1px solid', borderColor: 'divider' }}>
                 {isMobile ? (

--- a/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackFlowResponse/useActiveFeedbackFlowSubscription.tsx
+++ b/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackFlowResponse/useActiveFeedbackFlowSubscription.tsx
@@ -96,7 +96,7 @@ export function useActiveFeedbackFlow({ onFlowPrompted }: UseActiveFeedbackFlowP
 
     const displayFlowSnack = React.useCallback(
         (flowName: string | null, options?: OptionsObject) => {
-            enqueueSnackbar(`New Feedback Flow available: ${flowName || 'Untitled Flow'}`, {
+            enqueueSnackbar(`New Survey available: ${flowName || 'Untitled Survey'}`, {
                 variant: options?.variant || 'info',
                 action: (key) => options?.action || flowAction(key),
                 persist: true, // Keep it until user interacts
@@ -143,7 +143,7 @@ export function useActiveFeedbackFlow({ onFlowPrompted }: UseActiveFeedbackFlowP
                 displayFlowSnack(newFlow.flowName);
             },
             onError: (error: Error) => {
-                console.error('Error in feedback flow subscription:', error);
+                console.error('Error in survey subscription:', error);
             },
         }),
         [eventId, displayFlowSnack] // Removed showNextFlowInQueue from deps as it's stable

--- a/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackPrompt/FeedbackFlowResponsesDialog.tsx
+++ b/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackPrompt/FeedbackFlowResponsesDialog.tsx
@@ -64,7 +64,7 @@ export default function FeedbackFlowResponsesDialog({
             }}
         >
             <StyledDialogTitle id='feedback-flow-responses-dialog-title' onClose={handleClose}>
-                Feedback Flow Responses
+                Survey Responses
             </StyledDialogTitle>
             <DialogContent dividers>
                 <FlowInfo />
@@ -117,7 +117,7 @@ export default function FeedbackFlowResponsesDialog({
                             );
                         })
                     ) : (
-                        <Typography sx={{ textAlign: 'center', mt: 2 }}>This flow has no prompts.</Typography>
+                        <Typography sx={{ textAlign: 'center', mt: 2 }}>Survey has no prompts.</Typography>
                     )}
                 </Grid>
             </DialogContent>

--- a/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackPrompt/LiveFeedbackPromptList.tsx
+++ b/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackPrompt/LiveFeedbackPromptList.tsx
@@ -30,6 +30,7 @@ import { useLiveFeedbackPromptFlowsFragment$key } from '@local/__generated__/use
 import EmptyState from '@local/components/EmptyState';
 import FeedbackFlowResponsesDialog from './FeedbackFlowResponsesDialog';
 import { ShareFeedbackPromptFlow } from '../LiveFeedbackFlow/ShareFeedbackPromptFlow';
+import { ShareFeedbackPromptFlowDraft } from '../LiveFeedbackFlow/ShareFeedbackPromptFlowDraft';
 
 export type FeedbackDashboardTab = 'open-ended' | 'vote' | 'multiple-choice' | 'surveys';
 
@@ -147,10 +148,14 @@ function FlowItem({ flow, handleClick }: FlowItemProps) {
                 </Grid>
             </CardContent>
             <CardActions sx={{ justifyContent: 'center' }}>
-                <Stack direction='row' spacing={1}>
-                    <ShareFeedbackPromptFlow flow={flow} />
-                    <ViewResponses />
-                </Stack>
+                {flow.isDraft ? (
+                    <ShareFeedbackPromptFlowDraft flow={flow} />
+                ) : (
+                    <Stack direction='row' spacing={1}>
+                        <ShareFeedbackPromptFlow flow={flow} />
+                        <ViewResponses />
+                    </Stack>
+                )}
             </CardActions>
         </Card>
     );

--- a/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackPrompt/LiveFeedbackPromptList.tsx
+++ b/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackPrompt/LiveFeedbackPromptList.tsx
@@ -31,7 +31,7 @@ import EmptyState from '@local/components/EmptyState';
 import FeedbackFlowResponsesDialog from './FeedbackFlowResponsesDialog';
 import { ShareFeedbackPromptFlow } from '../LiveFeedbackFlow/ShareFeedbackPromptFlow';
 
-export type FeedbackDashboardTab = 'open-ended' | 'vote' | 'multiple-choice' | 'flows';
+export type FeedbackDashboardTab = 'open-ended' | 'vote' | 'multiple-choice' | 'surveys';
 
 export type Prompt = {
     readonly id: string;
@@ -210,7 +210,7 @@ function PromptList({
                 <Tab label='Open Ended' value='open-ended' />
                 <Tab label='Vote' value='vote' />
                 <Tab label='Multiple Choice' value='multiple-choice' />
-                <Tab label='Flows' value='flows' />
+                <Tab label='Surveys' value='surveys' />
             </Tabs>
             {selectedTab === 'open-ended' && (
                 <List
@@ -273,7 +273,7 @@ function PromptList({
                     )}
                 </List>
             )}
-            {selectedTab === 'flows' && (
+            {selectedTab === 'surveys' && (
                 <List
                     id='live-feedback-flows-prompt-list'
                     sx={{
@@ -286,7 +286,7 @@ function PromptList({
                     {flows.length > 0 ? (
                         flows.map((flow) => <FlowItem key={flow.id} flow={flow} handleClick={handleFlowClick} />)
                     ) : (
-                        <EmptyState message='No Flows To Display Yet.' />
+                        <EmptyState message='No Surveys To Display Yet.' />
                     )}
                 </List>
             )}

--- a/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackPromptResponse/LiveFeedbackPromptResponseForm.tsx
+++ b/app/client/src/features/events/LiveFeedbackPrompts/LiveFeedbackPromptResponse/LiveFeedbackPromptResponseForm.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, memo } from 'react';
 import {
     Button,
     TextField,
@@ -182,3 +182,5 @@ export function LiveFeedbackPromptResponseForm({
         </Form>
     );
 }
+
+export const MemoizedLiveFeedbackPromptResponseForm = memo(LiveFeedbackPromptResponseForm);

--- a/app/server/src/features/events/feedback/feedbackFlow.methods.ts
+++ b/app/server/src/features/events/feedback/feedbackFlow.methods.ts
@@ -310,3 +310,25 @@ export async function promptFlowResponses(globalFlowPromptId: string, prisma: Pr
         where: { promptId: feedbackPrompt.promptId },
     });
 }
+
+export async function updateFeedbackFlowDraftStatus(
+    globalFeedbackFlowId: string,
+    isDraft: boolean,
+    prisma: PrismaClient
+) {
+    server.log.debug(`Updating feedback flow draft status for ID: ${globalFeedbackFlowId} to ${isDraft}`);
+    return prisma.feedbackFlow.update({
+        where: { id: globalFeedbackFlowId },
+        data: { isDraft },
+        include: {
+            prompts: {
+                include: {
+                    prompt: true,
+                },
+                orderBy: {
+                    order: 'asc',
+                },
+            },
+        },
+    });
+}

--- a/app/server/src/features/events/feedback/feedbackFlow.methods.ts
+++ b/app/server/src/features/events/feedback/feedbackFlow.methods.ts
@@ -320,15 +320,5 @@ export async function updateFeedbackFlowDraftStatus(
     return prisma.feedbackFlow.update({
         where: { id: globalFeedbackFlowId },
         data: { isDraft },
-        include: {
-            prompts: {
-                include: {
-                    prompt: true,
-                },
-                orderBy: {
-                    order: 'asc',
-                },
-            },
-        },
     });
 }

--- a/app/server/src/features/events/feedback/resolvers.ts
+++ b/app/server/src/features/events/feedback/resolvers.ts
@@ -306,6 +306,8 @@ export const resolvers: Resolvers = {
                 if (!args.flowId) throw new ProtectedError({ userMessage: errors.invalidArgs });
                 const { id: flowId } = fromGlobalId(args.flowId);
                 const flow = await FeedbackFlowMethods.findFeedbackFlowByFlowId(flowId, ctx.prisma);
+                // Update the flow to be no longer a draft
+                await FeedbackFlowMethods.updateFeedbackFlowDraftStatus(flowId, false, ctx.prisma);
                 const formattedFlow = toFeedbackFlowId(flow);
                 ctx.app.log.debug(`Sharing feedback flow draft ${JSON.stringify(flow)}`);
                 const edge = {


### PR DESCRIPTION
- Should load faster now and show a loader while loading if not as fast.
- Draft feature now implemented and tested
- Fixed issue where going back was overwriting the prompt id causing the response data to be saved wrong and not display correctly in the results.
- Renamed the "flows" to surveys on the client side to make it easier for everyone to know what it is.